### PR TITLE
Add system status page and API with database TCP health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Next.js automatically loads `.env.local` for local development and Vercel projec
 - `AUTH_SECRET`
 - `MAIL_PROVIDER_API_KEY`
 
+
+## Status page
+
+- Visit `/status` to view a simple system health page.
+- Use `/api/status` for JSON output suitable for uptime checks.
+- Database connectivity is checked via a TCP probe to the `DATABASE_URL` host/port.
+
 ## Local development
 
 ```bash

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { getDatabaseStatus } from "@/lib/status";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const database = await getDatabaseStatus();
+
+  return NextResponse.json(
+    {
+      app: "Subscription Stalker",
+      status: database.connected ? "ok" : "degraded",
+      database,
+      metrics: {
+        users: null,
+        subscriptions: null,
+        monthlySpend: null,
+      },
+    },
+    {
+      status: database.connected ? 200 : 503,
+    },
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,3 +43,40 @@ a {
   border-radius: 12px;
   padding: 1.25rem;
 }
+
+.status-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 1rem;
+}
+
+.status-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.status-item h2 {
+  margin-top: 0;
+}
+
+.status-item ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.status-ok {
+  color: #166534;
+  font-weight: 600;
+}
+
+.status-fail {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.status-error {
+  margin-top: 0.75rem;
+  color: #b91c1c;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ const navItems = [
   { href: "/", label: "Dashboard" },
   { href: "/subscriptions", label: "Subscriptions" },
   { href: "/settings", label: "Settings" },
+  { href: "/status", label: "Status" },
   { href: "/auth/sign-in", label: "Sign In" },
   { href: "/auth/sign-up", label: "Sign Up" },
 ];

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,47 @@
+import { getDatabaseStatus } from "@/lib/status";
+
+function formatLatency(latencyMs: number | null): string {
+  if (latencyMs === null) {
+    return "n/a";
+  }
+
+  return `${latencyMs} ms`;
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function StatusPage() {
+  const database = await getDatabaseStatus();
+
+  return (
+    <section className="card">
+      <h1>System Status</h1>
+      <p>Simple operational status page for core services. This can be expanded with product metrics later.</p>
+
+      <div className="status-grid">
+        <article className="status-item">
+          <h2>Database connectivity</h2>
+          <p className={database.connected ? "status-ok" : "status-fail"}>
+            {database.connected ? "Connected" : "Not connected"}
+          </p>
+          <ul>
+            <li>Checked at: {database.checkedAt}</li>
+            <li>Host: {database.host ?? "n/a"}</li>
+            <li>Port: {database.port ?? "n/a"}</li>
+            <li>Latency: {formatLatency(database.latencyMs)}</li>
+          </ul>
+          {database.error ? <p className="status-error">Error: {database.error}</p> : null}
+        </article>
+
+        <article className="status-item">
+          <h2>Future metrics</h2>
+          <ul>
+            <li>Total users: pending</li>
+            <li>Total subscriptions: pending</li>
+            <li>Monthly spend tracked: pending</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/lib/status.ts
+++ b/lib/status.ts
@@ -1,0 +1,80 @@
+import { Socket } from "node:net";
+
+import { getServerEnv } from "./env";
+
+export type DatabaseStatus = {
+  connected: boolean;
+  latencyMs: number | null;
+  host: string | null;
+  port: number | null;
+  checkedAt: string;
+  error?: string;
+};
+
+function parseConnectionTarget(databaseUrl: string): { host: string; port: number } {
+  const parsed = new URL(databaseUrl);
+  const host = parsed.hostname;
+  const port = parsed.port ? Number(parsed.port) : 5432;
+
+  if (!host || Number.isNaN(port)) {
+    throw new Error("Invalid DATABASE_URL host/port.");
+  }
+
+  return { host, port };
+}
+
+function connectTcp(host: string, port: number, timeoutMs = 5000): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    const startedAt = Date.now();
+
+    const onError = (error: Error) => {
+      socket.destroy();
+      reject(error);
+    };
+
+    socket.setTimeout(timeoutMs);
+
+    socket.once("connect", () => {
+      const latencyMs = Date.now() - startedAt;
+      socket.end();
+      resolve(latencyMs);
+    });
+
+    socket.once("error", onError);
+    socket.once("timeout", () => {
+      onError(new Error(`TCP connection timed out after ${timeoutMs}ms.`));
+    });
+
+    socket.connect(port, host);
+  });
+}
+
+export async function getDatabaseStatus(): Promise<DatabaseStatus> {
+  const checkedAt = new Date().toISOString();
+
+  try {
+    const { DATABASE_URL } = getServerEnv();
+    const { host, port } = parseConnectionTarget(DATABASE_URL);
+    const latencyMs = await connectTcp(host, port);
+
+    return {
+      connected: true,
+      latencyMs,
+      host,
+      port,
+      checkedAt,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown database check error.";
+
+    return {
+      connected: false,
+      latencyMs: null,
+      host: null,
+      port: null,
+      checkedAt,
+      error: message,
+    };
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple operational status endpoint and UI for monitoring core services and uptime checks.
- Surface basic database connectivity and latency information from the running application.

### Description

- Added a server-side utility `getDatabaseStatus` in `lib/status.ts` that parses `DATABASE_URL` and probes the database host/port via a TCP connection with a timeout, returning connectivity, latency, host/port, timestamp, and any error message.
- Added a JSON status API at `app/api/status/route.ts` that returns overall `status` (`ok` or `degraded`) and the database probe result with an appropriate HTTP status code (200 or 503).
- Added a UI status page at `app/status/page.tsx` that renders database connectivity details and placeholder product metrics, and marked the page `dynamic` to always render fresh checks.
- Updated global styles in `app/globals.css` and added a `Status` navigation link in `app/layout.tsx`, and documented the new endpoints in `README.md`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dcab369c8321bf95aeb1897f4c49)