### PR TITLE
[Dashboard V2] Add spend breakdown donut chart and category legend

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 
 import SubscriptionDetailsModal from "@/app/components/SubscriptionDetailsModal";
 import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDetailsModal";
@@ -10,6 +10,7 @@ import {
   DASHBOARD_DATE_RANGE_OPTIONS,
   DEFAULT_DASHBOARD_DATE_RANGE,
   filterDashboardRecentActivity,
+  mapDashboardSpendBreakdownByCurrency,
   filterDashboardUpcomingRenewals,
   type DashboardDateRangeValue,
 } from "@/lib/dashboard-controls";
@@ -39,6 +40,18 @@ type DashboardSectionsClientProps = {
   availableCurrencies: string[];
   upcomingCharges: DashboardUpcomingChargeListItem[];
   recentSubscriptions: DashboardRecentActivityListItem[];
+  monthlySpendTotalsByCurrency: Array<{
+    currency: string;
+    monthlyEquivalentSpendCents: number;
+  }>;
+  spendBreakdownByCategory: Array<{
+    category: string;
+    subscriptionCount: number;
+    totalsByCurrency: Array<{
+      currency: string;
+      monthlyEquivalentSpendCents: number;
+    }>;
+  }>;
 };
 
 function formatMoney(amountCents: number, currency: string): string {
@@ -86,8 +99,12 @@ export default function DashboardSectionsClient({
   availableCurrencies,
   upcomingCharges,
   recentSubscriptions,
+  monthlySpendTotalsByCurrency,
+  spendBreakdownByCategory,
 }: DashboardSectionsClientProps) {
   const detailsModal = useSubscriptionDetailsModal();
+  const spendBreakdownTitleId = useId();
+  const spendBreakdownDescriptionId = useId();
   const [currency, setCurrency] = useState<string>(DASHBOARD_ALL_CURRENCIES);
   const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
   const [searchQuery, setSearchQuery] = useState("");
@@ -134,6 +151,69 @@ export default function DashboardSectionsClient({
 
     return ["USD", ...normalized.filter((value) => value !== "USD")];
   }, [availableCurrencies]);
+  const spendBreakdownCurrency = useMemo(() => {
+    if (currency !== DASHBOARD_ALL_CURRENCIES) {
+      return currency.toUpperCase();
+    }
+
+    return monthlySpendTotalsByCurrency.length === 1 ? monthlySpendTotalsByCurrency[0].currency : null;
+  }, [currency, monthlySpendTotalsByCurrency]);
+  const spendBreakdownRows = useMemo(() => {
+    if (!spendBreakdownCurrency) {
+      return [];
+    }
+
+    return mapDashboardSpendBreakdownByCurrency(spendBreakdownByCategory, spendBreakdownCurrency, searchQuery);
+  }, [searchQuery, spendBreakdownByCategory, spendBreakdownCurrency]);
+  const spendBreakdownTotalCents = useMemo(() => {
+    return spendBreakdownRows.reduce((total, row) => total + row.monthlyEquivalentSpendCents, 0);
+  }, [spendBreakdownRows]);
+  const spendBreakdownKpiTotalCents = useMemo(() => {
+    if (!spendBreakdownCurrency) {
+      return null;
+    }
+
+    return (
+      monthlySpendTotalsByCurrency.find((entry) => entry.currency === spendBreakdownCurrency)?.monthlyEquivalentSpendCents ??
+      null
+    );
+  }, [monthlySpendTotalsByCurrency, spendBreakdownCurrency]);
+  const spendBreakdownReconciled =
+    spendBreakdownKpiTotalCents === null || spendBreakdownKpiTotalCents === spendBreakdownTotalCents;
+  const spendBreakdownSegments = useMemo(() => {
+    if (!spendBreakdownCurrency || spendBreakdownTotalCents <= 0) {
+      return [];
+    }
+
+    const radius = 44;
+    const circumference = 2 * Math.PI * radius;
+    let dashOffset = 0;
+
+    return spendBreakdownRows.map((row) => {
+      const segmentLength = (row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * circumference;
+      const segment = {
+        category: row.category,
+        color: row.color,
+        segmentLength,
+        dashOffset,
+      };
+      dashOffset -= segmentLength;
+      return segment;
+    });
+  }, [spendBreakdownCurrency, spendBreakdownRows, spendBreakdownTotalCents]);
+  const spendBreakdownDescription = useMemo(() => {
+    if (!spendBreakdownCurrency || spendBreakdownRows.length === 0 || spendBreakdownTotalCents <= 0) {
+      return "No categorized spend data is available for the current controls.";
+    }
+
+    return spendBreakdownRows
+      .map((row) => {
+        const percent = Math.round((row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * 100);
+        return `${row.category}: ${formatMoney(row.monthlyEquivalentSpendCents, spendBreakdownCurrency)} (${percent}%).`;
+      })
+      .join(" ");
+  }, [spendBreakdownCurrency, spendBreakdownRows, spendBreakdownTotalCents]);
+  const spendBreakdownChartCircumference = 2 * Math.PI * 44;
 
   return (
     <>
@@ -194,8 +274,85 @@ export default function DashboardSectionsClient({
 
         <section className="dashboard-grid dashboard-grid-two-up">
           <article className="dashboard-card">
-            <h2>Spend Breakdown</h2>
-            <p className="text-muted">Chart and category legend content will render inside this container.</p>
+            <div className="dashboard-card-header">
+              <h2>Spend Breakdown</h2>
+              <span className="metric-note">
+                {spendBreakdownCurrency ? `${spendBreakdownRows.length} categories` : "Select a currency"}
+              </span>
+            </div>
+            {!spendBreakdownCurrency ? (
+              <p className="text-muted">
+                Choose a specific currency to compare category spend when your dashboard contains multiple currencies.
+              </p>
+            ) : spendBreakdownRows.length === 0 || spendBreakdownTotalCents <= 0 ? (
+              <p className="text-muted">No categorized spend exists for the current filters.</p>
+            ) : (
+              <div className="spend-breakdown-layout">
+                <figure className="spend-donut-figure">
+                  <svg
+                    aria-describedby={spendBreakdownDescriptionId}
+                    aria-labelledby={spendBreakdownTitleId}
+                    className="spend-donut"
+                    role="img"
+                    viewBox="0 0 112 112"
+                  >
+                    <title id={spendBreakdownTitleId}>
+                      Spend by category in {spendBreakdownCurrency}
+                    </title>
+                    <desc id={spendBreakdownDescriptionId}>{spendBreakdownDescription}</desc>
+                    <circle className="spend-donut-track" cx="56" cy="56" r="44" />
+                    {spendBreakdownSegments.map((segment) => (
+                      <circle
+                        className="spend-donut-segment"
+                        cx="56"
+                        cy="56"
+                        key={segment.category}
+                        r="44"
+                        stroke={segment.color}
+                        strokeDasharray={`${segment.segmentLength} ${spendBreakdownChartCircumference}`}
+                        strokeDashoffset={segment.dashOffset}
+                      />
+                    ))}
+                  </svg>
+                  <figcaption className="spend-donut-total">
+                    <span className="metric-note">Monthly total</span>
+                    <strong>{formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}</strong>
+                  </figcaption>
+                </figure>
+                <ul aria-label={`Spend category legend in ${spendBreakdownCurrency}`} className="spend-legend">
+                  {spendBreakdownRows.map((row) => {
+                    const percent = Math.round((row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * 100);
+                    const subscriptionLabel = row.subscriptionCount === 1 ? "1 subscription" : `${row.subscriptionCount} subscriptions`;
+
+                    return (
+                      <li className="spend-legend-item" key={row.category}>
+                        <span
+                          aria-hidden="true"
+                          className="spend-legend-swatch"
+                          style={{ backgroundColor: row.color }}
+                        />
+                        <div className="spend-legend-copy">
+                          <span className="spend-legend-label">{row.category}</span>
+                          <span className="spend-legend-value">
+                            {formatMoney(row.monthlyEquivalentSpendCents, spendBreakdownCurrency)} - {percent}% -{" "}
+                            {subscriptionLabel}
+                          </span>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+            {spendBreakdownCurrency && spendBreakdownRows.length === 1 ? (
+              <p className="text-muted">Only one category currently contributes spend for these filters.</p>
+            ) : null}
+            {spendBreakdownCurrency && !spendBreakdownReconciled ? (
+              <p className="text-muted" role="status">
+                Category totals ({formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}) differ from KPI total (
+                {formatMoney(spendBreakdownKpiTotalCents ?? 0, spendBreakdownCurrency)}).
+              </p>
+            ) : null}
           </article>
           <article className="dashboard-card">
             <h2>Attention Needed</h2>

--- a/app/globals.css
+++ b/app/globals.css
@@ -390,6 +390,92 @@ a {
   margin-bottom: 0.2rem;
 }
 
+.spend-breakdown-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.spend-donut-figure {
+  margin: 0;
+  min-width: 180px;
+  display: grid;
+  justify-items: center;
+  gap: 0.45rem;
+}
+
+.spend-donut {
+  width: 160px;
+  height: 160px;
+  display: block;
+}
+
+.spend-donut-track {
+  fill: none;
+  stroke: color-mix(in srgb, var(--panel-soft), var(--text) 14%);
+  stroke-width: 16;
+}
+
+.spend-donut-segment {
+  fill: none;
+  stroke-width: 16;
+  transform-origin: center;
+  transform: rotate(-90deg);
+  transition: stroke-dasharray 200ms ease, stroke-dashoffset 200ms ease;
+}
+
+.spend-donut-total {
+  display: grid;
+  justify-items: center;
+  gap: 0.08rem;
+  text-align: center;
+}
+
+.spend-donut-total strong {
+  font-size: 1.02rem;
+  letter-spacing: -0.01em;
+}
+
+.spend-legend {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  flex: 1;
+  min-width: min(300px, 100%);
+}
+
+.spend-legend-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem;
+  align-items: start;
+}
+
+.spend-legend-swatch {
+  width: 0.78rem;
+  height: 0.78rem;
+  border-radius: 999px;
+  margin-top: 0.25rem;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--panel), var(--text) 24%);
+}
+
+.spend-legend-copy {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.spend-legend-label {
+  font-weight: 650;
+}
+
+.spend-legend-value {
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
 .stack {
   display: grid;
   gap: 0.8rem;
@@ -981,6 +1067,14 @@ ul {
   }
 
   .dashboard-control-actions .button {
+    width: 100%;
+  }
+
+  .spend-breakdown-layout {
+    flex-direction: column;
+  }
+
+  .spend-donut-figure {
     width: 100%;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,6 +52,9 @@ export default async function DashboardPage() {
   const availableCurrencies = [
     ...new Set([
       ...dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency),
+      ...dashboardPayload.spendBreakdownByCategory.flatMap((entry) =>
+        entry.totalsByCurrency.map((total) => total.currency),
+      ),
       ...dashboardPayload.upcomingRenewals.map((entry) => entry.currency),
       ...dashboardPayload.recentSubscriptions.map((entry) => entry.currency),
     ]),
@@ -71,6 +74,10 @@ export default async function DashboardPage() {
 
       <DashboardSectionsClient
         availableCurrencies={availableCurrencies}
+        monthlySpendTotalsByCurrency={dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => ({
+          currency: entry.currency,
+          monthlyEquivalentSpendCents: entry.monthlyEquivalentSpendCents,
+        }))}
         recentSubscriptions={dashboardPayload.recentSubscriptions.map((subscription) => ({
           id: subscription.id,
           name: subscription.name,
@@ -89,6 +96,14 @@ export default async function DashboardPage() {
           renewalDate: subscription.renewalDate,
           createdAt: subscription.createdAt,
           tag: subscription.tag,
+        }))}
+        spendBreakdownByCategory={dashboardPayload.spendBreakdownByCategory.map((category) => ({
+          category: category.category,
+          subscriptionCount: category.subscriptionCount,
+          totalsByCurrency: category.totalsByCurrency.map((total) => ({
+            currency: total.currency,
+            monthlyEquivalentSpendCents: total.monthlyEquivalentSpendCents,
+          })),
         }))}
       />
     </section>

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -16,6 +16,19 @@ export type DashboardControlState = {
   searchQuery: string;
 };
 
+const DASHBOARD_CATEGORY_COLOR_PALETTE = [
+  "#0EA5E9",
+  "#F97316",
+  "#22C55E",
+  "#A855F7",
+  "#EAB308",
+  "#EF4444",
+  "#14B8A6",
+  "#6366F1",
+  "#EC4899",
+  "#84CC16",
+] as const;
+
 type DashboardUpcomingRenewalRecord = {
   name: string;
   currency: string;
@@ -27,6 +40,22 @@ type DashboardRecentActivityRecord = {
   name: string;
   currency: string;
   createdAt: string;
+};
+
+type DashboardSpendBreakdownCategoryRecord = {
+  category: string;
+  subscriptionCount: number;
+  totalsByCurrency: Array<{
+    currency: string;
+    monthlyEquivalentSpendCents: number;
+  }>;
+};
+
+export type DashboardSpendBreakdownRow = {
+  category: string;
+  monthlyEquivalentSpendCents: number;
+  subscriptionCount: number;
+  color: string;
 };
 
 function toNormalizedSearchQuery(value: string): string {
@@ -47,6 +76,27 @@ function matchesSearchFilter(parts: string[], normalizedQuery: string): boolean 
   }
 
   return parts.some((part) => part.toLowerCase().includes(normalizedQuery));
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+
+  for (const char of value) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+
+  return hash;
+}
+
+export function getDashboardCategoryColor(category: string): string {
+  const normalized = category.trim().toLowerCase();
+
+  if (!normalized) {
+    return DASHBOARD_CATEGORY_COLOR_PALETTE[0];
+  }
+
+  const index = hashString(normalized) % DASHBOARD_CATEGORY_COLOR_PALETTE.length;
+  return DASHBOARD_CATEGORY_COLOR_PALETTE[index];
 }
 
 function toDateRangeDays(value: DashboardDateRangeValue): number {
@@ -120,4 +170,39 @@ export function filterDashboardRecentActivity<T extends DashboardRecentActivityR
 
     return matchesSearchFilter([record.name, record.currency], normalizedQuery);
   });
+}
+
+export function mapDashboardSpendBreakdownByCurrency<T extends DashboardSpendBreakdownCategoryRecord>(
+  records: T[],
+  currency: string,
+  searchQuery: string,
+): DashboardSpendBreakdownRow[] {
+  const normalizedQuery = toNormalizedSearchQuery(searchQuery);
+
+  return records
+    .map((record) => {
+      const amount = record.totalsByCurrency.find(
+        (entry) => entry.currency.toUpperCase() === currency.toUpperCase(),
+      )?.monthlyEquivalentSpendCents;
+
+      if (amount === undefined || amount <= 0) {
+        return null;
+      }
+
+      return {
+        category: record.category,
+        monthlyEquivalentSpendCents: amount,
+        subscriptionCount: record.subscriptionCount,
+        color: getDashboardCategoryColor(record.category),
+      };
+    })
+    .filter((record): record is DashboardSpendBreakdownRow => record !== null)
+    .filter((record) => matchesSearchFilter([record.category], normalizedQuery))
+    .sort((first, second) => {
+      return (
+        second.monthlyEquivalentSpendCents - first.monthlyEquivalentSpendCents ||
+        second.subscriptionCount - first.subscriptionCount ||
+        first.category.localeCompare(second.category)
+      );
+    });
 }

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -6,6 +6,8 @@ import {
   DEFAULT_DASHBOARD_DATE_RANGE,
   filterDashboardRecentActivity,
   filterDashboardUpcomingRenewals,
+  getDashboardCategoryColor,
+  mapDashboardSpendBreakdownByCurrency,
 } from "../../lib/dashboard-controls";
 
 describe("dashboard controls filtering", () => {
@@ -123,5 +125,49 @@ describe("dashboard controls filtering", () => {
       filteredAud.map((record) => record.name),
       ["Spotify"],
     );
+  });
+
+  test("maps spend breakdown rows by currency and search query", () => {
+    const rows = mapDashboardSpendBreakdownByCurrency(
+      [
+        {
+          category: "Streaming",
+          subscriptionCount: 3,
+          totalsByCurrency: [
+            { currency: "USD", monthlyEquivalentSpendCents: 4500 },
+            { currency: "AUD", monthlyEquivalentSpendCents: 1200 },
+          ],
+        },
+        {
+          category: "Cloud & Hosting",
+          subscriptionCount: 2,
+          totalsByCurrency: [{ currency: "USD", monthlyEquivalentSpendCents: 9000 }],
+        },
+        {
+          category: "Productivity",
+          subscriptionCount: 1,
+          totalsByCurrency: [{ currency: "AUD", monthlyEquivalentSpendCents: 2200 }],
+        },
+      ],
+      "USD",
+      "cloud",
+    );
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.category, "Cloud & Hosting");
+    assert.equal(rows[0]?.monthlyEquivalentSpendCents, 9000);
+    assert.equal(rows[0]?.subscriptionCount, 2);
+  });
+
+  test("assigns deterministic category colors", () => {
+    const streamingColor = getDashboardCategoryColor("Streaming");
+    const streamingColorAgain = getDashboardCategoryColor("Streaming");
+    const trimmedCaseVariantColor = getDashboardCategoryColor(" streaming ");
+    const otherColor = getDashboardCategoryColor("Cloud & Hosting");
+
+    assert.equal(streamingColor, streamingColorAgain);
+    assert.equal(streamingColor, trimmedCaseVariantColor);
+    assert.notEqual(streamingColor.length, 0);
+    assert.notEqual(otherColor.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- implement the dashboard V2 spend breakdown card with an inline SVG donut chart and category legend
- source chart segments/legend values from `spendBreakdownByCategory` payload data and KPI monthly totals
- add deterministic category color mapping and spend-breakdown mapping helpers in `lib/dashboard-controls`
- add empty/low-data and multi-currency fallback states plus aria title/description for chart accessibility
- add responsive styles for donut + legend layout

## Validation
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`

Closes #34