### PR TITLE
Initialize Next.js App Router scaffold with env setup and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/sub_stalker"
+AUTH_SECRET="replace-with-a-random-secret"
+MAIL_PROVIDER_API_KEY="replace-with-provider-key"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-Subscription Stalker
+# Sub Stalker
+
+Next.js (App Router + TypeScript) starter for a subscription tracking app.
+
+## Prerequisites
+
+- Node.js 18.17+ (Node.js 20 recommended)
+- npm 9+
+
+## Environment variables
+
+Next.js automatically loads `.env.local` for local development and Vercel project environment variables in deployed environments.
+
+1. Copy the example:
+
+   ```bash
+   cp .env.example .env.local
+   ```
+
+2. Fill in required keys:
+
+- `DATABASE_URL`
+- `AUTH_SECRET`
+- `MAIL_PROVIDER_API_KEY`
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Production build locally
+
+```bash
+npm run build
+npm run start
+```
+
+## Deploy to Vercel
+
+1. Push the repository to GitHub/GitLab/Bitbucket.
+2. Import the project in Vercel.
+3. In **Project Settings → Environment Variables**, set:
+   - `DATABASE_URL`
+   - `AUTH_SECRET`
+   - `MAIL_PROVIDER_API_KEY`
+4. Deploy.
+
+Vercel will run `npm install` and `npm run build` automatically.

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -1,0 +1,8 @@
+export default function SignInPage() {
+  return (
+    <section className="card">
+      <h1>Sign In</h1>
+      <p>Sign in form placeholder.</p>
+    </section>
+  );
+}

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -1,0 +1,8 @@
+export default function SignUpPage() {
+  return (
+    <section className="card">
+      <h1>Sign Up</h1>
+      <p>Create account form placeholder.</p>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,45 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, Arial, sans-serif;
+  background: #f7f7fb;
+  color: #1f2937;
+}
+
+a {
+  color: inherit;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.nav {
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.nav ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 1rem 1.5rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1.25rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Sub Stalker",
+  description: "Subscription tracker dashboard",
+};
+
+const navItems = [
+  { href: "/", label: "Dashboard" },
+  { href: "/subscriptions", label: "Subscriptions" },
+  { href: "/settings", label: "Settings" },
+  { href: "/auth/sign-in", label: "Sign In" },
+  { href: "/auth/sign-up", label: "Sign Up" },
+];
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <nav className="nav">
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.href}>
+                <Link href={item.href}>{item.label}</Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <main className="container">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function DashboardPage() {
+  return (
+    <section className="card">
+      <h1>Dashboard</h1>
+      <p>Welcome to Sub Stalker. Use the navigation to manage subscriptions and account settings.</p>
+    </section>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,8 @@
+export default function SettingsPage() {
+  return (
+    <section className="card">
+      <h1>Settings</h1>
+      <p>Update profile, notifications, and billing preferences.</p>
+    </section>
+  );
+}

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -1,0 +1,8 @@
+export default function SubscriptionsPage() {
+  return (
+    <section className="card">
+      <h1>Subscriptions</h1>
+      <p>Your active and canceled subscriptions will appear here.</p>
+    </section>
+  );
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,25 @@
+export type ServerEnv = {
+  DATABASE_URL: string;
+  AUTH_SECRET: string;
+  MAIL_PROVIDER_API_KEY: string;
+};
+
+export function getServerEnv(): ServerEnv {
+  const env = {
+    DATABASE_URL: process.env.DATABASE_URL,
+    AUTH_SECRET: process.env.AUTH_SECRET,
+    MAIL_PROVIDER_API_KEY: process.env.MAIL_PROVIDER_API_KEY,
+  };
+
+  const missing = Object.entries(env)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}. Add them to your Vercel project or local .env.local.`,
+    );
+  }
+
+  return env as ServerEnv;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sub-stalker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.5.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Next.js (App Router + TypeScript) starter scaffold to serve as the foundation for the subscription tracker application.
- Include an application shell with navigation and placeholder routes to speed up feature development and onboarding.
- Make environment variable handling Vercel-compatible and explicit by adding a typed server helper and an example `.env` file.

### Description
- Added core project config files: `package.json`, `next.config.mjs`, `tsconfig.json`, and `next-env.d.ts`, plus a `.gitignore` tuned for Next.js and env files.
- Implemented App Router pages and base layout with navigation for `/`, `/subscriptions`, `/settings`, `/auth/sign-in`, and `/auth/sign-up` under `app/` and global styles in `app/globals.css`.
- Added `lib/env.ts` which exports a typed `ServerEnv` and `getServerEnv()` helper that validates required environment variables at runtime.
- Added `.env.example` with required keys (`DATABASE_URL`, `AUTH_SECRET`, `MAIL_PROVIDER_API_KEY`) and updated `README.md` with local run and Vercel deploy instructions.

### Testing
- Ran `npm install` in the environment which failed with an HTTP `403 Forbidden` from the npm registry, so dependencies could not be installed and no build/run verification was possible.
- Attempted a Playwright script to load `http://127.0.0.1:3000` and capture a screenshot, which failed with `ERR_EMPTY_RESPONSE` because the app server was not running due to the dependency installation failure.
- No further automated tests were executed because the runtime tooling could not be installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dd74e3a0832184e2a13ac15f8149)