### PR TITLE
Dashboard V2 shell and top control bar (issue #32)

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1,21 +1,44 @@
 "use client";
 
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
 import SubscriptionDetailsModal from "@/app/components/SubscriptionDetailsModal";
 import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDetailsModal";
+import {
+  DASHBOARD_ALL_CURRENCIES,
+  DASHBOARD_DATE_RANGE_OPTIONS,
+  DEFAULT_DASHBOARD_DATE_RANGE,
+  filterDashboardRecentActivity,
+  filterDashboardUpcomingRenewals,
+  type DashboardDateRangeValue,
+} from "@/lib/dashboard-controls";
 
-type DashboardSubscriptionListItem = {
+type DashboardUpcomingChargeListItem = {
   id: string;
   name: string;
   isActive: boolean;
   amountCents: number;
   currency: string;
-  nextBillingDate: string | null;
+  paymentMethod: string;
+  renewalDate: string;
+  createdAt: string;
+  tag: "urgent" | "soon" | "upcoming";
+};
+
+type DashboardRecentActivityListItem = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  amountCents: number;
+  currency: string;
   createdAt: string;
 };
 
 type DashboardSectionsClientProps = {
-  upcomingCharges: DashboardSubscriptionListItem[];
-  recentSubscriptions: DashboardSubscriptionListItem[];
+  availableCurrencies: string[];
+  upcomingCharges: DashboardUpcomingChargeListItem[];
+  recentSubscriptions: DashboardRecentActivityListItem[];
 };
 
 function formatMoney(amountCents: number, currency: string): string {
@@ -27,11 +50,7 @@ function formatMoney(amountCents: number, currency: string): string {
   }).format(amountCents / 100);
 }
 
-function formatDate(value: string | null): string {
-  if (!value) {
-    return "No date";
-  }
-
+function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
@@ -39,80 +58,243 @@ function formatDate(value: string | null): string {
   }).format(new Date(value));
 }
 
