### PR TITLE
[Dashboard V2] Implement aggregation contract and server route (#31)

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { getCurrentUser } from "@/lib/auth";
+import { getDashboardPayloadForUser } from "@/lib/dashboard";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const data = await getDashboardPayloadForUser(user.id);
+
+  return NextResponse.json(
+    {
+      data,
+      fetchedAt: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,19 +2,7 @@ import Link from "next/link";
 
 import DashboardSectionsClient from "@/app/DashboardSectionsClient";
 import { getCurrentUser } from "@/lib/auth";
-import { db } from "@/lib/db";
-
-function estimateMonthlyAmountCents(subscription: { amountCents: number; billingInterval: string }): number {
-  if (subscription.billingInterval === "YEARLY") {
-    return Math.round(subscription.amountCents / 12);
-  }
-
-  if (subscription.billingInterval === "WEEKLY") {
-    return Math.round(subscription.amountCents * 4.33);
-  }
-
-  return subscription.amountCents;
-}
+import { getDashboardPayloadForUser } from "@/lib/dashboard";
 
 function formatMoney(amountCents: number, currency: string): string {
   return new Intl.NumberFormat("en-US", {
@@ -25,12 +13,14 @@ function formatMoney(amountCents: number, currency: string): string {
   }).format(amountCents / 100);
 }
 
-function formatDate(value: Date): string {
+function formatDate(value: Date | string): string {
+  const parsedValue = value instanceof Date ? value : new Date(value);
+
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
-  }).format(value);
+  }).format(parsedValue);
 }
 
 export default async function DashboardPage() {
@@ -77,42 +67,15 @@ export default async function DashboardPage() {
     );
   }
 
-  const subscriptions = await db.subscription.findMany({
-    where: {
-      userId: user.id,
-    },
-    orderBy: [{ isActive: "desc" }, { nextBillingDate: "asc" }, { createdAt: "desc" }],
-  });
+  const dashboardPayload = await getDashboardPayloadForUser(user.id);
 
-  const activeSubscriptions = subscriptions.filter((subscription) => subscription.isActive);
-  const estimatedMonthlySpendCents = activeSubscriptions.reduce(
-    (total, subscription) => total + estimateMonthlyAmountCents(subscription),
-    0,
-  );
-  const activeCurrencies = new Set(activeSubscriptions.map((subscription) => subscription.currency));
+  const monthlySpendMetric = dashboardPayload.kpis.monthlyEquivalentSpend;
   const monthlySpendDisplay =
-    activeSubscriptions.length === 0
+    monthlySpendMetric.totalsByCurrency.length === 0
       ? "n/a"
-      : activeCurrencies.size === 1
-      ? formatMoney(estimatedMonthlySpendCents, activeSubscriptions[0].currency)
+      : monthlySpendMetric.amountCents !== null && monthlySpendMetric.currency
+      ? formatMoney(monthlySpendMetric.amountCents, monthlySpendMetric.currency)
       : "Mixed currencies";
-
-  const nextCharge = activeSubscriptions
-    .filter((subscription) => subscription.nextBillingDate !== null)
-    .sort((first, second) => {
-      return (
-        (first.nextBillingDate?.getTime() ?? Number.POSITIVE_INFINITY) -
-        (second.nextBillingDate?.getTime() ?? Number.POSITIVE_INFINITY)
-      );
-    })[0];
-
-  const upcomingCharges = activeSubscriptions
-    .filter((subscription) => subscription.nextBillingDate !== null)
-    .slice(0, 5);
-
-  const recentSubscriptions = [...subscriptions]
-    .sort((first, second) => second.createdAt.getTime() - first.createdAt.getTime())
-    .slice(0, 5);
 
   return (
     <section className="page-stack">
@@ -135,7 +98,7 @@ export default async function DashboardPage() {
       <section className="metric-grid">
         <article className="metric-card">
           <span className="metric-label">Active Subscriptions</span>
-          <strong className="metric-value">{activeSubscriptions.length}</strong>
+          <strong className="metric-value">{dashboardPayload.kpis.subscriptions.active}</strong>
           <span className="metric-note">Currently billing</span>
         </article>
         <article className="metric-card">
@@ -146,32 +109,36 @@ export default async function DashboardPage() {
         <article className="metric-card">
           <span className="metric-label">Next Charge</span>
           <strong className="metric-value">
-            {nextCharge ? formatMoney(nextCharge.amountCents, nextCharge.currency) : "n/a"}
+            {dashboardPayload.nextCharge
+              ? formatMoney(dashboardPayload.nextCharge.amountCents, dashboardPayload.nextCharge.currency)
+              : "n/a"}
           </strong>
           <span className="metric-note">
-            {nextCharge?.nextBillingDate ? `${nextCharge.name} on ${formatDate(nextCharge.nextBillingDate)}` : "No date set"}
+            {dashboardPayload.nextCharge
+              ? `${dashboardPayload.nextCharge.name} on ${formatDate(dashboardPayload.nextCharge.nextBillingDate)}`
+              : "No date set"}
           </span>
         </article>
       </section>
 
       <DashboardSectionsClient
-        recentSubscriptions={recentSubscriptions.map((subscription) => ({
+        recentSubscriptions={dashboardPayload.recentSubscriptions.map((subscription) => ({
           id: subscription.id,
           name: subscription.name,
           isActive: subscription.isActive,
           amountCents: subscription.amountCents,
           currency: subscription.currency,
-          nextBillingDate: subscription.nextBillingDate ? subscription.nextBillingDate.toISOString() : null,
-          createdAt: subscription.createdAt.toISOString(),
+          nextBillingDate: subscription.nextBillingDate,
+          createdAt: subscription.createdAt,
         }))}
-        upcomingCharges={upcomingCharges.map((subscription) => ({
+        upcomingCharges={dashboardPayload.upcomingRenewals.map((subscription) => ({
           id: subscription.id,
           name: subscription.name,
           isActive: subscription.isActive,
           amountCents: subscription.amountCents,
           currency: subscription.currency,
-          nextBillingDate: subscription.nextBillingDate ? subscription.nextBillingDate.toISOString() : null,
-          createdAt: subscription.createdAt.toISOString(),
+          nextBillingDate: subscription.renewalDate,
+          createdAt: subscription.createdAt,
         }))}
       />
 

--- a/docs/DASHBOARD_AGGREGATION.md
+++ b/docs/DASHBOARD_AGGREGATION.md
@@ -1,0 +1,33 @@
+# Dashboard Aggregation Contract
+
+The dashboard aggregation contract is built in `lib/dashboard.ts` and exposed through `GET /api/dashboard`.
+
+## Date windows
+
+- Renewals KPI window: next `7` days (`DASHBOARD_RENEWALS_WINDOW_DAYS`).
+- Upcoming renewals list window: next `30` days (`DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS`).
+- Window checks are inclusive at the upper bound (`<= window length`).
+
+## Normalization rules
+
+- Weekly to monthly: `amountCents * 4.33` (rounded to nearest cent).
+- Monthly to monthly: `amountCents`.
+- Yearly to monthly: `amountCents / 12` (rounded to nearest cent).
+- Weekly to annual: `amountCents * 52`.
+- Monthly to annual: `amountCents * 12`.
+- Yearly to annual: `amountCents`.
+- `CUSTOM` cadence subscriptions are excluded from normalized monthly and annual totals.
+
+## Currency handling
+
+- No FX conversion is applied.
+- Normalized KPI totals return a single `amountCents` only when all contributing subscriptions share one currency.
+- When multiple currencies are present, KPI totals are returned in `totalsByCurrency` and single-currency fields are `null`.
+
+## Deterministic ordering
+
+- `upcomingRenewals`: renewal date ascending, then name ascending.
+- `attentionNeeded`: severity descending, then due date ascending, then title ascending.
+- `topCostDrivers`: currency ascending, then monthly equivalent descending, then name ascending.
+- `spendBreakdownByCategory`: max category monthly total descending, then subscription count descending, then category ascending.
+- `potentialSavings.opportunities`: estimated monthly savings descending, then title ascending.

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,759 @@
+import { BillingInterval } from "@prisma/client";
+
+import { db } from "@/lib/db";
+
+export const DASHBOARD_RENEWALS_WINDOW_DAYS = 7;
+export const DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS = 30;
+
+const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1000;
+const WEEKLY_TO_MONTHLY_FACTOR = 4.33;
+const TOP_COST_DRIVERS_LIMIT = 5;
+const RECENT_SUBSCRIPTIONS_LIMIT = 5;
+
+const CATEGORY_RULES: ReadonlyArray<{ category: string; keywords: readonly string[] }> = [
+  { category: "Streaming", keywords: ["netflix", "hulu", "disney", "paramount", "spotify", "youtube", "apple tv", "prime video"] },
+  { category: "Productivity", keywords: ["notion", "slack", "figma", "github", "canva", "office", "microsoft 365", "workspace"] },
+  { category: "Cloud & Hosting", keywords: ["aws", "azure", "gcp", "cloudflare", "vercel", "netlify", "digitalocean", "render"] },
+  { category: "Gaming", keywords: ["xbox", "playstation", "steam", "nintendo", "epic"] },
+  { category: "Utilities", keywords: ["vpn", "internet", "mobile", "phone", "electricity", "water", "gas"] },
+];
+
+const ATTENTION_SEVERITY_RANK: Record<DashboardAttentionSeverity, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+export type DashboardSubscriptionSourceRecord = {
+  id: string;
+  name: string;
+  amountCents: number;
+  currency: string;
+  billingInterval: BillingInterval;
+  nextBillingDate: Date | string | null;
+  isActive: boolean;
+  paymentMethod: string;
+  signedUpBy: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
+export type DashboardCurrencyTotal = {
+  currency: string;
+  monthlyEquivalentSpendCents: number;
+  annualProjectionCents: number;
+};
+
+export type DashboardMetricAmount = {
+  amountCents: number | null;
+  currency: string | null;
+  totalsByCurrency: DashboardCurrencyTotal[];
+  excludedCustomCadenceCount: number;
+};
+
+export type DashboardKpis = {
+  monthlyEquivalentSpend: DashboardMetricAmount;
+  annualProjection: DashboardMetricAmount;
+  renewalsInNext7Days: number;
+  subscriptions: {
+    active: number;
+    canceled: number;
+    total: number;
+  };
+};
+
+export type DashboardSpendCategory = {
+  category: string;
+  amountCents: number | null;
+  annualProjectionCents: number | null;
+  currency: string | null;
+  totalsByCurrency: DashboardCurrencyTotal[];
+  subscriptionCount: number;
+};
+
+export type DashboardAttentionSeverity = "high" | "medium" | "low";
+
+export type DashboardAttentionType = "renewal_soon" | "annual_renewal_soon" | "potential_duplicate";
+
+export type DashboardAttentionItem = {
+  id: string;
+  type: DashboardAttentionType;
+  severity: DashboardAttentionSeverity;
+  title: string;
+  message: string;
+  dueDate: string | null;
+  subscriptionIds: string[];
+  estimatedMonthlyImpactCents: number | null;
+  currency: string | null;
+};
+
+export type DashboardUpcomingRenewalTag = "urgent" | "soon" | "upcoming";
+
+export type DashboardUpcomingRenewal = {
+  id: string;
+  name: string;
+  amountCents: number;
+  currency: string;
+  billingInterval: BillingInterval;
+  paymentMethod: string;
+  renewalDate: string;
+  daysUntilRenewal: number;
+  monthlyEquivalentAmountCents: number | null;
+  tag: DashboardUpcomingRenewalTag;
+  isActive: boolean;
+  createdAt: string;
+};
+
+export type DashboardTopCostDriver = {
+  id: string;
+  name: string;
+  currency: string;
+  billingInterval: BillingInterval;
+  monthlyEquivalentAmountCents: number;
+  annualProjectionCents: number;
+  nextBillingDate: string | null;
+};
+
+export type DashboardSavingsOpportunity = {
+  id: string;
+  type: "duplicate_overlap";
+  title: string;
+  description: string;
+  currency: string;
+  estimatedMonthlySavingsCents: number;
+  subscriptionIds: string[];
+};
+
+export type DashboardPotentialSavings = {
+  estimatedMonthlySavingsCents: number | null;
+  currency: string | null;
+  totalsByCurrency: Array<{ currency: string; estimatedMonthlySavingsCents: number }>;
+  opportunities: DashboardSavingsOpportunity[];
+  assumptions: string[];
+};
+
+export type DashboardRecentSubscription = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  amountCents: number;
+  currency: string;
+  nextBillingDate: string | null;
+  createdAt: string;
+};
+
+export type DashboardNextCharge = {
+  id: string;
+  name: string;
+  amountCents: number;
+  currency: string;
+  nextBillingDate: string;
+} | null;
+
+export type DashboardPayload = {
+  generatedAt: string;
+  dateWindows: {
+    renewalsNextDays: typeof DASHBOARD_RENEWALS_WINDOW_DAYS;
+    upcomingRenewalsDays: typeof DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS;
+  };
+  normalizationPolicy: "single_currency_totals_without_fx_conversion";
+  kpis: DashboardKpis;
+  spendBreakdownByCategory: DashboardSpendCategory[];
+  attentionNeeded: DashboardAttentionItem[];
+  upcomingRenewals: DashboardUpcomingRenewal[];
+  topCostDrivers: DashboardTopCostDriver[];
+  potentialSavings: DashboardPotentialSavings;
+  nextCharge: DashboardNextCharge;
+  recentSubscriptions: DashboardRecentSubscription[];
+};
+
+type NormalizedSubscription = DashboardSubscriptionSourceRecord & {
+  currency: string;
+  createdAtDate: Date;
+  updatedAtDate: Date;
+  nextBillingDateDate: Date | null;
+  monthlyEquivalentAmountCents: number | null;
+  annualProjectionCents: number | null;
+  canonicalServiceKey: string;
+  inferredCategory: string;
+};
+
+type DuplicateGroup = {
+  key: string;
+  currency: string;
+  displayName: string;
+  subscriptions: NormalizedSubscription[];
+};
+
+function toDate(value: Date | string): Date {
+  const parsed = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Invalid date value while building dashboard payload.");
+  }
+
+  return parsed;
+}
+
+function toOptionalDate(value: Date | string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  return toDate(value);
+}
+
+function normalizeCurrency(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  return normalized || "USD";
+}
+
+export function normalizeToMonthlyAmountCents(amountCents: number, billingInterval: BillingInterval): number | null {
+  switch (billingInterval) {
+    case "WEEKLY":
+      return Math.round(amountCents * WEEKLY_TO_MONTHLY_FACTOR);
+    case "MONTHLY":
+      return amountCents;
+    case "YEARLY":
+      return Math.round(amountCents / 12);
+    default:
+      return null;
+  }
+}
+
+export function normalizeToAnnualAmountCents(amountCents: number, billingInterval: BillingInterval): number | null {
+  switch (billingInterval) {
+    case "WEEKLY":
+      return amountCents * 52;
+    case "MONTHLY":
+      return amountCents * 12;
+    case "YEARLY":
+      return amountCents;
+    default:
+      return null;
+  }
+}
+
+function isWithinNextDays(value: Date, now: Date, days: number): boolean {
+  const delta = value.getTime() - now.getTime();
+  return delta >= 0 && delta <= days * DAYS_TO_MILLISECONDS;
+}
+
+function daysUntil(value: Date, now: Date): number {
+  return Math.max(0, Math.ceil((value.getTime() - now.getTime()) / DAYS_TO_MILLISECONDS));
+}
+
+function inferCategory(name: string): string {
+  const lowered = name.trim().toLowerCase();
+
+  if (!lowered) {
+    return "Other";
+  }
+
+  for (const rule of CATEGORY_RULES) {
+    if (rule.keywords.some((keyword) => lowered.includes(keyword))) {
+      return rule.category;
+    }
+  }
+
+  return "Other";
+}
+
+function canonicalizeServiceName(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ");
+
+  return normalized || "unknown";
+}
+
+function makeCurrencyTotals(records: Iterable<NormalizedSubscription>): DashboardCurrencyTotal[] {
+  const totals = new Map<string, DashboardCurrencyTotal>();
+
+  for (const record of records) {
+    if (record.monthlyEquivalentAmountCents === null || record.annualProjectionCents === null) {
+      continue;
+    }
+
+    const existing = totals.get(record.currency);
+
+    if (existing) {
+      existing.monthlyEquivalentSpendCents += record.monthlyEquivalentAmountCents;
+      existing.annualProjectionCents += record.annualProjectionCents;
+      continue;
+    }
+
+    totals.set(record.currency, {
+      currency: record.currency,
+      monthlyEquivalentSpendCents: record.monthlyEquivalentAmountCents,
+      annualProjectionCents: record.annualProjectionCents,
+    });
+  }
+
+  return [...totals.values()].sort((first, second) => {
+    return (
+      second.monthlyEquivalentSpendCents - first.monthlyEquivalentSpendCents || first.currency.localeCompare(second.currency)
+    );
+  });
+}
+
+function metricAmountFromCurrencyTotals(
+  totalsByCurrency: DashboardCurrencyTotal[],
+  excludedCustomCadenceCount: number,
+  type: "monthly" | "annual",
+): DashboardMetricAmount {
+  if (totalsByCurrency.length !== 1) {
+    return {
+      amountCents: null,
+      currency: null,
+      totalsByCurrency,
+      excludedCustomCadenceCount,
+    };
+  }
+
+  const [total] = totalsByCurrency;
+
+  return {
+    amountCents: type === "monthly" ? total.monthlyEquivalentSpendCents : total.annualProjectionCents,
+    currency: total.currency,
+    totalsByCurrency,
+    excludedCustomCadenceCount,
+  };
+}
+
+function chooseUpcomingRenewalTag(daysUntilRenewal: number): DashboardUpcomingRenewalTag {
+  if (daysUntilRenewal <= 3) {
+    return "urgent";
+  }
+
+  if (daysUntilRenewal <= 7) {
+    return "soon";
+  }
+
+  return "upcoming";
+}
+
+function compareAttentionItems(first: DashboardAttentionItem, second: DashboardAttentionItem): number {
+  const severityDelta = ATTENTION_SEVERITY_RANK[second.severity] - ATTENTION_SEVERITY_RANK[first.severity];
+
+  if (severityDelta !== 0) {
+    return severityDelta;
+  }
+
+  const firstDue = first.dueDate ? new Date(first.dueDate).getTime() : Number.POSITIVE_INFINITY;
+  const secondDue = second.dueDate ? new Date(second.dueDate).getTime() : Number.POSITIVE_INFINITY;
+
+  if (firstDue !== secondDue) {
+    return firstDue - secondDue;
+  }
+
+  return first.title.localeCompare(second.title);
+}
+
+function findDuplicateGroups(records: NormalizedSubscription[]): DuplicateGroup[] {
+  const grouped = new Map<string, DuplicateGroup>();
+
+  for (const record of records) {
+    if (!record.isActive || record.monthlyEquivalentAmountCents === null) {
+      continue;
+    }
+
+    const key = `${record.canonicalServiceKey}:${record.currency}`;
+    const existing = grouped.get(key);
+
+    if (existing) {
+      existing.subscriptions.push(record);
+      continue;
+    }
+
+    grouped.set(key, {
+      key,
+      currency: record.currency,
+      displayName: record.name,
+      subscriptions: [record],
+    });
+  }
+
+  return [...grouped.values()]
+    .map((group) => ({
+      ...group,
+      subscriptions: [...group.subscriptions].sort((first, second) => {
+        const firstMonthly = first.monthlyEquivalentAmountCents ?? Number.MAX_SAFE_INTEGER;
+        const secondMonthly = second.monthlyEquivalentAmountCents ?? Number.MAX_SAFE_INTEGER;
+
+        return firstMonthly - secondMonthly || first.name.localeCompare(second.name) || first.id.localeCompare(second.id);
+      }),
+    }))
+    .filter((group) => group.subscriptions.length > 1)
+    .sort((first, second) => {
+      return first.displayName.localeCompare(second.displayName) || first.currency.localeCompare(second.currency);
+    });
+}
+
+export function buildDashboardPayload(
+  subscriptions: DashboardSubscriptionSourceRecord[],
+  now: Date = new Date(),
+): DashboardPayload {
+  const normalizedSubscriptions: NormalizedSubscription[] = subscriptions.map((subscription) => {
+    const createdAtDate = toDate(subscription.createdAt);
+    const updatedAtDate = toDate(subscription.updatedAt);
+    const nextBillingDateDate = toOptionalDate(subscription.nextBillingDate);
+    const currency = normalizeCurrency(subscription.currency);
+
+    return {
+      ...subscription,
+      currency,
+      createdAtDate,
+      updatedAtDate,
+      nextBillingDateDate,
+      monthlyEquivalentAmountCents: normalizeToMonthlyAmountCents(subscription.amountCents, subscription.billingInterval),
+      annualProjectionCents: normalizeToAnnualAmountCents(subscription.amountCents, subscription.billingInterval),
+      canonicalServiceKey: canonicalizeServiceName(subscription.name),
+      inferredCategory: inferCategory(subscription.name),
+    };
+  });
+
+  const activeSubscriptions = normalizedSubscriptions.filter((subscription) => subscription.isActive);
+  const canceledCount = normalizedSubscriptions.length - activeSubscriptions.length;
+  const excludedCustomCadenceCount = activeSubscriptions.filter(
+    (subscription) => subscription.monthlyEquivalentAmountCents === null || subscription.annualProjectionCents === null,
+  ).length;
+
+  const totalsByCurrency = makeCurrencyTotals(activeSubscriptions);
+
+  const kpis: DashboardKpis = {
+    monthlyEquivalentSpend: metricAmountFromCurrencyTotals(totalsByCurrency, excludedCustomCadenceCount, "monthly"),
+    annualProjection: metricAmountFromCurrencyTotals(totalsByCurrency, excludedCustomCadenceCount, "annual"),
+    renewalsInNext7Days: activeSubscriptions.filter(
+      (subscription) =>
+        subscription.nextBillingDateDate !== null &&
+        isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_RENEWALS_WINDOW_DAYS),
+    ).length,
+    subscriptions: {
+      active: activeSubscriptions.length,
+      canceled: canceledCount,
+      total: normalizedSubscriptions.length,
+    },
+  };
+
+  const categoryGroups = new Map<
+    string,
+    {
+      category: string;
+      subscriptionCount: number;
+      records: NormalizedSubscription[];
+    }
+  >();
+
+  for (const subscription of activeSubscriptions) {
+    if (subscription.monthlyEquivalentAmountCents === null || subscription.annualProjectionCents === null) {
+      continue;
+    }
+
+    const existing = categoryGroups.get(subscription.inferredCategory);
+
+    if (existing) {
+      existing.subscriptionCount += 1;
+      existing.records.push(subscription);
+      continue;
+    }
+
+    categoryGroups.set(subscription.inferredCategory, {
+      category: subscription.inferredCategory,
+      subscriptionCount: 1,
+      records: [subscription],
+    });
+  }
+
+  const spendBreakdownByCategory: DashboardSpendCategory[] = [...categoryGroups.values()]
+    .map((group) => {
+      const categoryTotals = makeCurrencyTotals(group.records);
+
+      return {
+        category: group.category,
+        amountCents: categoryTotals.length === 1 ? categoryTotals[0].monthlyEquivalentSpendCents : null,
+        annualProjectionCents: categoryTotals.length === 1 ? categoryTotals[0].annualProjectionCents : null,
+        currency: categoryTotals.length === 1 ? categoryTotals[0].currency : null,
+        totalsByCurrency: categoryTotals,
+        subscriptionCount: group.subscriptionCount,
+      };
+    })
+    .sort((first, second) => {
+      const firstSortAmount = Math.max(0, ...first.totalsByCurrency.map((entry) => entry.monthlyEquivalentSpendCents));
+      const secondSortAmount = Math.max(0, ...second.totalsByCurrency.map((entry) => entry.monthlyEquivalentSpendCents));
+
+      return secondSortAmount - firstSortAmount || second.subscriptionCount - first.subscriptionCount || first.category.localeCompare(second.category);
+    });
+
+  const upcomingRenewals: DashboardUpcomingRenewal[] = activeSubscriptions
+    .filter(
+      (subscription) =>
+        subscription.nextBillingDateDate !== null &&
+        isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS),
+    )
+    .map((subscription) => {
+      const renewalDate = subscription.nextBillingDateDate as Date;
+      const daysUntilRenewal = daysUntil(renewalDate, now);
+
+      return {
+        id: subscription.id,
+        name: subscription.name,
+        amountCents: subscription.amountCents,
+        currency: subscription.currency,
+        billingInterval: subscription.billingInterval,
+        paymentMethod: subscription.paymentMethod,
+        renewalDate: renewalDate.toISOString(),
+        daysUntilRenewal,
+        monthlyEquivalentAmountCents: subscription.monthlyEquivalentAmountCents,
+        tag: chooseUpcomingRenewalTag(daysUntilRenewal),
+        isActive: subscription.isActive,
+        createdAt: subscription.createdAtDate.toISOString(),
+      };
+    })
+    .sort((first, second) => {
+      return (
+        new Date(first.renewalDate).getTime() - new Date(second.renewalDate).getTime() || first.name.localeCompare(second.name)
+      );
+    });
+
+  const duplicateGroups = findDuplicateGroups(activeSubscriptions);
+
+  const attentionNeeded: DashboardAttentionItem[] = [
+    ...activeSubscriptions
+      .filter(
+        (subscription) =>
+          subscription.nextBillingDateDate !== null &&
+          isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_RENEWALS_WINDOW_DAYS),
+      )
+      .map((subscription) => ({
+        id: `renewal-soon-${subscription.id}`,
+        type: "renewal_soon" as const,
+        severity: "high" as const,
+        title: `${subscription.name} renews soon`,
+        message: `Renews in ${daysUntil(subscription.nextBillingDateDate as Date, now)} day(s).`,
+        dueDate: (subscription.nextBillingDateDate as Date).toISOString(),
+        subscriptionIds: [subscription.id],
+        estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
+        currency: subscription.currency,
+      })),
+    ...activeSubscriptions
+      .filter(
+        (subscription) =>
+          subscription.billingInterval === "YEARLY" &&
+          subscription.nextBillingDateDate !== null &&
+          isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS) &&
+          !isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_RENEWALS_WINDOW_DAYS),
+      )
+      .map((subscription) => ({
+        id: `annual-renewal-${subscription.id}`,
+        type: "annual_renewal_soon" as const,
+        severity: "medium" as const,
+        title: `${subscription.name} annual renewal`,
+        message: `Annual charge is due in ${daysUntil(subscription.nextBillingDateDate as Date, now)} day(s).`,
+        dueDate: (subscription.nextBillingDateDate as Date).toISOString(),
+        subscriptionIds: [subscription.id],
+        estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
+        currency: subscription.currency,
+      })),
+    ...duplicateGroups.map((group) => {
+      const duplicates = group.subscriptions.slice(1);
+      const estimatedMonthlyImpactCents = duplicates.reduce(
+        (total, subscription) => total + (subscription.monthlyEquivalentAmountCents ?? 0),
+        0,
+      );
+      const soonestRenewal = group.subscriptions
+        .map((subscription) => subscription.nextBillingDateDate)
+        .filter((value): value is Date => value !== null)
+        .sort((first, second) => first.getTime() - second.getTime())[0];
+
+      return {
+        id: `potential-duplicate-${group.key}`,
+        type: "potential_duplicate" as const,
+        severity: "medium" as const,
+        title: `Potential duplicate: ${group.displayName}`,
+        message: `${group.subscriptions.length} active subscriptions look overlapping in ${group.currency}.`,
+        dueDate: soonestRenewal ? soonestRenewal.toISOString() : null,
+        subscriptionIds: group.subscriptions.map((subscription) => subscription.id),
+        estimatedMonthlyImpactCents,
+        currency: group.currency,
+      };
+    }),
+  ].sort(compareAttentionItems);
+
+  const topCostDrivers: DashboardTopCostDriver[] = activeSubscriptions
+    .filter(
+      (subscription): subscription is NormalizedSubscription & { monthlyEquivalentAmountCents: number; annualProjectionCents: number } =>
+        subscription.monthlyEquivalentAmountCents !== null && subscription.annualProjectionCents !== null,
+    )
+    .sort((first, second) => {
+      if (first.currency !== second.currency) {
+        return first.currency.localeCompare(second.currency);
+      }
+
+      return (
+        second.monthlyEquivalentAmountCents - first.monthlyEquivalentAmountCents ||
+        first.name.localeCompare(second.name) ||
+        first.id.localeCompare(second.id)
+      );
+    })
+    .slice(0, TOP_COST_DRIVERS_LIMIT)
+    .map((subscription) => ({
+      id: subscription.id,
+      name: subscription.name,
+      currency: subscription.currency,
+      billingInterval: subscription.billingInterval,
+      monthlyEquivalentAmountCents: subscription.monthlyEquivalentAmountCents,
+      annualProjectionCents: subscription.annualProjectionCents,
+      nextBillingDate: subscription.nextBillingDateDate ? subscription.nextBillingDateDate.toISOString() : null,
+    }));
+
+  const opportunities: DashboardSavingsOpportunity[] = duplicateGroups
+    .map((group) => {
+      const duplicateSubscriptions = group.subscriptions.slice(1);
+      const estimatedMonthlySavingsCents = duplicateSubscriptions.reduce(
+        (total, subscription) => total + (subscription.monthlyEquivalentAmountCents ?? 0),
+        0,
+      );
+
+      return {
+        id: `savings-duplicate-${group.key}`,
+        type: "duplicate_overlap" as const,
+        title: `Consolidate duplicate ${group.displayName} subscriptions`,
+        description: `Cancelling ${duplicateSubscriptions.length} overlapping subscription(s) could reduce recurring spend.`,
+        currency: group.currency,
+        estimatedMonthlySavingsCents,
+        subscriptionIds: duplicateSubscriptions.map((subscription) => subscription.id),
+      };
+    })
+    .filter((opportunity) => opportunity.estimatedMonthlySavingsCents > 0)
+    .sort((first, second) => {
+      return (
+        second.estimatedMonthlySavingsCents - first.estimatedMonthlySavingsCents ||
+        first.title.localeCompare(second.title) ||
+        first.id.localeCompare(second.id)
+      );
+    });
+
+  const savingsTotalsMap = new Map<string, number>();
+
+  for (const opportunity of opportunities) {
+    savingsTotalsMap.set(
+      opportunity.currency,
+      (savingsTotalsMap.get(opportunity.currency) ?? 0) + opportunity.estimatedMonthlySavingsCents,
+    );
+  }
+
+  const savingsTotalsByCurrency = [...savingsTotalsMap.entries()]
+    .map(([currency, estimatedMonthlySavingsCents]) => ({
+      currency,
+      estimatedMonthlySavingsCents,
+    }))
+    .sort((first, second) => {
+      return (
+        second.estimatedMonthlySavingsCents - first.estimatedMonthlySavingsCents ||
+        first.currency.localeCompare(second.currency)
+      );
+    });
+
+  const potentialSavings: DashboardPotentialSavings = {
+    estimatedMonthlySavingsCents:
+      savingsTotalsByCurrency.length === 1 ? savingsTotalsByCurrency[0].estimatedMonthlySavingsCents : null,
+    currency: savingsTotalsByCurrency.length === 1 ? savingsTotalsByCurrency[0].currency : null,
+    totalsByCurrency: savingsTotalsByCurrency,
+    opportunities,
+    assumptions: [
+      "Savings estimate includes only duplicate active subscriptions sharing a canonical service name and currency.",
+      "No FX conversion is applied when currencies differ.",
+      "Custom billing intervals are excluded from normalized monthly/annual estimates.",
+    ],
+  };
+
+  const nextChargeSource = [...activeSubscriptions]
+    .filter((subscription) => subscription.nextBillingDateDate !== null)
+    .sort((first, second) => {
+      return (
+        (first.nextBillingDateDate as Date).getTime() - (second.nextBillingDateDate as Date).getTime() ||
+        first.name.localeCompare(second.name)
+      );
+    })
+    .find((subscription) => (subscription.nextBillingDateDate as Date).getTime() >= now.getTime());
+
+  const fallbackNextChargeSource =
+    nextChargeSource ??
+    [...activeSubscriptions]
+      .filter((subscription) => subscription.nextBillingDateDate !== null)
+      .sort((first, second) => {
+        return (
+          (first.nextBillingDateDate as Date).getTime() - (second.nextBillingDateDate as Date).getTime() ||
+          first.name.localeCompare(second.name)
+        );
+      })[0];
+
+  const nextCharge: DashboardNextCharge = fallbackNextChargeSource
+    ? {
+        id: fallbackNextChargeSource.id,
+        name: fallbackNextChargeSource.name,
+        amountCents: fallbackNextChargeSource.amountCents,
+        currency: fallbackNextChargeSource.currency,
+        nextBillingDate: (fallbackNextChargeSource.nextBillingDateDate as Date).toISOString(),
+      }
+    : null;
+
+  const recentSubscriptions: DashboardRecentSubscription[] = [...normalizedSubscriptions]
+    .sort((first, second) => {
+      return second.createdAtDate.getTime() - first.createdAtDate.getTime() || first.name.localeCompare(second.name);
+    })
+    .slice(0, RECENT_SUBSCRIPTIONS_LIMIT)
+    .map((subscription) => ({
+      id: subscription.id,
+      name: subscription.name,
+      isActive: subscription.isActive,
+      amountCents: subscription.amountCents,
+      currency: subscription.currency,
+      nextBillingDate: subscription.nextBillingDateDate ? subscription.nextBillingDateDate.toISOString() : null,
+      createdAt: subscription.createdAtDate.toISOString(),
+    }));
+
+  return {
+    generatedAt: now.toISOString(),
+    dateWindows: {
+      renewalsNextDays: DASHBOARD_RENEWALS_WINDOW_DAYS,
+      upcomingRenewalsDays: DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS,
+    },
+    normalizationPolicy: "single_currency_totals_without_fx_conversion",
+    kpis,
+    spendBreakdownByCategory,
+    attentionNeeded,
+    upcomingRenewals,
+    topCostDrivers,
+    potentialSavings,
+    nextCharge,
+    recentSubscriptions,
+  };
+}
+
+export async function getDashboardPayloadForUser(userId: string, now: Date = new Date()): Promise<DashboardPayload> {
+  const subscriptions = await db.subscription.findMany({
+    where: {
+      userId,
+    },
+    select: {
+      id: true,
+      name: true,
+      amountCents: true,
+      currency: true,
+      billingInterval: true,
+      nextBillingDate: true,
+      isActive: true,
+      paymentMethod: true,
+      signedUpBy: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: [{ isActive: "desc" }, { nextBillingDate: "asc" }, { createdAt: "desc" }],
+  });
+
+  return buildDashboardPayload(subscriptions, now);
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test:invites": "dotenv -e .env.local -- node --import tsx --test tests/invites/*.test.ts",
     "test:mail": "dotenv -e .env.local -- node --import tsx --test tests/mail/*.test.ts",
+    "test:dashboard": "dotenv -e .env.local -- node --import tsx --test tests/dashboard/*.test.ts",
     "email:dev": "email dev --dir lib/mail/templates",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  DASHBOARD_RENEWALS_WINDOW_DAYS,
+  DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS,
+  type DashboardSubscriptionSourceRecord,
+  buildDashboardPayload,
+} from "../../lib/dashboard";
+
+function makeSubscription(
+  overrides: Partial<DashboardSubscriptionSourceRecord> & Pick<DashboardSubscriptionSourceRecord, "id" | "name">,
+): DashboardSubscriptionSourceRecord {
+  const { id, name, ...rest } = overrides;
+
+  return {
+    amountCents: 1000,
+    currency: "usd",
+    billingInterval: "MONTHLY",
+    nextBillingDate: new Date("2026-03-20T00:00:00.000Z"),
+    isActive: true,
+    paymentMethod: "Visa 1234",
+    signedUpBy: null,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    ...rest,
+    id,
+    name,
+  };
+}
+
+describe("buildDashboardPayload", () => {
+  test("handles an empty subscription list", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const payload = buildDashboardPayload([], now);
+
+    assert.equal(payload.generatedAt, now.toISOString());
+    assert.equal(payload.kpis.subscriptions.total, 0);
+    assert.equal(payload.kpis.subscriptions.active, 0);
+    assert.equal(payload.kpis.subscriptions.canceled, 0);
+    assert.equal(payload.kpis.renewalsInNext7Days, 0);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, null);
+    assert.equal(payload.kpis.annualProjection.amountCents, null);
+    assert.deepEqual(payload.spendBreakdownByCategory, []);
+    assert.deepEqual(payload.attentionNeeded, []);
+    assert.deepEqual(payload.upcomingRenewals, []);
+    assert.deepEqual(payload.topCostDrivers, []);
+    assert.deepEqual(payload.potentialSavings.opportunities, []);
+    assert.deepEqual(payload.recentSubscriptions, []);
+    assert.equal(payload.nextCharge, null);
+  });
+
+  test("uses explicit next-7 and next-30-day windows and excludes custom cadence from normalized totals", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const inSevenDays = new Date(now.getTime() + DASHBOARD_RENEWALS_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const justAfterSevenDays = new Date(inSevenDays.getTime() + 1);
+    const inThirtyDays = new Date(now.getTime() + DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const justAfterThirtyDays = new Date(inThirtyDays.getTime() + 1);
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({
+          id: "monthly",
+          name: "Notion",
+          amountCents: 1000,
+          billingInterval: "MONTHLY",
+          nextBillingDate: inSevenDays,
+        }),
+        makeSubscription({
+          id: "yearly",
+          name: "Cloudflare",
+          amountCents: 12000,
+          billingInterval: "YEARLY",
+          nextBillingDate: inThirtyDays,
+        }),
+        makeSubscription({
+          id: "weekly",
+          name: "Gym",
+          amountCents: 500,
+          billingInterval: "WEEKLY",
+          nextBillingDate: justAfterSevenDays,
+        }),
+        makeSubscription({
+          id: "custom",
+          name: "Other Service",
+          amountCents: 700,
+          billingInterval: "CUSTOM",
+          nextBillingDate: new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000),
+        }),
+        makeSubscription({
+          id: "outside-window",
+          name: "Beyond Window",
+          amountCents: 2500,
+          billingInterval: "MONTHLY",
+          nextBillingDate: justAfterThirtyDays,
+        }),
+      ],
+      now,
+    );
+
+    assert.equal(payload.kpis.renewalsInNext7Days, 2);
+    assert.equal(payload.upcomingRenewals.length, 4);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.currency, "USD");
+    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, 6665);
+    assert.equal(payload.kpis.annualProjection.amountCents, 80000);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.excludedCustomCadenceCount, 1);
+    assert.equal(payload.kpis.annualProjection.excludedCustomCadenceCount, 1);
+    assert.equal(payload.attentionNeeded.some((item) => item.type === "annual_renewal_soon"), true);
+  });
+
+  test("does not merge mixed currencies into a single normalized KPI total", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "usd", name: "GitHub", amountCents: 1000, currency: "usd" }),
+        makeSubscription({ id: "aud", name: "Canva", amountCents: 2000, currency: "aud" }),
+      ],
+      now,
+    );
+
+    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, null);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.currency, null);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.totalsByCurrency.length, 2);
+    assert.deepEqual(payload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency), ["AUD", "USD"]);
+  });
+
+  test("keeps canceled subscriptions in counts while excluding them from active spend and cost drivers", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "active", name: "Netlify", amountCents: 3000, isActive: true }),
+        makeSubscription({ id: "inactive", name: "Old Tool", amountCents: 9000, isActive: false }),
+      ],
+      now,
+    );
+
+    assert.equal(payload.kpis.subscriptions.total, 2);
+    assert.equal(payload.kpis.subscriptions.active, 1);
+    assert.equal(payload.kpis.subscriptions.canceled, 1);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, 3000);
+    assert.deepEqual(payload.topCostDrivers.map((driver) => driver.id), ["active"]);
+  });
+
+  test("builds duplicate-service alerts and savings opportunities deterministically", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "stream-a", name: "Netflix", amountCents: 1000, currency: "usd" }),
+        makeSubscription({ id: "stream-b", name: "Netflix", amountCents: 2200, currency: "usd" }),
+        makeSubscription({ id: "stream-c", name: "Netflix", amountCents: 1800, currency: "usd" }),
+      ],
+      now,
+    );
+
+    assert.equal(payload.attentionNeeded.some((item) => item.type === "potential_duplicate"), true);
+    assert.equal(payload.potentialSavings.opportunities.length, 1);
+    assert.equal(payload.potentialSavings.currency, "USD");
+    assert.equal(payload.potentialSavings.estimatedMonthlySavingsCents, 4000);
+    assert.deepEqual(payload.potentialSavings.opportunities[0]?.subscriptionIds, ["stream-c", "stream-b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a typed dashboard aggregation contract in `lib/dashboard.ts`
- add authenticated `GET /api/dashboard` route returning the aggregated payload
- migrate `app/page.tsx` to consume the centralized dashboard payload
- document normalization/date-window/currency rules in `docs/DASHBOARD_AGGREGATION.md`
- add unit tests for dashboard aggregation edge cases (`tests/dashboard/dashboard-aggregation.test.ts`)

## What this covers from #31
- single typed dashboard payload that can power dashboard widgets
- server-side KPI/list computations with deterministic sorting/grouping
- explicit and tested date windows (`next 7` and `next 30` days)
- explicit and tested monthly/annual normalization and mixed-currency handling
- edge-case test coverage (empty data, mixed cadence/currency, canceled items, duplicate services)

## Verification
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`