### PR TITLE
Implement dashboard Potential Savings and Top Cost Drivers widgets

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -12,6 +12,7 @@ import type {
   DashboardCurrencyTotal,
   DashboardKpis,
   DashboardMetricAmount,
+  DashboardSavingsOpportunity,
   DashboardUpcomingRenewalTag,
 } from "@/lib/dashboard";
 import {
@@ -58,10 +59,43 @@ type DashboardAttentionListItem = {
   currency: string | null;
 };
 
+type DashboardTopCostDriverListItem = {
+  id: string;
+  name: string;
+  currency: string;
+  billingInterval: "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM";
+  monthlyEquivalentAmountCents: number;
+  annualProjectionCents: number;
+  nextBillingDate: string | null;
+};
+
+type DashboardSavingsOpportunityListItem = {
+  id: string;
+  type: DashboardSavingsOpportunity["type"];
+  title: string;
+  description: string;
+  currency: string;
+  estimatedMonthlySavingsCents: number;
+  subscriptionIds: string[];
+};
+
+type DashboardPotentialSavingsData = {
+  estimatedMonthlySavingsCents: number | null;
+  currency: string | null;
+  totalsByCurrency: Array<{
+    currency: string;
+    estimatedMonthlySavingsCents: number;
+  }>;
+  opportunities: DashboardSavingsOpportunityListItem[];
+  assumptions: string[];
+};
+
 type DashboardSectionsClientProps = {
   availableCurrencies: string[];
   kpis?: DashboardKpis | null;
   attentionNeeded: DashboardAttentionListItem[];
+  topCostDrivers: DashboardTopCostDriverListItem[];
+  potentialSavings: DashboardPotentialSavingsData;
   upcomingCharges: DashboardUpcomingChargeListItem[];
   recentSubscriptions: DashboardRecentActivityListItem[];
   monthlySpendTotalsByCurrency: Array<{
@@ -143,6 +177,26 @@ function formatCurrencyTotalsSummary(totalsByCurrency: DashboardCurrencyTotal[],
   return `${summary} · +${remainingCount} more`;
 }
 
+function formatSavingsCurrencyTotalsSummary(
+  totalsByCurrency: Array<{ currency: string; estimatedMonthlySavingsCents: number }>,
+): string {
+  if (totalsByCurrency.length === 0) {
+    return "No opportunities currently qualify for savings.";
+  }
+
+  const visibleTotals = totalsByCurrency.slice(0, 2);
+  const summary = visibleTotals
+    .map((entry) => `${formatMoney(entry.estimatedMonthlySavingsCents, entry.currency)} ${entry.currency}/mo`)
+    .join(" · ");
+  const remainingCount = totalsByCurrency.length - visibleTotals.length;
+
+  if (remainingCount <= 0) {
+    return summary;
+  }
+
+  return `${summary} · +${remainingCount} more`;
+}
+
 type KpiCardContent = {
   value: string;
   note: string;
@@ -199,6 +253,14 @@ function formatTag(tag: DashboardUpcomingRenewalTag): string {
   }
 
   return "RENEW";
+}
+
+function formatSavingsOpportunityType(type: DashboardSavingsOpportunity["type"]): string {
+  if (type === "duplicate_overlap") {
+    return "Duplicate overlap";
+  }
+
+  return "Potentially unused";
 }
 
 function tagClassName(tag: DashboardUpcomingRenewalTag): string {
@@ -339,6 +401,8 @@ export default function DashboardSectionsClient({
   availableCurrencies,
   kpis,
   attentionNeeded,
+  topCostDrivers,
+  potentialSavings,
   upcomingCharges,
   recentSubscriptions,
   monthlySpendTotalsByCurrency,
@@ -420,6 +484,93 @@ export default function DashboardSectionsClient({
       );
     });
   }, [attentionNeeded, currency, dateRangeDays, now, searchQuery]);
+  const filteredTopCostDrivers = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    const selectedCurrency = currency.toUpperCase();
+
+    return topCostDrivers.filter((driver) => {
+      if (currency !== DASHBOARD_ALL_CURRENCIES && driver.currency.toUpperCase() !== selectedCurrency) {
+        return false;
+      }
+
+      if (!isInDateRange(driver.nextBillingDate, now, dateRangeDays)) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return [driver.name, driver.currency, driver.billingInterval].some((value) =>
+        value.toLowerCase().includes(normalizedQuery),
+      );
+    });
+  }, [currency, dateRangeDays, now, searchQuery, topCostDrivers]);
+  const filteredSavingsOpportunities = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    const selectedCurrency = currency.toUpperCase();
+
+    return potentialSavings.opportunities.filter((opportunity) => {
+      if (currency !== DASHBOARD_ALL_CURRENCIES && opportunity.currency.toUpperCase() !== selectedCurrency) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      return [opportunity.title, opportunity.description, opportunity.currency, opportunity.type].some((value) =>
+        value.toLowerCase().includes(normalizedQuery),
+      );
+    });
+  }, [currency, potentialSavings.opportunities, searchQuery]);
+  const filteredSavingsTotalsByCurrency = useMemo(() => {
+    const totalsMap = new Map<string, number>();
+
+    for (const opportunity of filteredSavingsOpportunities) {
+      totalsMap.set(
+        opportunity.currency,
+        (totalsMap.get(opportunity.currency) ?? 0) + opportunity.estimatedMonthlySavingsCents,
+      );
+    }
+
+    return [...totalsMap.entries()]
+      .map(([currencyCode, estimatedMonthlySavingsCents]) => ({
+        currency: currencyCode,
+        estimatedMonthlySavingsCents,
+      }))
+      .sort((first, second) => {
+        return (
+          second.estimatedMonthlySavingsCents - first.estimatedMonthlySavingsCents ||
+          first.currency.localeCompare(second.currency)
+        );
+      });
+  }, [filteredSavingsOpportunities]);
+  const potentialSavingsSummary = useMemo<KpiCardContent>(() => {
+    if (filteredSavingsTotalsByCurrency.length === 0) {
+      return {
+        value: "No opportunities",
+        note: "No savings candidates match the current control filters.",
+      };
+    }
+
+    if (filteredSavingsTotalsByCurrency.length === 1) {
+      const [singleTotal] = filteredSavingsTotalsByCurrency;
+
+      return {
+        value: `${formatMoney(singleTotal.estimatedMonthlySavingsCents, singleTotal.currency)}${formatCadenceSuffix("monthly")}`,
+        note: `Estimated from ${formatCountLabel(filteredSavingsOpportunities.length, "opportunity")} in ${singleTotal.currency}.`,
+      };
+    }
+
+    return {
+      value: `${filteredSavingsTotalsByCurrency.length} currencies`,
+      note: formatSavingsCurrencyTotalsSummary(filteredSavingsTotalsByCurrency),
+    };
+  }, [filteredSavingsOpportunities.length, filteredSavingsTotalsByCurrency]);
+  const topCostDriverCurrencyCount = useMemo(() => {
+    return new Set(filteredTopCostDrivers.map((driver) => driver.currency.toUpperCase())).size;
+  }, [filteredTopCostDrivers]);
   const currencyOptions = useMemo(() => {
     const normalized = [
       ...new Set(
@@ -848,12 +999,105 @@ export default function DashboardSectionsClient({
 
         <section className="dashboard-grid dashboard-grid-two-up">
           <article className="dashboard-card">
-            <h2>Potential Savings</h2>
-            <p className="text-muted">Savings opportunity insights will render in this container.</p>
+            <div className="dashboard-card-header">
+              <h2>Potential Savings</h2>
+              <span className="metric-note">{filteredSavingsOpportunities.length} matching opportunities</span>
+            </div>
+            <article className="metric-card savings-summary-card">
+              <span className="metric-label">Estimated monthly savings</span>
+              <strong className="metric-value">{potentialSavingsSummary.value}</strong>
+              <span className="metric-note">{potentialSavingsSummary.note}</span>
+            </article>
+            {filteredSavingsOpportunities.length === 0 ? (
+              <p className="text-muted mt-sm">No savings opportunities match the current control filters.</p>
+            ) : (
+              <ul className="savings-opportunity-list">
+                {filteredSavingsOpportunities.map((opportunity) => {
+                  const singleSubscriptionId =
+                    opportunity.subscriptionIds.length === 1 ? opportunity.subscriptionIds[0] : null;
+
+                  return (
+                    <li className="savings-opportunity-item" key={opportunity.id}>
+                      <div className="savings-opportunity-header">
+                        <span className="pill savings-rule-pill">{formatSavingsOpportunityType(opportunity.type)}</span>
+                        <strong>{formatMoney(opportunity.estimatedMonthlySavingsCents, opportunity.currency)}/mo</strong>
+                      </div>
+                      <h3>{opportunity.title}</h3>
+                      <p className="text-muted">{opportunity.description}</p>
+                      {singleSubscriptionId ? (
+                        <button
+                          className="button button-secondary button-small"
+                          onClick={() =>
+                            void detailsModal.openModal({
+                              subscriptionId: singleSubscriptionId,
+                              source: "subscriptions_list",
+                            })
+                          }
+                          type="button"
+                        >
+                          View subscription
+                        </button>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            {potentialSavings.assumptions.length > 0 ? (
+              <div className="savings-assumptions">
+                <span className="metric-note">Assumptions</span>
+                <ul>
+                  {potentialSavings.assumptions.map((assumption) => (
+                    <li key={assumption}>{assumption}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
           </article>
           <article className="dashboard-card">
-            <h2>Top Cost Drivers</h2>
-            <p className="text-muted">Top-cost subscription rankings will render in this section.</p>
+            <div className="dashboard-card-header">
+              <h2>Top Cost Drivers</h2>
+              <span className="metric-note">{filteredTopCostDrivers.length} matching rows</span>
+            </div>
+            {filteredTopCostDrivers.length === 0 ? (
+              <p className="text-muted">No cost drivers match the current control filters.</p>
+            ) : (
+              <ol className="cost-driver-list">
+                {filteredTopCostDrivers.map((driver, index) => (
+                  <li className="cost-driver-item" key={driver.id}>
+                    <span aria-hidden="true" className="cost-driver-rank">
+                      {index + 1}
+                    </span>
+                    <div className="cost-driver-copy">
+                      <div className="cost-driver-header">
+                        <button
+                          aria-label={`View details for ${driver.name}`}
+                          className="renewal-service-button"
+                          onClick={() =>
+                            void detailsModal.openModal({
+                              subscriptionId: driver.id,
+                              source: "subscriptions_list",
+                            })
+                          }
+                          type="button"
+                        >
+                          {driver.name}
+                        </button>
+                        <strong>{formatMoney(driver.monthlyEquivalentAmountCents, driver.currency)}/mo</strong>
+                      </div>
+                      <p className="cost-driver-meta">
+                        Annual projection {formatMoney(driver.annualProjectionCents, driver.currency)} · Billing cadence{" "}
+                        {driver.billingInterval.toLowerCase()}
+                        {driver.nextBillingDate ? ` · Next renewal ${formatDate(driver.nextBillingDate)}` : ""}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+            {topCostDriverCurrencyCount > 1 ? (
+              <p className="text-muted mt-sm">Ranking is normalized to monthly amounts without FX conversion.</p>
+            ) : null}
           </article>
         </section>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -575,6 +575,124 @@ a {
   color: var(--text-muted);
 }
 
+.savings-summary-card {
+  margin-top: 0.25rem;
+}
+
+.savings-opportunity-list {
+  margin: 0.7rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.62rem;
+}
+
+.savings-opportunity-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel-soft);
+  padding: 0.75rem 0.8rem;
+  display: grid;
+  gap: 0.42rem;
+}
+
+.savings-opportunity-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.savings-opportunity-item h3 {
+  margin: 0;
+  font-size: 0.97rem;
+}
+
+.savings-opportunity-item p {
+  margin: 0;
+}
+
+.savings-rule-pill {
+  color: color-mix(in srgb, var(--brand), var(--text) 26%);
+  border-color: color-mix(in srgb, var(--brand), var(--border) 45%);
+  background: color-mix(in srgb, var(--brand) 10%, var(--panel));
+}
+
+.savings-assumptions {
+  margin-top: 0.7rem;
+  display: grid;
+  gap: 0.32rem;
+}
+
+.savings-assumptions ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.83rem;
+}
+
+.cost-driver-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.cost-driver-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel-soft);
+  padding: 0.72rem 0.75rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.64rem;
+  align-items: start;
+}
+
+.cost-driver-rank {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--brand), var(--border) 45%);
+  background: color-mix(in srgb, var(--brand) 12%, var(--panel));
+  color: color-mix(in srgb, var(--brand), var(--text) 25%);
+  font-size: 0.76rem;
+  font-weight: 750;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.05rem;
+}
+
+.cost-driver-copy {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.cost-driver-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.cost-driver-header strong {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.cost-driver-meta {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.83rem;
+}
+
 .stack {
   display: grid;
   gap: 0.8rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,6 +59,9 @@ export default async function DashboardPage() {
         .map((entry) => entry.currency)
         .filter((value): value is string => value !== null),
       ...dashboardPayload.upcomingRenewals.map((entry) => entry.currency),
+      ...dashboardPayload.topCostDrivers.map((entry) => entry.currency),
+      ...dashboardPayload.potentialSavings.totalsByCurrency.map((entry) => entry.currency),
+      ...dashboardPayload.potentialSavings.opportunities.map((entry) => entry.currency),
       ...dashboardPayload.recentSubscriptions.map((entry) => entry.currency),
     ]),
   ];
@@ -93,6 +96,24 @@ export default async function DashboardPage() {
           currency: entry.currency,
           monthlyEquivalentSpendCents: entry.monthlyEquivalentSpendCents,
         }))}
+        potentialSavings={{
+          estimatedMonthlySavingsCents: dashboardPayload.potentialSavings.estimatedMonthlySavingsCents,
+          currency: dashboardPayload.potentialSavings.currency,
+          totalsByCurrency: dashboardPayload.potentialSavings.totalsByCurrency.map((entry) => ({
+            currency: entry.currency,
+            estimatedMonthlySavingsCents: entry.estimatedMonthlySavingsCents,
+          })),
+          opportunities: dashboardPayload.potentialSavings.opportunities.map((opportunity) => ({
+            id: opportunity.id,
+            type: opportunity.type,
+            title: opportunity.title,
+            description: opportunity.description,
+            currency: opportunity.currency,
+            estimatedMonthlySavingsCents: opportunity.estimatedMonthlySavingsCents,
+            subscriptionIds: opportunity.subscriptionIds,
+          })),
+          assumptions: dashboardPayload.potentialSavings.assumptions,
+        }}
         recentSubscriptions={dashboardPayload.recentSubscriptions.map((subscription) => ({
           id: subscription.id,
           name: subscription.name,
@@ -100,6 +121,15 @@ export default async function DashboardPage() {
           amountCents: subscription.amountCents,
           currency: subscription.currency,
           createdAt: subscription.createdAt,
+        }))}
+        topCostDrivers={dashboardPayload.topCostDrivers.map((driver) => ({
+          id: driver.id,
+          name: driver.name,
+          currency: driver.currency,
+          billingInterval: driver.billingInterval,
+          monthlyEquivalentAmountCents: driver.monthlyEquivalentAmountCents,
+          annualProjectionCents: driver.annualProjectionCents,
+          nextBillingDate: driver.nextBillingDate,
         }))}
         upcomingCharges={dashboardPayload.upcomingRenewals.map((subscription) => ({
           id: subscription.id,

--- a/docs/DASHBOARD_AGGREGATION.md
+++ b/docs/DASHBOARD_AGGREGATION.md
@@ -24,10 +24,18 @@ The dashboard aggregation contract is built in `lib/dashboard.ts` and exposed th
 - Normalized KPI totals return a single `amountCents` only when all contributing subscriptions share one currency.
 - When multiple currencies are present, KPI totals are returned in `totalsByCurrency` and single-currency fields are `null`.
 
+## Potential savings rules
+
+- Rule 1 (`duplicate_overlap`): for active subscriptions sharing canonical service name and currency, keep the lowest monthly-equivalent entry and treat the remaining entries as overlap savings.
+- Rule 2 (`potentially_unused_subscription`): active subscriptions are flagged when they have an upcoming renewal in 30 days, account age is at least 120 days, and last update is at least 90 days old.
+- To avoid double counting, subscriptions that are part of duplicate groups are excluded from the potentially-unused rule.
+- Savings totals are grouped by currency with no FX conversion.
+- `CUSTOM` cadence subscriptions are excluded from savings opportunities because monthly normalization is undefined.
+
 ## Deterministic ordering
 
 - `upcomingRenewals`: renewal date ascending, then name ascending.
 - `attentionNeeded`: severity descending, then due date ascending, then title ascending.
-- `topCostDrivers`: currency ascending, then monthly equivalent descending, then name ascending.
+- `topCostDrivers`: monthly equivalent descending, then currency ascending, then name ascending.
 - `spendBreakdownByCategory`: max category monthly total descending, then subscription count descending, then category ascending.
 - `potentialSavings.opportunities`: estimated monthly savings descending, then title ascending.

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -145,7 +145,7 @@ export type DashboardTopCostDriver = {
 
 export type DashboardSavingsOpportunity = {
   id: string;
-  type: "duplicate_overlap";
+  type: "duplicate_overlap" | "potentially_unused_subscription";
   title: string;
   description: string;
   currency: string;
@@ -411,6 +411,15 @@ function chooseUpcomingRenewalTag(subscription: NormalizedSubscription, daysUnti
   return "renew";
 }
 
+function isPotentiallyUnusedCandidate(subscription: NormalizedSubscription, now: Date): boolean {
+  return (
+    subscription.nextBillingDateDate !== null &&
+    isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS) &&
+    daysSince(subscription.createdAtDate, now) >= ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS &&
+    daysSince(subscription.updatedAtDate, now) >= ATTENTION_UNUSED_STALE_UPDATED_DAYS
+  );
+}
+
 function compareAttentionItems(first: DashboardAttentionItem, second: DashboardAttentionItem): number {
   const severityDelta = ATTENTION_SEVERITY_RANK[second.severity] - ATTENTION_SEVERITY_RANK[first.severity];
 
@@ -623,13 +632,7 @@ export function buildDashboardPayload(
         };
       }),
     ...activeSubscriptions
-      .filter(
-        (subscription) =>
-          subscription.nextBillingDateDate !== null &&
-          isWithinNextDays(subscription.nextBillingDateDate, now, DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS) &&
-          daysSince(subscription.createdAtDate, now) >= ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS &&
-          daysSince(subscription.updatedAtDate, now) >= ATTENTION_UNUSED_STALE_UPDATED_DAYS,
-      )
+      .filter((subscription) => isPotentiallyUnusedCandidate(subscription, now))
       .map((subscription) => {
         const dueDate = subscription.nextBillingDateDate as Date;
         const staleDays = daysSince(subscription.updatedAtDate, now);
@@ -704,12 +707,9 @@ export function buildDashboardPayload(
         subscription.monthlyEquivalentAmountCents !== null && subscription.annualProjectionCents !== null,
     )
     .sort((first, second) => {
-      if (first.currency !== second.currency) {
-        return first.currency.localeCompare(second.currency);
-      }
-
       return (
         second.monthlyEquivalentAmountCents - first.monthlyEquivalentAmountCents ||
+        first.currency.localeCompare(second.currency) ||
         first.name.localeCompare(second.name) ||
         first.id.localeCompare(second.id)
       );
@@ -725,7 +725,7 @@ export function buildDashboardPayload(
       nextBillingDate: subscription.nextBillingDateDate ? subscription.nextBillingDateDate.toISOString() : null,
     }));
 
-  const opportunities: DashboardSavingsOpportunity[] = duplicateGroups
+  const duplicateOpportunities: DashboardSavingsOpportunity[] = duplicateGroups
     .map((group) => {
       const duplicateSubscriptions = group.subscriptions.slice(1);
       const estimatedMonthlySavingsCents = duplicateSubscriptions.reduce(
@@ -743,14 +743,39 @@ export function buildDashboardPayload(
         subscriptionIds: duplicateSubscriptions.map((subscription) => subscription.id),
       };
     })
-    .filter((opportunity) => opportunity.estimatedMonthlySavingsCents > 0)
-    .sort((first, second) => {
+    .filter((opportunity) => opportunity.estimatedMonthlySavingsCents > 0);
+
+  const subscriptionsInDuplicateGroups = new Set(
+    duplicateGroups.flatMap((group) => group.subscriptions.map((subscription) => subscription.id)),
+  );
+
+  const potentiallyUnusedOpportunities: DashboardSavingsOpportunity[] = activeSubscriptions
+    .filter(
+      (subscription): subscription is NormalizedSubscription & { monthlyEquivalentAmountCents: number } =>
+        subscription.monthlyEquivalentAmountCents !== null &&
+        isPotentiallyUnusedCandidate(subscription, now) &&
+        !subscriptionsInDuplicateGroups.has(subscription.id),
+    )
+    .map((subscription) => ({
+      id: `savings-unused-${subscription.id}`,
+      type: "potentially_unused_subscription" as const,
+      title: `Review usage for ${subscription.name}`,
+      description: "No recent updates detected. Confirm this subscription is still needed before the next renewal.",
+      currency: subscription.currency,
+      estimatedMonthlySavingsCents: subscription.monthlyEquivalentAmountCents,
+      subscriptionIds: [subscription.id],
+    }))
+    .filter((opportunity) => opportunity.estimatedMonthlySavingsCents > 0);
+
+  const opportunities: DashboardSavingsOpportunity[] = [...duplicateOpportunities, ...potentiallyUnusedOpportunities].sort(
+    (first, second) => {
       return (
         second.estimatedMonthlySavingsCents - first.estimatedMonthlySavingsCents ||
         first.title.localeCompare(second.title) ||
         first.id.localeCompare(second.id)
       );
-    });
+    },
+  );
 
   const savingsTotalsMap = new Map<string, number>();
 
@@ -780,7 +805,9 @@ export function buildDashboardPayload(
     totalsByCurrency: savingsTotalsByCurrency,
     opportunities,
     assumptions: [
-      "Savings estimate includes only duplicate active subscriptions sharing a canonical service name and currency.",
+      "Savings estimate includes duplicate-overlap candidates (same canonical service name + currency) and potentially-unused subscriptions.",
+      "Potentially-unused candidates require an upcoming renewal within 30 days, account age of at least 120 days, and no updates for 90+ days.",
+      "Subscriptions in duplicate groups are excluded from the potentially-unused rule to avoid double counting.",
       "No FX conversion is applied when currencies differ.",
       "Custom billing intervals are excluded from normalized monthly/annual estimates.",
     ],

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -143,6 +143,21 @@ describe("buildDashboardPayload", () => {
     assert.deepEqual(payload.topCostDrivers.map((driver) => driver.id), ["active"]);
   });
 
+  test("ranks top cost drivers by normalized monthly equivalent spend", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "monthly", name: "Monthly Plan", amountCents: 2100, billingInterval: "MONTHLY" }),
+        makeSubscription({ id: "weekly", name: "Weekly Plan", amountCents: 500, billingInterval: "WEEKLY" }),
+        makeSubscription({ id: "yearly", name: "Yearly Plan", amountCents: 24000, billingInterval: "YEARLY" }),
+      ],
+      now,
+    );
+
+    assert.deepEqual(payload.topCostDrivers.map((driver) => driver.id), ["weekly", "monthly", "yearly"]);
+  });
+
   test("builds duplicate-service alerts and savings opportunities deterministically", () => {
     const now = new Date("2026-03-11T00:00:00.000Z");
 
@@ -160,6 +175,50 @@ describe("buildDashboardPayload", () => {
     assert.equal(payload.potentialSavings.currency, "USD");
     assert.equal(payload.potentialSavings.estimatedMonthlySavingsCents, 4000);
     assert.deepEqual(payload.potentialSavings.opportunities[0]?.subscriptionIds, ["stream-c", "stream-b"]);
+  });
+
+  test("includes potentially-unused savings candidates while preventing duplicate-group double counting", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({
+          id: "duplicate-a",
+          name: "Netflix",
+          amountCents: 1000,
+          createdAt: new Date("2025-06-01T00:00:00.000Z"),
+          updatedAt: new Date("2025-10-01T00:00:00.000Z"),
+          nextBillingDate: new Date("2026-03-20T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "duplicate-b",
+          name: "Netflix",
+          amountCents: 2200,
+          createdAt: new Date("2025-06-01T00:00:00.000Z"),
+          updatedAt: new Date("2025-10-01T00:00:00.000Z"),
+          nextBillingDate: new Date("2026-03-22T00:00:00.000Z"),
+        }),
+        makeSubscription({
+          id: "unused-standalone",
+          name: "Legacy Tool",
+          amountCents: 3000,
+          createdAt: new Date("2025-06-01T00:00:00.000Z"),
+          updatedAt: new Date("2025-10-01T00:00:00.000Z"),
+          nextBillingDate: new Date("2026-03-24T00:00:00.000Z"),
+        }),
+      ],
+      now,
+    );
+
+    assert.deepEqual(
+      payload.potentialSavings.opportunities.map((opportunity) => [opportunity.type, opportunity.subscriptionIds]),
+      [
+        ["potentially_unused_subscription", ["unused-standalone"]],
+        ["duplicate_overlap", ["duplicate-b"]],
+      ],
+    );
+    assert.equal(payload.potentialSavings.currency, "USD");
+    assert.equal(payload.potentialSavings.estimatedMonthlySavingsCents, 5200);
   });
 
   test("builds promo-ending and potentially-unused alerts with actionable amount/date context", () => {


### PR DESCRIPTION
## Summary
- wire `topCostDrivers` and `potentialSavings` data into the dashboard page and render both lower insight widgets
- replace placeholder cards with functional UI, including control-aware filtering and empty states
- extend savings estimation with a `potentially_unused_subscription` rule and guard against duplicate-rule double counting
- document savings estimation rules in the dashboard aggregation contract

## Testing
- `npm run test:dashboard`
- `npm run typecheck`
- `npm run lint`

Closes #37