-export default function DashboardSectionsClient({ upcomingCharges, recentSubscriptions }: DashboardSectionsClientProps) {
+function formatTag(tag: "urgent" | "soon" | "upcoming"): string {
+  if (tag === "urgent") {
+    return "URGENT";
+  }
+
+  if (tag === "soon") {
+    return "SOON";
+  }
+
+  return "UPCOMING";
+}
+
+function tagClassName(tag: "urgent" | "soon" | "upcoming"): string {
+  if (tag === "urgent") {
+    return "pill pill-fail";
+  }
+
+  if (tag === "soon") {
+    return "pill pill-ok";
+  }
+
+  return "pill";
+}
+
+export default function DashboardSectionsClient({
+  availableCurrencies,
+  upcomingCharges,
+  recentSubscriptions,
+}: DashboardSectionsClientProps) {
   const detailsModal = useSubscriptionDetailsModal();
+  const [currency, setCurrency] = useState<string>(DASHBOARD_ALL_CURRENCIES);
+  const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
+  const [searchQuery, setSearchQuery] = useState("");
+  const now = useMemo(() => new Date(), []);
+
+  const filteredUpcomingCharges = useMemo(
+    () =>
+      filterDashboardUpcomingRenewals(
+        upcomingCharges,
+        {
+          currency,
+          dateRange,
+          searchQuery,
+        },
+        now,
+      ),
+    [currency, dateRange, now, searchQuery, upcomingCharges],
+  );
+  const filteredRecentActivity = useMemo(
+    () =>
+      filterDashboardRecentActivity(
+        recentSubscriptions,
+        {
+          currency,
+          dateRange,
+          searchQuery,
+        },
+        now,
+      ),
+    [currency, dateRange, now, recentSubscriptions, searchQuery],
+  );
+  const currencyOptions = useMemo(() => {
+    const normalized = [
+      ...new Set(
+        availableCurrencies
+          .map((value) => value.trim().toUpperCase())
+          .filter((value) => value.length > 0),
+      ),
+    ].sort((first, second) => first.localeCompare(second));
+
+    if (!normalized.includes("USD")) {
+      return normalized;
+    }
+
+    return ["USD", ...normalized.filter((value) => value !== "USD")];
+  }, [availableCurrencies]);
 
   return (
     <>
-      <div className="split-grid">
-        <article className="surface">
-          <h2>Upcoming Charges</h2>
-          {upcomingCharges.length === 0 ? (
-            <p className="text-muted">No upcoming charges with billing dates yet.</p>
-          ) : (
-            <div className="stack">
-              {upcomingCharges.map((subscription) => (
-                <button
-                  aria-label={`View details for ${subscription.name}`}
-                  className="status-item subscription-entry-button"
-                  key={subscription.id}
-                  onClick={() =>
-                    void detailsModal.openModal({
-                      subscriptionId: subscription.id,
-                      source: "upcoming_charges",
-                    })
-                  }
-                  type="button"
-                >
-                  <div className="subscription-header">
-                    <h2>{subscription.name}</h2>
-                    <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
-                      {subscription.isActive ? "ACTIVE" : "INACTIVE"}
-                    </span>
-                  </div>
-                  <p className="subscription-meta">
-                    {formatMoney(subscription.amountCents, subscription.currency)} -{" "}
-                    {formatDate(subscription.nextBillingDate)}
-                  </p>
-                </button>
-              ))}
-            </div>
-          )}
+      <div className="dashboard-shell">
+        <article className="dashboard-card dashboard-controls-shell">
+          <div className="dashboard-control-grid">
+            <label className="form-field" htmlFor="dashboard-currency-select">
+              Currency
+              <select id="dashboard-currency-select" onChange={(event) => setCurrency(event.target.value)} value={currency}>
+                <option value={DASHBOARD_ALL_CURRENCIES}>All currencies</option>
+                {currencyOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="form-field" htmlFor="dashboard-date-range-select">
+              Date range
+              <select
+                id="dashboard-date-range-select"
+                onChange={(event) => setDateRange(event.target.value as DashboardDateRangeValue)}
+                value={dateRange}
+              >
+                {DASHBOARD_DATE_RANGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="form-field dashboard-search-control" htmlFor="dashboard-search-input">
+              Search
+              <input
+                id="dashboard-search-input"
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search name, payment method, or currency..."
+                type="search"
+                value={searchQuery}
+              />
+            </label>
+          </div>
+          <div className="dashboard-control-actions">
+            <Link className="button" href="/subscriptions">
+              Add Subscription
+            </Link>
+          </div>
         </article>
 
-        <article className="surface surface-soft">
-          <h2>Recent Activity</h2>
-          {recentSubscriptions.length === 0 ? (
-            <p className="text-muted">No subscriptions added yet.</p>
-          ) : (
-            <div className="stack">
-              {recentSubscriptions.map((subscription) => (
-                <button
-                  aria-label={`View details for ${subscription.name}`}
-                  className="status-item subscription-entry-button"
-                  key={subscription.id}
-                  onClick={() =>
-                    void detailsModal.openModal({
-                      subscriptionId: subscription.id,
-                      source: "recent_activity",
-                    })
-                  }
-                  type="button"
-                >
-                  <div className="subscription-header">
-                    <h2>{subscription.name}</h2>
-                    <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
-                      {subscription.isActive ? "ACTIVE" : "INACTIVE"}
-                    </span>
-                  </div>
-                  <p className="subscription-meta">
-                    Added {formatDate(subscription.createdAt)} - {formatMoney(subscription.amountCents, subscription.currency)}
-                  </p>
-                </button>
-              ))}
+        <section className="dashboard-grid">
+          <article className="dashboard-card">
+            <h2>KPI Summary</h2>
+            <p className="text-muted">
+              Summary metric cards are reserved in this section and will expand in the next dashboard iteration.
+            </p>
+          </article>
+        </section>
+
+        <section className="dashboard-grid dashboard-grid-two-up">
+          <article className="dashboard-card">
+            <h2>Spend Breakdown</h2>
+            <p className="text-muted">Chart and category legend content will render inside this container.</p>
+          </article>
+          <article className="dashboard-card">
+            <h2>Attention Needed</h2>
+            <p className="text-muted">Alert items and severity indicators will render in this section.</p>
+          </article>
+        </section>
+
+        <section className="dashboard-grid">
+          <article className="dashboard-card">
+            <div className="dashboard-card-header">
+              <h2>Upcoming Renewals</h2>
+              <span className="metric-note">{filteredUpcomingCharges.length} matching rows</span>
             </div>
-          )}
-        </article>
+            {filteredUpcomingCharges.length === 0 ? (
+              <p className="text-muted">No upcoming renewals match the current control filters.</p>
+            ) : (
+              <div className="stack">
+                {filteredUpcomingCharges.map((subscription) => (
+                  <button
+                    aria-label={`View details for ${subscription.name}`}
+                    className="status-item subscription-entry-button"
+                    key={subscription.id}
+                    onClick={() =>
+                      void detailsModal.openModal({
+                        subscriptionId: subscription.id,
+                        source: "upcoming_charges",
+                      })
+                    }
+                    type="button"
+                  >
+                    <div className="subscription-header">
+                      <h2>{subscription.name}</h2>
+                      <div className="inline-actions">
+                        <span className={tagClassName(subscription.tag)}>{formatTag(subscription.tag)}</span>
+                        <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
+                          {subscription.isActive ? "ACTIVE" : "INACTIVE"}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="subscription-meta">
+                      {formatMoney(subscription.amountCents, subscription.currency)} - {formatDate(subscription.renewalDate)}
+                    </p>
+                    <p className="subscription-meta">Payment method: {subscription.paymentMethod}</p>
+                  </button>
+                ))}
+              </div>
+            )}
+          </article>
+        </section>
+
+        <section className="dashboard-grid dashboard-grid-two-up">
+          <article className="dashboard-card">
+            <h2>Potential Savings</h2>
+            <p className="text-muted">Savings opportunity insights will render in this container.</p>
+          </article>
+          <article className="dashboard-card">
+            <h2>Top Cost Drivers</h2>
+            <p className="text-muted">Top-cost subscription rankings will render in this section.</p>
+          </article>
+        </section>
+
+        <section className="dashboard-grid">
+          <article className="dashboard-card">
+            <div className="dashboard-card-header">
+              <h2>Recent Activity</h2>
+              <span className="metric-note">{filteredRecentActivity.length} matching rows</span>
+            </div>
+            {filteredRecentActivity.length === 0 ? (
+              <p className="text-muted">No recent subscriptions match the current control filters.</p>
+            ) : (
+              <div className="stack">
+                {filteredRecentActivity.map((subscription) => (
+                  <button
+                    aria-label={`View details for ${subscription.name}`}
+                    className="status-item subscription-entry-button"
+                    key={subscription.id}
+                    onClick={() =>
+                      void detailsModal.openModal({
+                        subscriptionId: subscription.id,
+                        source: "recent_activity",
+                      })
+                    }
+                    type="button"
+                  >
+                    <div className="subscription-header">
+                      <h2>{subscription.name}</h2>
+                      <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
+                        {subscription.isActive ? "ACTIVE" : "INACTIVE"}
+                      </span>
+                    </div>
+                    <p className="subscription-meta">
+                      Added {formatDate(subscription.createdAt)} - {formatMoney(subscription.amountCents, subscription.currency)}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            )}
+          </article>
+        </section>
       </div>
 
       <SubscriptionDetailsModal

--- a/app/globals.css
+++ b/app/globals.css
@@ -278,6 +278,7 @@ a {
 
 .card,
 .surface,
+.dashboard-card,
 .status-item {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -336,6 +337,57 @@ a {
   display: grid;
   gap: 0.9rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dashboard-shell {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: 1fr;
+}
+
+.dashboard-grid-two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.dashboard-controls-shell {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.9rem;
+}
+
+.dashboard-control-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-search-control {
+  min-width: min(320px, 100%);
+}
+
+.dashboard-control-actions {
+  display: inline-flex;
+  align-items: center;
+}
+
+.dashboard-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.dashboard-card-header h2 {
+  margin-bottom: 0.2rem;
 }
 
 .stack {
@@ -913,6 +965,23 @@ ul {
 
   .split-grid {
     grid-template-columns: 1fr;
+  }
+
+  .dashboard-grid-two-up {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-control-grid {
+    grid-template-columns: 1fr;
+    width: 100%;
+  }
+
+  .dashboard-control-actions {
+    width: 100%;
+  }
+
+  .dashboard-control-actions .button {
+    width: 100%;
   }
 
   .control-grid {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,25 +4,6 @@ import DashboardSectionsClient from "@/app/DashboardSectionsClient";
 import { getCurrentUser } from "@/lib/auth";
 import { getDashboardPayloadForUser } from "@/lib/dashboard";
 
-function formatMoney(amountCents: number, currency: string): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amountCents / 100);
-}
-
-function formatDate(value: Date | string): string {
-  const parsedValue = value instanceof Date ? value : new Date(value);
-
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(parsedValue);
-}
-
 export default async function DashboardPage() {
   const user = await getCurrentUser();
 
@@ -68,14 +49,13 @@ export default async function DashboardPage() {
   }
 
   const dashboardPayload = await getDashboardPayloadForUser(user.id);
-
-  const monthlySpendMetric = dashboardPayload.kpis.monthlyEquivalentSpend;
-  const monthlySpendDisplay =
-    monthlySpendMetric.totalsByCurrency.length === 0
-      ? "n/a"
-      : monthlySpendMetric.amountCents !== null && monthlySpendMetric.currency
-      ? formatMoney(monthlySpendMetric.amountCents, monthlySpendMetric.currency)
-      : "Mixed currencies";
+  const availableCurrencies = [
+    ...new Set([
+      ...dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency),
+      ...dashboardPayload.upcomingRenewals.map((entry) => entry.currency),
+      ...dashboardPayload.recentSubscriptions.map((entry) => entry.currency),
+    ]),
+  ];
 
   return (
     <section className="page-stack">
@@ -83,52 +63,20 @@ export default async function DashboardPage() {
         <div className="stack">
           <p className="eyebrow">Dashboard</p>
           <h1>Subscription overview</h1>
-          <p className="page-lead">Signed in as {user.email}. Review upcoming charges and recent account activity.</p>
-        </div>
-        <div className="inline-actions">
-          <Link className="button" href="/subscriptions">
-            Manage Subscriptions
-          </Link>
-          <Link className="button button-secondary" href="/settings">
-            Preferences
-          </Link>
+          <p className="page-lead">
+            Signed in as {user.email}. Use the control bar to scope dashboard sections by currency, date range, and search.
+          </p>
         </div>
       </header>
 
-      <section className="metric-grid">
-        <article className="metric-card">
-          <span className="metric-label">Active Subscriptions</span>
-          <strong className="metric-value">{dashboardPayload.kpis.subscriptions.active}</strong>
-          <span className="metric-note">Currently billing</span>
-        </article>
-        <article className="metric-card">
-          <span className="metric-label">Estimated Monthly Spend</span>
-          <strong className="metric-value">{monthlySpendDisplay}</strong>
-          <span className="metric-note">Normalized from all active plans</span>
-        </article>
-        <article className="metric-card">
-          <span className="metric-label">Next Charge</span>
-          <strong className="metric-value">
-            {dashboardPayload.nextCharge
-              ? formatMoney(dashboardPayload.nextCharge.amountCents, dashboardPayload.nextCharge.currency)
-              : "n/a"}
-          </strong>
-          <span className="metric-note">
-            {dashboardPayload.nextCharge
-              ? `${dashboardPayload.nextCharge.name} on ${formatDate(dashboardPayload.nextCharge.nextBillingDate)}`
-              : "No date set"}
-          </span>
-        </article>
-      </section>
-
       <DashboardSectionsClient
+        availableCurrencies={availableCurrencies}
         recentSubscriptions={dashboardPayload.recentSubscriptions.map((subscription) => ({
           id: subscription.id,
           name: subscription.name,
           isActive: subscription.isActive,
           amountCents: subscription.amountCents,
           currency: subscription.currency,
-          nextBillingDate: subscription.nextBillingDate,
           createdAt: subscription.createdAt,
         }))}
         upcomingCharges={dashboardPayload.upcomingRenewals.map((subscription) => ({
@@ -137,25 +85,12 @@ export default async function DashboardPage() {
           isActive: subscription.isActive,
           amountCents: subscription.amountCents,
           currency: subscription.currency,
-          nextBillingDate: subscription.renewalDate,
+          paymentMethod: subscription.paymentMethod,
+          renewalDate: subscription.renewalDate,
           createdAt: subscription.createdAt,
+          tag: subscription.tag,
         }))}
       />
-
-      <article className="surface">
-        <h2>Quick Actions</h2>
-        <div className="inline-actions mt-sm">
-          <Link className="button" href="/subscriptions">
-            Add or Update Subscriptions
-          </Link>
-          <Link className="button button-secondary" href="/tools">
-            Run Maintenance Tools
-          </Link>
-          <Link className="button button-secondary" href="/status">
-            View System Status
-          </Link>
-        </div>
-      </article>
     </section>
   );
 }

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -1,0 +1,123 @@
+export const DASHBOARD_ALL_CURRENCIES = "all";
+
+export const DASHBOARD_DATE_RANGE_OPTIONS = [
+  { value: "7d", label: "Last 7 days", days: 7 },
+  { value: "30d", label: "Last 30 days", days: 30 },
+  { value: "90d", label: "Last 90 days", days: 90 },
+] as const;
+
+export const DEFAULT_DASHBOARD_DATE_RANGE = "30d";
+
+export type DashboardDateRangeValue = (typeof DASHBOARD_DATE_RANGE_OPTIONS)[number]["value"];
+
+export type DashboardControlState = {
+  currency: string;
+  dateRange: DashboardDateRangeValue;
+  searchQuery: string;
+};
+
+type DashboardUpcomingRenewalRecord = {
+  name: string;
+  currency: string;
+  paymentMethod: string;
+  renewalDate: string;
+};
+
+type DashboardRecentActivityRecord = {
+  name: string;
+  currency: string;
+  createdAt: string;
+};
+
+function toNormalizedSearchQuery(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function matchesCurrencyFilter(recordCurrency: string, selectedCurrency: string): boolean {
+  if (selectedCurrency === DASHBOARD_ALL_CURRENCIES) {
+    return true;
+  }
+
+  return recordCurrency.toUpperCase() === selectedCurrency.toUpperCase();
+}
+
+function matchesSearchFilter(parts: string[], normalizedQuery: string): boolean {
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return parts.some((part) => part.toLowerCase().includes(normalizedQuery));
+}
+
+function toDateRangeDays(value: DashboardDateRangeValue): number {
+  const option = DASHBOARD_DATE_RANGE_OPTIONS.find((entry) => entry.value === value);
+  return option?.days ?? DASHBOARD_DATE_RANGE_OPTIONS[1].days;
+}
+
+function isWithinUpcomingWindow(dateValue: string, now: Date, rangeDays: number): boolean {
+  const parsedDate = new Date(dateValue);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return false;
+  }
+
+  const deltaMs = parsedDate.getTime() - now.getTime();
+  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
+
+  return deltaMs >= 0 && deltaMs <= maxMs;
+}
+
+function isWithinRecentWindow(dateValue: string, now: Date, rangeDays: number): boolean {
+  const parsedDate = new Date(dateValue);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return false;
+  }
+
+  const deltaMs = now.getTime() - parsedDate.getTime();
+  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
+
+  return deltaMs >= 0 && deltaMs <= maxMs;
+}
+
+export function filterDashboardUpcomingRenewals<T extends DashboardUpcomingRenewalRecord>(
+  records: T[],
+  controls: DashboardControlState,
+  now: Date,
+): T[] {
+  const rangeDays = toDateRangeDays(controls.dateRange);
+  const normalizedQuery = toNormalizedSearchQuery(controls.searchQuery);
+
+  return records.filter((record) => {
+    if (!matchesCurrencyFilter(record.currency, controls.currency)) {
+      return false;
+    }
+
+    if (!isWithinUpcomingWindow(record.renewalDate, now, rangeDays)) {
+      return false;
+    }
+
+    return matchesSearchFilter([record.name, record.paymentMethod, record.currency], normalizedQuery);
+  });
+}
+
+export function filterDashboardRecentActivity<T extends DashboardRecentActivityRecord>(
+  records: T[],
+  controls: DashboardControlState,
+  now: Date,
+): T[] {
+  const rangeDays = toDateRangeDays(controls.dateRange);
+  const normalizedQuery = toNormalizedSearchQuery(controls.searchQuery);
+
+  return records.filter((record) => {
+    if (!matchesCurrencyFilter(record.currency, controls.currency)) {
+      return false;
+    }
+
+    if (!isWithinRecentWindow(record.createdAt, now, rangeDays)) {
+      return false;
+    }
+
+    return matchesSearchFilter([record.name, record.currency], normalizedQuery);
+  });
+}

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  DASHBOARD_ALL_CURRENCIES,
+  DEFAULT_DASHBOARD_DATE_RANGE,
+  filterDashboardRecentActivity,
+  filterDashboardUpcomingRenewals,
+} from "../../lib/dashboard-controls";
+
+describe("dashboard controls filtering", () => {
+  test("uses last 30 days as the default date range", () => {
+    assert.equal(DEFAULT_DASHBOARD_DATE_RANGE, "30d");
+  });
+
+  test("filters upcoming renewals by currency, search, and upcoming date window", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const records = [
+      {
+        name: "GitHub Team",
+        currency: "USD",
+        paymentMethod: "Visa 1234",
+        renewalDate: "2026-03-20T00:00:00.000Z",
+      },
+      {
+        name: "Canva Pro",
+        currency: "AUD",
+        paymentMethod: "Mastercard 9876",
+        renewalDate: "2026-03-18T00:00:00.000Z",
+      },
+      {
+        name: "Legacy Service",
+        currency: "USD",
+        paymentMethod: "Visa 1234",
+        renewalDate: "2026-04-20T00:00:00.000Z",
+      },
+      {
+        name: "Past Renewal",
+        currency: "USD",
+        paymentMethod: "Visa 1234",
+        renewalDate: "2026-03-01T00:00:00.000Z",
+      },
+    ];
+
+    const allResults = filterDashboardUpcomingRenewals(
+      records,
+      {
+        currency: DASHBOARD_ALL_CURRENCIES,
+        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
+        searchQuery: "",
+      },
+      now,
+    );
+    const filteredUsdVisa = filterDashboardUpcomingRenewals(
+      records,
+      {
+        currency: "usd",
+        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
+        searchQuery: "visa",
+      },
+      now,
+    );
+
+    assert.deepEqual(
+      allResults.map((record) => record.name),
+      ["GitHub Team", "Canva Pro"],
+    );
+    assert.deepEqual(
+      filteredUsdVisa.map((record) => record.name),
+      ["GitHub Team"],
+    );
+  });
+
+  test("filters recent activity by date window, currency, and search", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const records = [
+      {
+        name: "Notion",
+        currency: "USD",
+        createdAt: "2026-03-09T00:00:00.000Z",
+      },
+      {
+        name: "Spotify",
+        currency: "AUD",
+        createdAt: "2026-02-25T00:00:00.000Z",
+      },
+      {
+        name: "Old Service",
+        currency: "USD",
+        createdAt: "2026-01-15T00:00:00.000Z",
+      },
+      {
+        name: "Future Service",
+        currency: "USD",
+        createdAt: "2026-04-01T00:00:00.000Z",
+      },
+    ];
+
+    const allResults = filterDashboardRecentActivity(
+      records,
+      {
+        currency: DASHBOARD_ALL_CURRENCIES,
+        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
+        searchQuery: "",
+      },
+      now,
+    );
+    const filteredAud = filterDashboardRecentActivity(
+      records,
+      {
+        currency: "AUD",
+        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
+        searchQuery: "spot",
+      },
+      now,
+    );
+
+    assert.deepEqual(
+      allResults.map((record) => record.name),
+      ["Notion", "Spotify"],
+    );
+    assert.deepEqual(
+      filteredAud.map((record) => record.name),
+      ["Spotify"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement Dashboard V2 shell structure with reusable `dashboard-card` container styling and responsive grid sections
- add top control bar with keyboard-accessible currency selector, date-range selector (default: last 30 days), search input, and primary `Add Subscription` CTA
- wire controls to upcoming renewals and recent activity filtering via new `lib/dashboard-controls.ts` utilities
- keep section placeholders in place for follow-up issues (#33-#37) while preserving subscription details modal interactions

## Validation
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Closes #32