### PR TITLE
Move themeColor from metadata to viewport export

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import type { DisplayMode } from "@prisma/client";
@@ -24,6 +24,9 @@ export const metadata: Metadata = {
     apple: [{ url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" }],
     other: [{ rel: "mask-icon", url: "/safari-pinned-tab.svg", color: "#1f6feb" }],
   },
+};
+
+export const viewport: Viewport = {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#f3f6fb" },
     { media: "(prefers-color-scheme: dark)", color: "#0c1018" },


### PR DESCRIPTION
## Summary
- migrate `themeColor` from `export const metadata` to `export const viewport`
- keep existing light/dark theme colors unchanged
- update Next.js type import to include `Viewport`

## Why
Next.js warns when `themeColor` is configured in `metadata` exports in App Router routes/layouts. Moving it to `viewport` removes the warning and aligns with current API guidance.

## Validation
- `npm run lint -- --file app/layout.tsx`