### PR TITLE
fix: enable RLS and revoke Supabase API role table access

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -30,6 +30,13 @@ Supabase guidance:
 - Use pooled URL for `DATABASE_URL` (runtime).
 - Use migration-safe URL for `DIRECT_URL`.
 
+Public schema security baseline:
+
+- Every new table in `public` must enable Row Level Security in the same Prisma migration that creates it.
+- If the table is internal-only, revoke table privileges from `anon` and `authenticated`.
+- If API access is required, add explicit least-privilege RLS policies instead of broad grants.
+- After deploy, confirm Supabase Security Advisor shows no `RLS Disabled in Public` findings for app tables.
+
 ## Build and migration pipeline
 
 `npm run build:vercel` performs:

--- a/prisma/migrations/20260311093000_enable_rls_and_revoke_public_api_roles/migration.sql
+++ b/prisma/migrations/20260311093000_enable_rls_and_revoke_public_api_roles/migration.sql
@@ -1,0 +1,31 @@
+-- Enable RLS on all Prisma-managed tables in the public schema.
+ALTER TABLE "public"."_prisma_migrations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."UserSettings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."Session" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."SignInAttempt" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."Subscription" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."Invite" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."EmailDeliveryLog" ENABLE ROW LEVEL SECURITY;
+
+-- Supabase API roles may not exist in local/dev databases.
+-- Revoke table access only when those roles are present.
+DO $$
+DECLARE
+    role_name TEXT;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated']
+    LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."_prisma_migrations" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."User" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."UserSettings" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."Session" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."SignInAttempt" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."Subscription" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."Invite" FROM %I', role_name);
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."EmailDeliveryLog" FROM %I', role_name);
+        END IF;
+    END LOOP;
+END
+$$;


### PR DESCRIPTION
## Summary
- adds a Prisma migration to enable Row Level Security on all app tables in `public`
- conditionally revokes table privileges from Supabase API roles (`anon`, `authenticated`) when those roles exist
- adds an operations runbook note to keep `public` tables RLS-protected by default

## Why
Supabase Security Advisor flagged `RLS Disabled in Public` for internal Prisma-managed tables.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run db:migrate:deploy` (applied migration `20260311093000_enable_rls_and_revoke_public_api_roles` locally)

Closes #28