### PR TITLE
[Dashboard V2] Implement upcoming renewals table with deterministic tags

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useId, useMemo, useState } from "react";
+import Image from "next/image";
+import { useEffect, useId, useMemo, useState } from "react";
 
 import SubscriptionDetailsModal from "@/app/components/SubscriptionDetailsModal";
 import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDetailsModal";
@@ -11,6 +12,7 @@ import type {
   DashboardCurrencyTotal,
   DashboardKpis,
   DashboardMetricAmount,
+  DashboardUpcomingRenewalTag,
 } from "@/lib/dashboard";
 import {
   DASHBOARD_ALL_CURRENCIES,
@@ -28,10 +30,11 @@ type DashboardUpcomingChargeListItem = {
   isActive: boolean;
   amountCents: number;
   currency: string;
+  billingInterval: "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM";
   paymentMethod: string;
   renewalDate: string;
   createdAt: string;
-  tag: "urgent" | "soon" | "upcoming";
+  tag: DashboardUpcomingRenewalTag;
 };
 
 type DashboardRecentActivityListItem = {
@@ -75,6 +78,8 @@ type DashboardSectionsClientProps = {
   }>;
 };
 
+const UPCOMING_RENEWALS_VISIBLE_ROWS = 6;
+
 function formatMoney(amountCents: number, currency: string): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -94,6 +99,22 @@ function formatDate(value: string): string {
 
 function formatCadenceSuffix(type: "monthly" | "annual"): string {
   return type === "monthly" ? "/mo" : "/yr";
+}
+
+function formatRenewalCadenceSuffix(billingInterval: DashboardUpcomingChargeListItem["billingInterval"]): string {
+  if (billingInterval === "WEEKLY") {
+    return "/wk";
+  }
+
+  if (billingInterval === "MONTHLY") {
+    return "/mo";
+  }
+
+  if (billingInterval === "YEARLY") {
+    return "/yr";
+  }
+
+  return "/custom";
 }
 
 function formatCountLabel(value: number, singular: string, plural: string = `${singular}s`): string {
@@ -164,28 +185,109 @@ function buildSpendMetricContent(
   };
 }
 
-function formatTag(tag: "urgent" | "soon" | "upcoming"): string {
+function formatTag(tag: DashboardUpcomingRenewalTag): string {
   if (tag === "urgent") {
     return "URGENT";
   }
 
-  if (tag === "soon") {
-    return "SOON";
+  if (tag === "work") {
+    return "WORK";
   }
 
-  return "UPCOMING";
+  if (tag === "gaming") {
+    return "GAMING";
+  }
+
+  return "RENEW";
 }
 
-function tagClassName(tag: "urgent" | "soon" | "upcoming"): string {
+function tagClassName(tag: DashboardUpcomingRenewalTag): string {
   if (tag === "urgent") {
-    return "pill pill-fail";
+    return "pill renewal-tag renewal-tag-urgent";
   }
 
-  if (tag === "soon") {
-    return "pill pill-ok";
+  if (tag === "work") {
+    return "pill renewal-tag renewal-tag-work";
   }
 
-  return "pill";
+  if (tag === "gaming") {
+    return "pill renewal-tag renewal-tag-gaming";
+  }
+
+  if (tag === "renew") {
+    return "pill renewal-tag renewal-tag-renew";
+  }
+
+  return "pill renewal-tag";
+}
+
+function getPaymentMethodIndicator(paymentMethod: string): string {
+  const normalized = paymentMethod.trim().toLowerCase();
+
+  if (!normalized) {
+    return "NA";
+  }
+
+  if (normalized.includes("visa")) {
+    return "VISA";
+  }
+
+  if (normalized.includes("mastercard")) {
+    return "MC";
+  }
+
+  if (normalized.includes("amex") || normalized.includes("american express")) {
+    return "AMEX";
+  }
+
+  if (normalized.includes("paypal")) {
+    return "PP";
+  }
+
+  if (normalized.includes("apple pay")) {
+    return "AP";
+  }
+
+  if (normalized.includes("google pay")) {
+    return "GP";
+  }
+
+  if (normalized.includes("bank") || normalized.includes("ach")) {
+    return "BANK";
+  }
+
+  return "CARD";
+}
+
+function getServiceInitials(name: string): string {
+  const words = name
+    .trim()
+    .split(/\s+/)
+    .filter((value) => value.length > 0);
+
+  if (words.length === 0) {
+    return "?";
+  }
+
+  if (words.length === 1) {
+    return words[0].slice(0, 2).toUpperCase();
+  }
+
+  return `${words[0]?.charAt(0) ?? ""}${words[1]?.charAt(0) ?? ""}`.toUpperCase();
+}
+
+function getServiceLogoSrc(name: string): string | null {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!slug) {
+    return null;
+  }
+
+  return `/brands/${slug}.svg`;
 }
 
 function formatAttentionSeverityLabel(severity: DashboardAttentionSeverity): string {
@@ -248,6 +350,7 @@ export default function DashboardSectionsClient({
   const [currency, setCurrency] = useState<string>(DASHBOARD_ALL_CURRENCIES);
   const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
   const [searchQuery, setSearchQuery] = useState("");
+  const [showAllUpcomingRenewals, setShowAllUpcomingRenewals] = useState(false);
   const now = useMemo(() => new Date(), []);
   const dateRangeDays = useMemo(() => {
     return DASHBOARD_DATE_RANGE_OPTIONS.find((option) => option.value === dateRange)?.days ?? 30;
@@ -266,6 +369,18 @@ export default function DashboardSectionsClient({
       ),
     [currency, dateRange, now, searchQuery, upcomingCharges],
   );
+  useEffect(() => {
+    setShowAllUpcomingRenewals(false);
+  }, [currency, dateRange, searchQuery]);
+  const visibleUpcomingCharges = useMemo(() => {
+    if (showAllUpcomingRenewals) {
+      return filteredUpcomingCharges;
+    }
+
+    return filteredUpcomingCharges.slice(0, UPCOMING_RENEWALS_VISIBLE_ROWS);
+  }, [filteredUpcomingCharges, showAllUpcomingRenewals]);
+  const hasClippedUpcomingRenewals = filteredUpcomingCharges.length > UPCOMING_RENEWALS_VISIBLE_ROWS;
+  const hiddenUpcomingRenewalsCount = Math.max(filteredUpcomingCharges.length - visibleUpcomingCharges.length, 0);
   const filteredRecentActivity = useMemo(
     () =>
       filterDashboardRecentActivity(
@@ -628,40 +743,104 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Upcoming Renewals</h2>
-              <span className="metric-note">{filteredUpcomingCharges.length} matching rows</span>
+              <span className="metric-note">{filteredUpcomingCharges.length} matching rows, sorted by soonest date</span>
             </div>
             {filteredUpcomingCharges.length === 0 ? (
               <p className="text-muted">No upcoming renewals match the current control filters.</p>
             ) : (
-              <div className="stack">
-                {filteredUpcomingCharges.map((subscription) => (
-                  <button
-                    aria-label={`View details for ${subscription.name}`}
-                    className="status-item subscription-entry-button"
-                    key={subscription.id}
-                    onClick={() =>
-                      void detailsModal.openModal({
-                        subscriptionId: subscription.id,
-                        source: "upcoming_charges",
-                      })
-                    }
-                    type="button"
-                  >
-                    <div className="subscription-header">
-                      <h2>{subscription.name}</h2>
-                      <div className="inline-actions">
-                        <span className={tagClassName(subscription.tag)}>{formatTag(subscription.tag)}</span>
-                        <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
-                          {subscription.isActive ? "ACTIVE" : "INACTIVE"}
-                        </span>
-                      </div>
-                    </div>
-                    <p className="subscription-meta">
-                      {formatMoney(subscription.amountCents, subscription.currency)} - {formatDate(subscription.renewalDate)}
-                    </p>
-                    <p className="subscription-meta">Payment method: {subscription.paymentMethod}</p>
-                  </button>
-                ))}
+              <div className="upcoming-renewals-table-shell">
+                <p className="text-muted" role="status">
+                  {showAllUpcomingRenewals
+                    ? `Showing all ${filteredUpcomingCharges.length} rows.`
+                    : `Showing ${visibleUpcomingCharges.length} of ${filteredUpcomingCharges.length} rows.`}
+                </p>
+                <div className="upcoming-renewals-table-wrap">
+                  <table className="upcoming-renewals-table">
+                    <caption className="visually-hidden">
+                      Upcoming renewals including service, renewal date, amount cadence, payment method, and tag.
+                    </caption>
+                    <thead>
+                      <tr>
+                        <th scope="col">Service</th>
+                        <th scope="col">Renewal Date</th>
+                        <th scope="col">Amount/Cadence</th>
+                        <th scope="col">Payment</th>
+                        <th scope="col">Tag</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visibleUpcomingCharges.map((subscription) => {
+                        const serviceInitials = getServiceInitials(subscription.name);
+                        const logoSrc = getServiceLogoSrc(subscription.name);
+
+                        return (
+                          <tr key={subscription.id}>
+                            <td data-label="Service">
+                              <div className="renewal-service-cell">
+                                <span aria-hidden="true" className="renewal-service-icon">
+                                  {logoSrc ? (
+                                    <Image
+                                      alt=""
+                                      className="renewal-service-logo"
+                                      height={28}
+                                      loading="lazy"
+                                      onError={(event) => {
+                                        event.currentTarget.style.display = "none";
+                                      }}
+                                      src={logoSrc}
+                                      width={28}
+                                    />
+                                  ) : null}
+                                  <span className="renewal-service-fallback">{serviceInitials}</span>
+                                </span>
+                                <button
+                                  aria-label={`View details for ${subscription.name}`}
+                                  className="renewal-service-button"
+                                  onClick={() =>
+                                    void detailsModal.openModal({
+                                      subscriptionId: subscription.id,
+                                      source: "upcoming_charges",
+                                    })
+                                  }
+                                  type="button"
+                                >
+                                  {subscription.name}
+                                </button>
+                              </div>
+                            </td>
+                            <td data-label="Renewal Date">{formatDate(subscription.renewalDate)}</td>
+                            <td data-label="Amount/Cadence">
+                              {formatMoney(subscription.amountCents, subscription.currency)}{" "}
+                              {formatRenewalCadenceSuffix(subscription.billingInterval)}
+                            </td>
+                            <td data-label="Payment">
+                              <div className="renewal-payment-cell">
+                                <span className="payment-indicator">{getPaymentMethodIndicator(subscription.paymentMethod)}</span>
+                                <span className="text-muted">
+                                  {subscription.paymentMethod.trim() || "No payment method on file"}
+                                </span>
+                              </div>
+                            </td>
+                            <td data-label="Tag">
+                              <span className={tagClassName(subscription.tag)}>{formatTag(subscription.tag)}</span>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                {hasClippedUpcomingRenewals ? (
+                  <div className="upcoming-renewals-actions">
+                    <button
+                      className="button button-secondary button-small"
+                      onClick={() => setShowAllUpcomingRenewals((currentValue) => !currentValue)}
+                      type="button"
+                    >
+                      {showAllUpcomingRenewals ? "Show less" : `Show ${hiddenUpcomingRenewalsCount} more`}
+                    </button>
+                  </div>
+                ) : null}
               </div>
             )}
           </article>

--- a/app/globals.css
+++ b/app/globals.css
@@ -862,6 +862,176 @@ button:disabled,
   margin: 0.2rem 0 0.6rem;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.upcoming-renewals-table-shell {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.upcoming-renewals-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel-soft);
+}
+
+.upcoming-renewals-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 700px;
+}
+
+.upcoming-renewals-table th,
+.upcoming-renewals-table td {
+  padding: 0.68rem 0.72rem;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
+.upcoming-renewals-table th {
+  text-align: left;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--panel-soft), var(--panel) 60%);
+}
+
+.upcoming-renewals-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.upcoming-renewals-table tbody tr:hover {
+  background: color-mix(in srgb, var(--panel-soft), var(--panel) 45%);
+}
+
+.renewal-service-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+}
+
+.renewal-service-icon {
+  position: relative;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--brand) 12%, var(--panel));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.renewal-service-logo {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.renewal-service-fallback {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: color-mix(in srgb, var(--brand), var(--text) 38%);
+}
+
+.renewal-service-button {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  padding: 0;
+  text-align: left;
+  justify-content: flex-start;
+}
+
+.renewal-service-button:hover {
+  background: transparent;
+  transform: none;
+  color: var(--brand);
+}
+
+.renewal-service-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--brand) 72%, #ffffff 28%);
+  outline-offset: 2px;
+}
+
+.renewal-payment-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.46rem;
+  flex-wrap: wrap;
+}
+
+.payment-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.6rem;
+  padding: 0.18rem 0.34rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: var(--panel);
+  color: var(--text-muted);
+}
+
+.renewal-tag {
+  text-transform: uppercase;
+}
+
+.renewal-tag-urgent {
+  color: var(--fail);
+  border-color: color-mix(in srgb, var(--fail), var(--border) 42%);
+  background: color-mix(in srgb, var(--fail) 9%, var(--panel));
+}
+
+.renewal-tag-renew {
+  color: color-mix(in srgb, var(--brand), var(--text) 26%);
+  border-color: color-mix(in srgb, var(--brand), var(--border) 45%);
+  background: color-mix(in srgb, var(--brand) 10%, var(--panel));
+}
+
+.renewal-tag-work {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok), var(--border) 42%);
+  background: color-mix(in srgb, var(--ok) 11%, var(--panel));
+}
+
+.renewal-tag-gaming {
+  color: #7a3db5;
+  border-color: color-mix(in srgb, #7a3db5, var(--border) 35%);
+  background: color-mix(in srgb, #7a3db5 11%, var(--panel));
+}
+
+.upcoming-renewals-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .status-ok {
   color: var(--ok);
   font-weight: 700;
@@ -917,6 +1087,60 @@ button:disabled,
   color: var(--fail);
   border-color: var(--pill-fail-border);
   background: var(--pill-fail-bg);
+}
+
+@media (max-width: 760px) {
+  .upcoming-renewals-table {
+    min-width: 100%;
+  }
+
+  .upcoming-renewals-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
+  }
+
+  .upcoming-renewals-table,
+  .upcoming-renewals-table tbody,
+  .upcoming-renewals-table tr,
+  .upcoming-renewals-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .upcoming-renewals-table tbody tr {
+    border-bottom: 1px solid var(--border);
+    padding: 0.32rem 0;
+  }
+
+  .upcoming-renewals-table tbody tr:last-child {
+    border-bottom: 0;
+  }
+
+  .upcoming-renewals-table td {
+    border-bottom: 0;
+    padding: 0.42rem 0.62rem;
+    display: grid;
+    grid-template-columns: minmax(110px, 38%) minmax(0, 1fr);
+    gap: 0.4rem;
+    align-items: center;
+  }
+
+  .upcoming-renewals-table td::before {
+    content: attr(data-label);
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
 }
 
 .text-muted {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,6 +107,7 @@ export default async function DashboardPage() {
           isActive: subscription.isActive,
           amountCents: subscription.amountCents,
           currency: subscription.currency,
+          billingInterval: subscription.billingInterval,
           paymentMethod: subscription.paymentMethod,
           renewalDate: subscription.renewalDate,
           createdAt: subscription.createdAt,

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -13,8 +13,27 @@ const ATTENTION_PROMO_WINDOW_DAYS = 7;
 const ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS = 45;
 const ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS = 120;
 const ATTENTION_UNUSED_STALE_UPDATED_DAYS = 90;
+const UPCOMING_RENEW_URGENCY_WINDOW_DAYS = 3;
+const UPCOMING_RENEW_TAG_WINDOW_DAYS = 10;
 
 const PROMO_HINT_KEYWORDS = ["trial", "promo", "intro", "discount", "offer", "starter"] as const;
+const WORK_TAG_HINT_KEYWORDS = [
+  "github",
+  "figma",
+  "slack",
+  "notion",
+  "workspace",
+  "office",
+  "jira",
+  "confluence",
+  "cloud",
+  "aws",
+  "azure",
+  "gcp",
+  "vercel",
+  "netlify",
+] as const;
+const GAMING_TAG_HINT_KEYWORDS = ["xbox", "playstation", "steam", "nintendo", "epic", "game pass", "ea play"] as const;
 
 const CATEGORY_RULES: ReadonlyArray<{ category: string; keywords: readonly string[] }> = [
   { category: "Streaming", keywords: ["netflix", "hulu", "disney", "paramount", "spotify", "youtube", "apple tv", "prime video"] },
@@ -97,7 +116,7 @@ export type DashboardAttentionItem = {
   currency: string | null;
 };
 
-export type DashboardUpcomingRenewalTag = "urgent" | "soon" | "upcoming";
+export type DashboardUpcomingRenewalTag = "urgent" | "renew" | "work" | "gaming";
 
 export type DashboardUpcomingRenewal = {
   id: string;
@@ -279,6 +298,11 @@ function hasPromoHint(name: string): boolean {
   return PROMO_HINT_KEYWORDS.some((keyword) => lowered.includes(keyword));
 }
 
+function includesAnyKeyword(value: string, keywords: readonly string[]): boolean {
+  const lowered = value.trim().toLowerCase();
+  return keywords.some((keyword) => lowered.includes(keyword));
+}
+
 function inferCategory(name: string): string {
   const lowered = name.trim().toLowerCase();
 
@@ -359,16 +383,32 @@ function metricAmountFromCurrencyTotals(
   };
 }
 
-function chooseUpcomingRenewalTag(daysUntilRenewal: number): DashboardUpcomingRenewalTag {
-  if (daysUntilRenewal <= 3) {
+function chooseUpcomingRenewalTag(subscription: NormalizedSubscription, daysUntilRenewal: number): DashboardUpcomingRenewalTag {
+  if (daysUntilRenewal <= UPCOMING_RENEW_URGENCY_WINDOW_DAYS) {
     return "urgent";
   }
 
-  if (daysUntilRenewal <= 7) {
-    return "soon";
+  if (daysUntilRenewal <= UPCOMING_RENEW_TAG_WINDOW_DAYS) {
+    return "renew";
   }
 
-  return "upcoming";
+  const searchableText = [subscription.name, subscription.paymentMethod, subscription.signedUpBy ?? ""].join(" ");
+  const isWorkTagged =
+    subscription.inferredCategory === "Productivity" ||
+    subscription.inferredCategory === "Cloud & Hosting" ||
+    includesAnyKeyword(searchableText, WORK_TAG_HINT_KEYWORDS);
+
+  if (isWorkTagged) {
+    return "work";
+  }
+
+  const isGamingTagged = subscription.inferredCategory === "Gaming" || includesAnyKeyword(searchableText, GAMING_TAG_HINT_KEYWORDS);
+
+  if (isGamingTagged) {
+    return "gaming";
+  }
+
+  return "renew";
 }
 
 function compareAttentionItems(first: DashboardAttentionItem, second: DashboardAttentionItem): number {
@@ -543,7 +583,7 @@ export function buildDashboardPayload(
         renewalDate: renewalDate.toISOString(),
         daysUntilRenewal,
         monthlyEquivalentAmountCents: subscription.monthlyEquivalentAmountCents,
-        tag: chooseUpcomingRenewalTag(daysUntilRenewal),
+        tag: chooseUpcomingRenewalTag(subscription, daysUntilRenewal),
         isActive: subscription.isActive,
         createdAt: subscription.createdAtDate.toISOString(),
       };

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -248,4 +248,68 @@ describe("buildDashboardPayload", () => {
 
     assert.deepEqual(forwardIds, reverseIds);
   });
+
+  test("sorts upcoming renewals by soonest renewal date and then name", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({
+          id: "third",
+          name: "Zulu Service",
+          nextBillingDate: new Date("2026-03-26T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "first-b",
+          name: "Beta Service",
+          nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "first-a",
+          name: "Alpha Service",
+          nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+        }),
+      ],
+      now,
+    );
+
+    assert.deepEqual(payload.upcomingRenewals.map((renewal) => renewal.id), ["first-a", "first-b", "third"]);
+  });
+
+  test("assigns deterministic upcoming renewal tags with explicit precedence", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({
+          id: "urgent-over-work",
+          name: "GitHub Team",
+          nextBillingDate: new Date("2026-03-12T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "renew-over-gaming",
+          name: "Xbox Game Pass",
+          nextBillingDate: new Date("2026-03-16T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "work-over-gaming",
+          name: "Steam GitHub Bundle",
+          nextBillingDate: new Date("2026-03-30T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "gaming",
+          name: "PlayStation Plus",
+          nextBillingDate: new Date("2026-03-31T00:00:00.000Z"),
+        }),
+      ],
+      now,
+    );
+
+    const tagsById = new Map(payload.upcomingRenewals.map((renewal) => [renewal.id, renewal.tag]));
+
+    assert.equal(tagsById.get("urgent-over-work"), "urgent");
+    assert.equal(tagsById.get("renew-over-gaming"), "renew");
+    assert.equal(tagsById.get("work-over-gaming"), "work");
+    assert.equal(tagsById.get("gaming"), "gaming");
+  });
 });


### PR DESCRIPTION
## Summary
- replace the upcoming renewals stacked list with an accessible, responsive table (service, renewal date, amount/cadence, payment, tag)
- add deterministic renewal tag precedence in aggregation logic: `urgent` > `renew` > `work` > `gaming`
- define clipping behavior with a default visible row count and `Show more` / `Show less` controls
- add service logo path support with initial-based fallback when a brand asset is missing
- include payment method indicator chips and cadence formatting in the table rows
- add unit coverage for renewal ordering and tag precedence

## Validation
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`

Closes #36