### PR TITLE
feat(dashboard): implement Attention Needed panel heuristics (#35)

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -5,7 +5,13 @@ import { useId, useMemo, useState } from "react";
 
 import SubscriptionDetailsModal from "@/app/components/SubscriptionDetailsModal";
 import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDetailsModal";
-import type { DashboardCurrencyTotal, DashboardKpis, DashboardMetricAmount } from "@/lib/dashboard";
+import type {
+  DashboardAttentionSeverity,
+  DashboardAttentionType,
+  DashboardCurrencyTotal,
+  DashboardKpis,
+  DashboardMetricAmount,
+} from "@/lib/dashboard";
 import {
   DASHBOARD_ALL_CURRENCIES,
   DASHBOARD_DATE_RANGE_OPTIONS,
@@ -37,9 +43,22 @@ type DashboardRecentActivityListItem = {
   createdAt: string;
 };
 
+type DashboardAttentionListItem = {
+  id: string;
+  type: DashboardAttentionType;
+  severity: DashboardAttentionSeverity;
+  title: string;
+  message: string;
+  dueDate: string | null;
+  subscriptionIds: string[];
+  estimatedMonthlyImpactCents: number | null;
+  currency: string | null;
+};
+
 type DashboardSectionsClientProps = {
   availableCurrencies: string[];
   kpis?: DashboardKpis | null;
+  attentionNeeded: DashboardAttentionListItem[];
   upcomingCharges: DashboardUpcomingChargeListItem[];
   recentSubscriptions: DashboardRecentActivityListItem[];
   monthlySpendTotalsByCurrency: Array<{
@@ -169,9 +188,55 @@ function tagClassName(tag: "urgent" | "soon" | "upcoming"): string {
   return "pill";
 }
 
+function formatAttentionSeverityLabel(severity: DashboardAttentionSeverity): string {
+  if (severity === "high") {
+    return "High";
+  }
+
+  if (severity === "medium") {
+    return "Medium";
+  }
+
+  return "Low";
+}
+
+function attentionSeverityClassName(severity: DashboardAttentionSeverity): string {
+  return `attention-severity attention-severity-${severity}`;
+}
+
+function attentionSeverityGlyph(severity: DashboardAttentionSeverity): string {
+  if (severity === "high") {
+    return "!";
+  }
+
+  if (severity === "medium") {
+    return "~";
+  }
+
+  return "i";
+}
+
+function isInDateRange(value: string | null, now: Date, rangeDays: number): boolean {
+  if (!value) {
+    return true;
+  }
+
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return false;
+  }
+
+  const deltaMs = parsedDate.getTime() - now.getTime();
+  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
+
+  return deltaMs >= 0 && deltaMs <= maxMs;
+}
+
 export default function DashboardSectionsClient({
   availableCurrencies,
   kpis,
+  attentionNeeded,
   upcomingCharges,
   recentSubscriptions,
   monthlySpendTotalsByCurrency,
@@ -184,6 +249,9 @@ export default function DashboardSectionsClient({
   const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
   const [searchQuery, setSearchQuery] = useState("");
   const now = useMemo(() => new Date(), []);
+  const dateRangeDays = useMemo(() => {
+    return DASHBOARD_DATE_RANGE_OPTIONS.find((option) => option.value === dateRange)?.days ?? 30;
+  }, [dateRange]);
 
   const filteredUpcomingCharges = useMemo(
     () =>
@@ -211,6 +279,32 @@ export default function DashboardSectionsClient({
       ),
     [currency, dateRange, now, recentSubscriptions, searchQuery],
   );
+  const filteredAttentionNeeded = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    const selectedCurrency = currency.toUpperCase();
+
+    return attentionNeeded.filter((alert) => {
+      if (
+        currency !== DASHBOARD_ALL_CURRENCIES &&
+        alert.currency !== null &&
+        alert.currency.toUpperCase() !== selectedCurrency
+      ) {
+        return false;
+      }
+
+      if (!isInDateRange(alert.dueDate, now, dateRangeDays)) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return [alert.title, alert.message, alert.currency ?? "", alert.type].some((value) =>
+        value.toLowerCase().includes(normalizedQuery),
+      );
+    });
+  }, [attentionNeeded, currency, dateRangeDays, now, searchQuery]);
   const currencyOptions = useMemo(() => {
     const normalized = [
       ...new Set(
@@ -479,8 +573,54 @@ export default function DashboardSectionsClient({
             ) : null}
           </article>
           <article className="dashboard-card">
-            <h2>Attention Needed</h2>
-            <p className="text-muted">Alert items and severity indicators will render in this section.</p>
+            <div className="dashboard-card-header">
+              <h2>Attention Needed</h2>
+              <span className="metric-note">{filteredAttentionNeeded.length} matching alerts</span>
+            </div>
+            {filteredAttentionNeeded.length === 0 ? (
+              <p className="text-muted">No attention alerts match the current control filters.</p>
+            ) : (
+              <div className="attention-list">
+                {filteredAttentionNeeded.map((alert) => {
+                  const singleSubscriptionId = alert.subscriptionIds.length === 1 ? alert.subscriptionIds[0] : null;
+
+                  return (
+                    <article className="attention-item" key={alert.id}>
+                      <div className="attention-item-header">
+                        <span className={attentionSeverityClassName(alert.severity)}>
+                          <span aria-hidden="true" className="attention-severity-glyph">
+                            {attentionSeverityGlyph(alert.severity)}
+                          </span>
+                          {formatAttentionSeverityLabel(alert.severity)}
+                        </span>
+                        {alert.dueDate ? <span className="metric-note">Due {formatDate(alert.dueDate)}</span> : null}
+                      </div>
+                      <h3>{alert.title}</h3>
+                      <p className="text-muted">{alert.message}</p>
+                      {alert.estimatedMonthlyImpactCents !== null && alert.currency ? (
+                        <p className="attention-impact">
+                          Estimated monthly impact: {formatMoney(alert.estimatedMonthlyImpactCents, alert.currency)}
+                        </p>
+                      ) : null}
+                      {singleSubscriptionId ? (
+                        <button
+                          className="button button-secondary button-small"
+                          onClick={() =>
+                            void detailsModal.openModal({
+                              subscriptionId: singleSubscriptionId,
+                              source: "subscriptions_list",
+                            })
+                          }
+                          type="button"
+                        >
+                          View subscription
+                        </button>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            )}
           </article>
         </section>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -485,6 +485,96 @@ a {
   font-size: 0.84rem;
 }
 
+.attention-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.attention-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel-soft);
+  padding: 0.8rem 0.85rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.attention-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.attention-item h3 {
+  margin: 0;
+  font-size: 0.98rem;
+}
+
+.attention-item p {
+  margin: 0;
+}
+
+.attention-severity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.48rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.attention-severity-glyph {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  font-weight: 800;
+}
+
+.attention-severity-high {
+  color: var(--fail);
+  border-color: color-mix(in srgb, var(--fail), var(--border) 40%);
+  background: color-mix(in srgb, var(--fail) 12%, var(--panel));
+}
+
+.attention-severity-high .attention-severity-glyph {
+  background: color-mix(in srgb, var(--fail) 22%, var(--panel));
+}
+
+.attention-severity-medium {
+  color: color-mix(in srgb, var(--brand), var(--text) 26%);
+  border-color: color-mix(in srgb, var(--brand) 46%, var(--border));
+  background: color-mix(in srgb, var(--brand) 9%, var(--panel));
+}
+
+.attention-severity-medium .attention-severity-glyph {
+  background: color-mix(in srgb, var(--brand) 20%, var(--panel));
+}
+
+.attention-severity-low {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok), var(--border) 42%);
+  background: color-mix(in srgb, var(--ok) 10%, var(--panel));
+}
+
+.attention-severity-low .attention-severity-glyph {
+  background: color-mix(in srgb, var(--ok) 20%, var(--panel));
+}
+
+.attention-impact {
+  font-size: 0.84rem;
+  color: var(--text-muted);
+}
+
 .stack {
   display: grid;
   gap: 0.8rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,9 @@ export default async function DashboardPage() {
       ...dashboardPayload.spendBreakdownByCategory.flatMap((entry) =>
         entry.totalsByCurrency.map((total) => total.currency),
       ),
+      ...dashboardPayload.attentionNeeded
+        .map((entry) => entry.currency)
+        .filter((value): value is string => value !== null),
       ...dashboardPayload.upcomingRenewals.map((entry) => entry.currency),
       ...dashboardPayload.recentSubscriptions.map((entry) => entry.currency),
     ]),
@@ -74,6 +77,17 @@ export default async function DashboardPage() {
 
       <DashboardSectionsClient
         availableCurrencies={availableCurrencies}
+        attentionNeeded={dashboardPayload.attentionNeeded.map((item) => ({
+          id: item.id,
+          type: item.type,
+          severity: item.severity,
+          title: item.title,
+          message: item.message,
+          dueDate: item.dueDate,
+          subscriptionIds: item.subscriptionIds,
+          estimatedMonthlyImpactCents: item.estimatedMonthlyImpactCents,
+          currency: item.currency,
+        }))}
         kpis={dashboardPayload.kpis}
         monthlySpendTotalsByCurrency={dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => ({
           currency: entry.currency,

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -9,6 +9,12 @@ const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1000;
 const WEEKLY_TO_MONTHLY_FACTOR = 4.33;
 const TOP_COST_DRIVERS_LIMIT = 5;
 const RECENT_SUBSCRIPTIONS_LIMIT = 5;
+const ATTENTION_PROMO_WINDOW_DAYS = 7;
+const ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS = 45;
+const ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS = 120;
+const ATTENTION_UNUSED_STALE_UPDATED_DAYS = 90;
+
+const PROMO_HINT_KEYWORDS = ["trial", "promo", "intro", "discount", "offer", "starter"] as const;
 
 const CATEGORY_RULES: ReadonlyArray<{ category: string; keywords: readonly string[] }> = [
   { category: "Streaming", keywords: ["netflix", "hulu", "disney", "paramount", "spotify", "youtube", "apple tv", "prime video"] },
@@ -73,7 +79,11 @@ export type DashboardSpendCategory = {
 
 export type DashboardAttentionSeverity = "high" | "medium" | "low";
 
-export type DashboardAttentionType = "renewal_soon" | "annual_renewal_soon" | "potential_duplicate";
+export type DashboardAttentionType =
+  | "promo_ending_soon"
+  | "potentially_unused_subscription"
+  | "potential_duplicate_services"
+  | "annual_renewal_approaching";
 
 export type DashboardAttentionItem = {
   id: string;
@@ -243,6 +253,32 @@ function daysUntil(value: Date, now: Date): number {
   return Math.max(0, Math.ceil((value.getTime() - now.getTime()) / DAYS_TO_MILLISECONDS));
 }
 
+function daysSince(value: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - value.getTime()) / DAYS_TO_MILLISECONDS));
+}
+
+function formatCurrencyCents(amountCents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amountCents / 100);
+}
+
+function formatAttentionDate(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(value);
+}
+
+function hasPromoHint(name: string): boolean {
+  const lowered = name.trim().toLowerCase();
+  return PROMO_HINT_KEYWORDS.some((keyword) => lowered.includes(keyword));
+}
+
 function inferCategory(name: string): string {
   const lowered = name.trim().toLowerCase();
 
@@ -349,7 +385,7 @@ function compareAttentionItems(first: DashboardAttentionItem, second: DashboardA
     return firstDue - secondDue;
   }
 
-  return first.title.localeCompare(second.title);
+  return first.title.localeCompare(second.title) || first.id.localeCompare(second.id);
 }
 
 function findDuplicateGroups(records: NormalizedSubscription[]): DuplicateGroup[] {
@@ -524,20 +560,52 @@ export function buildDashboardPayload(
     ...activeSubscriptions
       .filter(
         (subscription) =>
+          subscription.billingInterval !== "YEARLY" &&
           subscription.nextBillingDateDate !== null &&
-          isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_RENEWALS_WINDOW_DAYS),
+          isWithinNextDays(subscription.nextBillingDateDate, now, ATTENTION_PROMO_WINDOW_DAYS) &&
+          (daysSince(subscription.createdAtDate, now) <= ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS ||
+            hasPromoHint(subscription.name)),
       )
-      .map((subscription) => ({
-        id: `renewal-soon-${subscription.id}`,
-        type: "renewal_soon" as const,
-        severity: "high" as const,
-        title: `${subscription.name} renews soon`,
-        message: `Renews in ${daysUntil(subscription.nextBillingDateDate as Date, now)} day(s).`,
-        dueDate: (subscription.nextBillingDateDate as Date).toISOString(),
-        subscriptionIds: [subscription.id],
-        estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
-        currency: subscription.currency,
-      })),
+      .map((subscription) => {
+        const dueDate = subscription.nextBillingDateDate as Date;
+        const daysUntilDue = daysUntil(dueDate, now);
+
+        return {
+          id: `promo-ending-${subscription.id}`,
+          type: "promo_ending_soon" as const,
+          severity: "high" as const,
+          title: `Promo ending soon: ${subscription.name}`,
+          message: `Potential charge of ${formatCurrencyCents(subscription.amountCents, subscription.currency)} on ${formatAttentionDate(dueDate)} (${daysUntilDue} day(s)).`,
+          dueDate: dueDate.toISOString(),
+          subscriptionIds: [subscription.id],
+          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
+          currency: subscription.currency,
+        };
+      }),
+    ...activeSubscriptions
+      .filter(
+        (subscription) =>
+          subscription.nextBillingDateDate !== null &&
+          isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS) &&
+          daysSince(subscription.createdAtDate, now) >= ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS &&
+          daysSince(subscription.updatedAtDate, now) >= ATTENTION_UNUSED_STALE_UPDATED_DAYS,
+      )
+      .map((subscription) => {
+        const dueDate = subscription.nextBillingDateDate as Date;
+        const staleDays = daysSince(subscription.updatedAtDate, now);
+
+        return {
+          id: `potentially-unused-${subscription.id}`,
+          type: "potentially_unused_subscription" as const,
+          severity: "low" as const,
+          title: `Potentially unused: ${subscription.name}`,
+          message: `No subscription updates in ${staleDays} day(s). Next charge ${formatCurrencyCents(subscription.amountCents, subscription.currency)} on ${formatAttentionDate(dueDate)}.`,
+          dueDate: dueDate.toISOString(),
+          subscriptionIds: [subscription.id],
+          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
+          currency: subscription.currency,
+        };
+      }),
     ...activeSubscriptions
       .filter(
         (subscription) =>
@@ -546,17 +614,22 @@ export function buildDashboardPayload(
           isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS) &&
           !isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_RENEWALS_WINDOW_DAYS),
       )
-      .map((subscription) => ({
-        id: `annual-renewal-${subscription.id}`,
-        type: "annual_renewal_soon" as const,
-        severity: "medium" as const,
-        title: `${subscription.name} annual renewal`,
-        message: `Annual charge is due in ${daysUntil(subscription.nextBillingDateDate as Date, now)} day(s).`,
-        dueDate: (subscription.nextBillingDateDate as Date).toISOString(),
-        subscriptionIds: [subscription.id],
-        estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
-        currency: subscription.currency,
-      })),
+      .map((subscription) => {
+        const dueDate = subscription.nextBillingDateDate as Date;
+        const daysUntilDue = daysUntil(dueDate, now);
+
+        return {
+          id: `annual-renewal-${subscription.id}`,
+          type: "annual_renewal_approaching" as const,
+          severity: daysUntilDue <= 14 ? ("high" as const) : ("medium" as const),
+          title: `Annual renewal approaching: ${subscription.name}`,
+          message: `Annual charge of ${formatCurrencyCents(subscription.amountCents, subscription.currency)} is due on ${formatAttentionDate(dueDate)} (${daysUntilDue} day(s)).`,
+          dueDate: dueDate.toISOString(),
+          subscriptionIds: [subscription.id],
+          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
+          currency: subscription.currency,
+        };
+      }),
     ...duplicateGroups.map((group) => {
       const duplicates = group.subscriptions.slice(1);
       const estimatedMonthlyImpactCents = duplicates.reduce(
@@ -567,13 +640,16 @@ export function buildDashboardPayload(
         .map((subscription) => subscription.nextBillingDateDate)
         .filter((value): value is Date => value !== null)
         .sort((first, second) => first.getTime() - second.getTime())[0];
+      const soonestRenewalText = soonestRenewal
+        ? ` Earliest renewal is ${formatAttentionDate(soonestRenewal)}.`
+        : "";
 
       return {
         id: `potential-duplicate-${group.key}`,
-        type: "potential_duplicate" as const,
-        severity: "medium" as const,
-        title: `Potential duplicate: ${group.displayName}`,
-        message: `${group.subscriptions.length} active subscriptions look overlapping in ${group.currency}.`,
+        type: "potential_duplicate_services" as const,
+        severity: "high" as const,
+        title: `Potential duplicate services: ${group.displayName}`,
+        message: `${group.subscriptions.length} active subscriptions may overlap. Estimated extra spend is ${formatCurrencyCents(estimatedMonthlyImpactCents, group.currency)} per month.${soonestRenewalText}`,
         dueDate: soonestRenewal ? soonestRenewal.toISOString() : null,
         subscriptionIds: group.subscriptions.map((subscription) => subscription.id),
         estimatedMonthlyImpactCents,

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -105,7 +105,7 @@ describe("buildDashboardPayload", () => {
     assert.equal(payload.kpis.annualProjection.amountCents, 80000);
     assert.equal(payload.kpis.monthlyEquivalentSpend.excludedCustomCadenceCount, 1);
     assert.equal(payload.kpis.annualProjection.excludedCustomCadenceCount, 1);
-    assert.equal(payload.attentionNeeded.some((item) => item.type === "annual_renewal_soon"), true);
+    assert.equal(payload.attentionNeeded.some((item) => item.type === "annual_renewal_approaching"), true);
   });
 
   test("does not merge mixed currencies into a single normalized KPI total", () => {
@@ -155,10 +155,97 @@ describe("buildDashboardPayload", () => {
       now,
     );
 
-    assert.equal(payload.attentionNeeded.some((item) => item.type === "potential_duplicate"), true);
+    assert.equal(payload.attentionNeeded.some((item) => item.type === "potential_duplicate_services"), true);
     assert.equal(payload.potentialSavings.opportunities.length, 1);
     assert.equal(payload.potentialSavings.currency, "USD");
     assert.equal(payload.potentialSavings.estimatedMonthlySavingsCents, 4000);
     assert.deepEqual(payload.potentialSavings.opportunities[0]?.subscriptionIds, ["stream-c", "stream-b"]);
+  });
+
+  test("builds promo-ending and potentially-unused alerts with actionable amount/date context", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({
+          id: "promo-1",
+          name: "Streaming Trial Promo",
+          amountCents: 1299,
+          billingInterval: "MONTHLY",
+          createdAt: new Date("2026-02-20T00:00:00.000Z"),
+          updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+          nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "unused-1",
+          name: "Legacy Tool Suite",
+          amountCents: 4500,
+          billingInterval: "MONTHLY",
+          createdAt: new Date("2025-07-01T00:00:00.000Z"),
+          updatedAt: new Date("2025-10-01T00:00:00.000Z"),
+          nextBillingDate: new Date("2026-03-20T00:00:00.000Z"),
+        }),
+      ],
+      now,
+    );
+
+    const promoAlert = payload.attentionNeeded.find((item) => item.type === "promo_ending_soon");
+    const unusedAlert = payload.attentionNeeded.find((item) => item.type === "potentially_unused_subscription");
+
+    assert.ok(promoAlert);
+    assert.equal(promoAlert.severity, "high");
+    assert.equal(promoAlert.message.includes("$12.99"), true);
+    assert.equal(promoAlert.message.includes("Mar"), true);
+
+    assert.ok(unusedAlert);
+    assert.equal(unusedAlert.severity, "low");
+    assert.equal(unusedAlert.message.includes("$45.00"), true);
+    assert.equal(unusedAlert.message.includes("No subscription updates"), true);
+  });
+
+  test("keeps attention ordering deterministic regardless of input order", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const records = [
+      makeSubscription({
+        id: "promo-1",
+        name: "Cloud Trial Promo",
+        amountCents: 1599,
+        createdAt: new Date("2026-02-18T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+        nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+      }),
+      makeSubscription({
+        id: "annual-1",
+        name: "Cloudflare Pro",
+        amountCents: 12000,
+        billingInterval: "YEARLY",
+        nextBillingDate: new Date("2026-03-28T00:00:00.000Z"),
+      }),
+      makeSubscription({
+        id: "duplicate-a",
+        name: "Netflix",
+        amountCents: 1000,
+        nextBillingDate: new Date("2026-03-22T00:00:00.000Z"),
+      }),
+      makeSubscription({
+        id: "duplicate-b",
+        name: "Netflix",
+        amountCents: 2200,
+        nextBillingDate: new Date("2026-03-26T00:00:00.000Z"),
+      }),
+      makeSubscription({
+        id: "unused-1",
+        name: "Design Toolkit",
+        amountCents: 3000,
+        createdAt: new Date("2025-07-01T00:00:00.000Z"),
+        updatedAt: new Date("2025-10-01T00:00:00.000Z"),
+        nextBillingDate: new Date("2026-03-24T00:00:00.000Z"),
+      }),
+    ] satisfies DashboardSubscriptionSourceRecord[];
+
+    const forwardIds = buildDashboardPayload(records, now).attentionNeeded.map((item) => item.id);
+    const reverseIds = buildDashboardPayload([...records].reverse(), now).attentionNeeded.map((item) => item.id);
+
+    assert.deepEqual(forwardIds, reverseIds);
   });
 });


### PR DESCRIPTION
## Summary
- implement deterministic Attention Needed heuristics for:
  - promo ending soon
  - potentially unused subscription
  - potential duplicate services
  - annual renewal approaching
- render Attention Needed panel in dashboard with severity icon/color treatment, due date, and monthly impact context
- wire `attentionNeeded` items from dashboard payload into the dashboard client
- add empty-state handling for attention alerts and control-filter-aware attention rendering
- extend dashboard aggregation tests for new alert types, contextual messaging, and deterministic ordering

## Verification
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`

Closes #35