### PR TITLE
[Dashboard V2] Hardening pass for loading, accessibility, and QA (#38)

### DIFF
--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import DashboardSectionsClient from "@/app/DashboardSectionsClient";
+import type { DashboardPayload } from "@/lib/dashboard";
+import {
+  getDashboardRenderState,
+  INITIAL_DASHBOARD_REQUEST_STATE,
+  reduceDashboardRequestState,
+} from "@/lib/dashboard-view-state";
+
+type DashboardApiResponse = {
+  data?: DashboardPayload;
+  fetchedAt?: string;
+  error?: string;
+};
+
+function buildAvailableCurrencies(payload: DashboardPayload): string[] {
+  return [
+    ...new Set([
+      ...payload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency),
+      ...payload.spendBreakdownByCategory.flatMap((entry) => entry.totalsByCurrency.map((total) => total.currency)),
+      ...payload.attentionNeeded.map((entry) => entry.currency).filter((value): value is string => value !== null),
+      ...payload.upcomingRenewals.map((entry) => entry.currency),
+      ...payload.topCostDrivers.map((entry) => entry.currency),
+      ...payload.potentialSavings.totalsByCurrency.map((entry) => entry.currency),
+      ...payload.potentialSavings.opportunities.map((entry) => entry.currency),
+      ...payload.recentSubscriptions.map((entry) => entry.currency),
+    ]),
+  ];
+}
+
+async function loadDashboardPayload(signal?: AbortSignal): Promise<DashboardPayload> {
+  const response = await fetch("/api/dashboard", {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+    signal,
+  });
+
+  let parsedResponse: DashboardApiResponse | null = null;
+
+  try {
+    parsedResponse = (await response.json()) as DashboardApiResponse;
+  } catch {
+    parsedResponse = null;
+  }
+
+  if (!response.ok) {
+    const statusMessage = `Dashboard request failed with status ${response.status}.`;
+    throw new Error(parsedResponse?.error || statusMessage);
+  }
+
+  if (!parsedResponse?.data) {
+    throw new Error("Dashboard payload was missing from the API response.");
+  }
+
+  return parsedResponse.data;
+}
+
+export default function DashboardDataClient() {
+  const [requestState, setRequestState] = useState(INITIAL_DASHBOARD_REQUEST_STATE);
+
+  const refreshDashboard = useCallback(async (signal?: AbortSignal) => {
+    setRequestState((currentState) => reduceDashboardRequestState(currentState, { type: "fetch_start" }));
+
+    try {
+      const payload = await loadDashboardPayload(signal);
+      setRequestState((currentState) =>
+        reduceDashboardRequestState(currentState, {
+          type: "fetch_success",
+          data: payload,
+        }),
+      );
+    } catch (error) {
+      if (signal?.aborted) {
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : "Unable to load dashboard data.";
+      setRequestState((currentState) =>
+        reduceDashboardRequestState(currentState, {
+          type: "fetch_error",
+          errorMessage: message,
+        }),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void refreshDashboard(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [refreshDashboard]);
+
+  const renderState = getDashboardRenderState(requestState);
+  const payload = requestState.data;
+
+  const availableCurrencies = useMemo(() => {
+    if (!payload) {
+      return [];
+    }
+
+    return buildAvailableCurrencies(payload);
+  }, [payload]);
+
+  return (
+    <DashboardSectionsClient
+      attentionNeeded={payload?.attentionNeeded.map((item) => ({
+        id: item.id,
+        type: item.type,
+        severity: item.severity,
+        title: item.title,
+        message: item.message,
+        dueDate: item.dueDate,
+        subscriptionIds: item.subscriptionIds,
+        estimatedMonthlyImpactCents: item.estimatedMonthlyImpactCents,
+        currency: item.currency,
+      })) ?? []}
+      availableCurrencies={availableCurrencies}
+      kpis={payload?.kpis ?? null}
+      loadErrorMessage={requestState.errorMessage}
+      monthlySpendTotalsByCurrency={
+        payload?.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => ({
+          currency: entry.currency,
+          monthlyEquivalentSpendCents: entry.monthlyEquivalentSpendCents,
+        })) ?? []
+      }
+      onRetryLoad={() => {
+        void refreshDashboard();
+      }}
+      potentialSavings={{
+        estimatedMonthlySavingsCents: payload?.potentialSavings.estimatedMonthlySavingsCents ?? null,
+        currency: payload?.potentialSavings.currency ?? null,
+        totalsByCurrency:
+          payload?.potentialSavings.totalsByCurrency.map((entry) => ({
+            currency: entry.currency,
+            estimatedMonthlySavingsCents: entry.estimatedMonthlySavingsCents,
+          })) ?? [],
+        opportunities:
+          payload?.potentialSavings.opportunities.map((opportunity) => ({
+            id: opportunity.id,
+            type: opportunity.type,
+            title: opportunity.title,
+            description: opportunity.description,
+            currency: opportunity.currency,
+            estimatedMonthlySavingsCents: opportunity.estimatedMonthlySavingsCents,
+            subscriptionIds: opportunity.subscriptionIds,
+          })) ?? [],
+        assumptions: payload?.potentialSavings.assumptions ?? [],
+      }}
+      recentSubscriptions={
+        payload?.recentSubscriptions.map((subscription) => ({
+          id: subscription.id,
+          name: subscription.name,
+          isActive: subscription.isActive,
+          amountCents: subscription.amountCents,
+          currency: subscription.currency,
+          createdAt: subscription.createdAt,
+        })) ?? []
+      }
+      renderState={renderState}
+      spendBreakdownByCategory={
+        payload?.spendBreakdownByCategory.map((category) => ({
+          category: category.category,
+          subscriptionCount: category.subscriptionCount,
+          totalsByCurrency: category.totalsByCurrency.map((total) => ({
+            currency: total.currency,
+            monthlyEquivalentSpendCents: total.monthlyEquivalentSpendCents,
+          })),
+        })) ?? []
+      }
+      topCostDrivers={
+        payload?.topCostDrivers.map((driver) => ({
+          id: driver.id,
+          name: driver.name,
+          currency: driver.currency,
+          billingInterval: driver.billingInterval,
+          monthlyEquivalentAmountCents: driver.monthlyEquivalentAmountCents,
+          annualProjectionCents: driver.annualProjectionCents,
+          nextBillingDate: driver.nextBillingDate,
+        })) ?? []
+      }
+      upcomingCharges={
+        payload?.upcomingRenewals.map((subscription) => ({
+          id: subscription.id,
+          name: subscription.name,
+          isActive: subscription.isActive,
+          amountCents: subscription.amountCents,
+          currency: subscription.currency,
+          billingInterval: subscription.billingInterval,
+          paymentMethod: subscription.paymentMethod,
+          renewalDate: subscription.renewalDate,
+          createdAt: subscription.createdAt,
+          tag: subscription.tag,
+        })) ?? []
+      }
+    />
+  );
+}

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -24,6 +24,7 @@ import {
   filterDashboardUpcomingRenewals,
   type DashboardDateRangeValue,
 } from "@/lib/dashboard-controls";
+import type { DashboardRenderState } from "@/lib/dashboard-view-state";
 
 type DashboardUpcomingChargeListItem = {
   id: string;
@@ -110,6 +111,9 @@ type DashboardSectionsClientProps = {
       monthlyEquivalentSpendCents: number;
     }>;
   }>;
+  renderState?: DashboardRenderState;
+  loadErrorMessage?: string | null;
+  onRetryLoad?: () => void;
 };
 
 const UPCOMING_RENEWALS_VISIBLE_ROWS = 6;
@@ -397,6 +401,10 @@ function isInDateRange(value: string | null, now: Date, rangeDays: number): bool
   return deltaMs >= 0 && deltaMs <= maxMs;
 }
 
+function DashboardSkeletonLine({ className = "" }: { className?: string }) {
+  return <span aria-hidden="true" className={`dashboard-skeleton-line ${className}`.trim()} />;
+}
+
 export default function DashboardSectionsClient({
   availableCurrencies,
   kpis,
@@ -407,10 +415,17 @@ export default function DashboardSectionsClient({
   recentSubscriptions,
   monthlySpendTotalsByCurrency,
   spendBreakdownByCategory,
+  renderState,
+  loadErrorMessage,
+  onRetryLoad,
 }: DashboardSectionsClientProps) {
   const detailsModal = useSubscriptionDetailsModal();
   const spendBreakdownTitleId = useId();
   const spendBreakdownDescriptionId = useId();
+  const resolvedRenderState = renderState ?? (kpis ? "populated" : "loading");
+  const isLoading = resolvedRenderState === "loading";
+  const isError = resolvedRenderState === "error";
+  const controlsDisabled = isLoading;
   const [currency, setCurrency] = useState<string>(DASHBOARD_ALL_CURRENCIES);
   const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
   const [searchQuery, setSearchQuery] = useState("");
@@ -682,12 +697,25 @@ export default function DashboardSectionsClient({
 
   return (
     <>
-      <div className="dashboard-shell">
-        <article className="dashboard-card dashboard-controls-shell">
+      <div className="dashboard-shell" aria-busy={isLoading}>
+        <span className="visually-hidden" aria-live="polite" role="status">
+          {isLoading
+            ? "Dashboard content is loading."
+            : isError
+              ? "Dashboard failed to load."
+              : "Dashboard content loaded."}
+        </span>
+
+        <article aria-label="Dashboard filters and actions" className="dashboard-card dashboard-controls-shell">
           <div className="dashboard-control-grid">
             <label className="form-field" htmlFor="dashboard-currency-select">
               Currency
-              <select id="dashboard-currency-select" onChange={(event) => setCurrency(event.target.value)} value={currency}>
+              <select
+                disabled={controlsDisabled}
+                id="dashboard-currency-select"
+                onChange={(event) => setCurrency(event.target.value)}
+                value={currency}
+              >
                 <option value={DASHBOARD_ALL_CURRENCIES}>All currencies</option>
                 {currencyOptions.map((option) => (
                   <option key={option} value={option}>
@@ -699,6 +727,7 @@ export default function DashboardSectionsClient({
             <label className="form-field" htmlFor="dashboard-date-range-select">
               Date range
               <select
+                disabled={controlsDisabled}
                 id="dashboard-date-range-select"
                 onChange={(event) => setDateRange(event.target.value as DashboardDateRangeValue)}
                 value={dateRange}
@@ -713,6 +742,7 @@ export default function DashboardSectionsClient({
             <label className="form-field dashboard-search-control" htmlFor="dashboard-search-input">
               Search
               <input
+                disabled={controlsDisabled}
                 id="dashboard-search-input"
                 onChange={(event) => setSearchQuery(event.target.value)}
                 placeholder="Search name, payment method, or currency..."
@@ -722,37 +752,60 @@ export default function DashboardSectionsClient({
             </label>
           </div>
           <div className="dashboard-control-actions">
-            <Link className="button" href="/subscriptions">
+            <Link aria-disabled={controlsDisabled} className="button" href="/subscriptions" tabIndex={controlsDisabled ? -1 : undefined}>
               Add Subscription
             </Link>
           </div>
         </article>
 
+        {isError ? (
+          <div className="notice-error dashboard-error-banner" role="alert">
+            <span>{loadErrorMessage ?? "Unable to load dashboard data. Please try again."}</span>
+            {onRetryLoad ? (
+              <button className="button button-secondary button-small" onClick={onRetryLoad} type="button">
+                Retry
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
         <section className="dashboard-grid">
           <article className="dashboard-card">
             <h2>KPI Summary</h2>
-            <div className="metric-grid dashboard-kpi-grid">
-              <article className="metric-card" aria-live="polite" aria-busy={!kpis}>
-                <span className="metric-label">Monthly equivalent spend</span>
-                <strong className="metric-value">{monthlyEquivalentSpend.value}</strong>
-                <span className="metric-note">{monthlyEquivalentSpend.note}</span>
-              </article>
-              <article className="metric-card" aria-live="polite" aria-busy={!kpis}>
-                <span className="metric-label">Annual projection</span>
-                <strong className="metric-value">{annualProjection.value}</strong>
-                <span className="metric-note">{annualProjection.note}</span>
-              </article>
-              <article className="metric-card" aria-live="polite" aria-busy={!kpis}>
-                <span className="metric-label">Renewing in next 7 days</span>
-                <strong className="metric-value">{renewalsInNextSevenDays.value}</strong>
-                <span className="metric-note">{renewalsInNextSevenDays.note}</span>
-              </article>
-              <article className="metric-card" aria-live="polite" aria-busy={!kpis}>
-                <span className="metric-label">Active vs canceled subscriptions</span>
-                <strong className="metric-value">{activeVsCanceled.value}</strong>
-                <span className="metric-note">{activeVsCanceled.note}</span>
-              </article>
-            </div>
+            {isLoading ? (
+              <div className="metric-grid dashboard-kpi-grid" aria-hidden="true">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <article className="metric-card metric-card-skeleton" key={index}>
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="metric-grid dashboard-kpi-grid">
+                <article className="metric-card" aria-live="polite">
+                  <span className="metric-label">Monthly equivalent spend</span>
+                  <strong className="metric-value">{monthlyEquivalentSpend.value}</strong>
+                  <span className="metric-note">{monthlyEquivalentSpend.note}</span>
+                </article>
+                <article className="metric-card" aria-live="polite">
+                  <span className="metric-label">Annual projection</span>
+                  <strong className="metric-value">{annualProjection.value}</strong>
+                  <span className="metric-note">{annualProjection.note}</span>
+                </article>
+                <article className="metric-card" aria-live="polite">
+                  <span className="metric-label">Renewing in next 7 days</span>
+                  <strong className="metric-value">{renewalsInNextSevenDays.value}</strong>
+                  <span className="metric-note">{renewalsInNextSevenDays.note}</span>
+                </article>
+                <article className="metric-card" aria-live="polite">
+                  <span className="metric-label">Active vs canceled subscriptions</span>
+                  <strong className="metric-value">{activeVsCanceled.value}</strong>
+                  <span className="metric-note">{activeVsCanceled.note}</span>
+                </article>
+              </div>
+            )}
           </article>
         </section>
 
@@ -761,10 +814,35 @@ export default function DashboardSectionsClient({
             <div className="dashboard-card-header">
               <h2>Spend Breakdown</h2>
               <span className="metric-note">
-                {spendBreakdownCurrency ? `${spendBreakdownRows.length} categories` : "Select a currency"}
+                {isLoading
+                  ? "Loading categories..."
+                  : spendBreakdownCurrency
+                    ? `${spendBreakdownRows.length} categories`
+                    : "Select a currency"}
               </span>
             </div>
-            {!spendBreakdownCurrency ? (
+            {isLoading ? (
+              <div className="spend-breakdown-layout" aria-hidden="true">
+                <figure className="spend-donut-figure spend-donut-figure-skeleton">
+                  <span className="spend-donut-skeleton" />
+                  <figcaption className="spend-donut-total">
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                  </figcaption>
+                </figure>
+                <ul className="spend-legend spend-legend-skeleton">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <li className="spend-legend-item" key={index}>
+                      <span className="spend-legend-swatch dashboard-skeleton-swatch" />
+                      <div className="spend-legend-copy">
+                        <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                        <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : !spendBreakdownCurrency ? (
               <p className="text-muted">
                 Choose a specific currency to compare category spend when your dashboard contains multiple currencies.
               </p>
@@ -828,10 +906,10 @@ export default function DashboardSectionsClient({
                 </ul>
               </div>
             )}
-            {spendBreakdownCurrency && spendBreakdownRows.length === 1 ? (
+            {!isLoading && spendBreakdownCurrency && spendBreakdownRows.length === 1 ? (
               <p className="text-muted">Only one category currently contributes spend for these filters.</p>
             ) : null}
-            {spendBreakdownCurrency && !spendBreakdownReconciled ? (
+            {!isLoading && spendBreakdownCurrency && !spendBreakdownReconciled ? (
               <p className="text-muted" role="status">
                 Category totals ({formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}) differ from KPI total (
                 {formatMoney(spendBreakdownKpiTotalCents ?? 0, spendBreakdownCurrency)}).
@@ -841,9 +919,25 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Attention Needed</h2>
-              <span className="metric-note">{filteredAttentionNeeded.length} matching alerts</span>
+              <span className="metric-note">
+                {isLoading ? "Loading alerts..." : `${filteredAttentionNeeded.length} matching alerts`}
+              </span>
             </div>
-            {filteredAttentionNeeded.length === 0 ? (
+            {isLoading ? (
+              <div className="attention-list" aria-hidden="true">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <article className="attention-item attention-item-skeleton" key={index}>
+                    <div className="attention-item-header">
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                    </div>
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                  </article>
+                ))}
+              </div>
+            ) : filteredAttentionNeeded.length === 0 ? (
               <p className="text-muted">No attention alerts match the current control filters.</p>
             ) : (
               <div className="attention-list">
@@ -894,9 +988,42 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Upcoming Renewals</h2>
-              <span className="metric-note">{filteredUpcomingCharges.length} matching rows, sorted by soonest date</span>
+              <span className="metric-note">
+                {isLoading
+                  ? "Loading renewals..."
+                  : `${filteredUpcomingCharges.length} matching rows, sorted by soonest date`}
+              </span>
             </div>
-            {filteredUpcomingCharges.length === 0 ? (
+            {isLoading ? (
+              <div className="upcoming-renewals-table-shell" aria-hidden="true">
+                <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                <div className="upcoming-renewals-table-wrap">
+                  <table className="upcoming-renewals-table">
+                    <tbody>
+                      {Array.from({ length: 4 }).map((_, index) => (
+                        <tr key={index}>
+                          <td>
+                            <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                          </td>
+                          <td>
+                            <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                          </td>
+                          <td>
+                            <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                          </td>
+                          <td>
+                            <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                          </td>
+                          <td>
+                            <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : filteredUpcomingCharges.length === 0 ? (
               <p className="text-muted">No upcoming renewals match the current control filters.</p>
             ) : (
               <div className="upcoming-renewals-table-shell">
@@ -926,7 +1053,7 @@ export default function DashboardSectionsClient({
 
                         return (
                           <tr key={subscription.id}>
-                            <td data-label="Service">
+                            <th data-label="Service" scope="row">
                               <div className="renewal-service-cell">
                                 <span aria-hidden="true" className="renewal-service-icon">
                                   {logoSrc ? (
@@ -958,7 +1085,7 @@ export default function DashboardSectionsClient({
                                   {subscription.name}
                                 </button>
                               </div>
-                            </td>
+                            </th>
                             <td data-label="Renewal Date">{formatDate(subscription.renewalDate)}</td>
                             <td data-label="Amount/Cadence">
                               {formatMoney(subscription.amountCents, subscription.currency)}{" "}
@@ -1001,49 +1128,72 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Potential Savings</h2>
-              <span className="metric-note">{filteredSavingsOpportunities.length} matching opportunities</span>
+              <span className="metric-note">
+                {isLoading ? "Loading opportunities..." : `${filteredSavingsOpportunities.length} matching opportunities`}
+              </span>
             </div>
-            <article className="metric-card savings-summary-card">
-              <span className="metric-label">Estimated monthly savings</span>
-              <strong className="metric-value">{potentialSavingsSummary.value}</strong>
-              <span className="metric-note">{potentialSavingsSummary.note}</span>
-            </article>
-            {filteredSavingsOpportunities.length === 0 ? (
-              <p className="text-muted mt-sm">No savings opportunities match the current control filters.</p>
-            ) : (
-              <ul className="savings-opportunity-list">
-                {filteredSavingsOpportunities.map((opportunity) => {
-                  const singleSubscriptionId =
-                    opportunity.subscriptionIds.length === 1 ? opportunity.subscriptionIds[0] : null;
-
-                  return (
-                    <li className="savings-opportunity-item" key={opportunity.id}>
-                      <div className="savings-opportunity-header">
-                        <span className="pill savings-rule-pill">{formatSavingsOpportunityType(opportunity.type)}</span>
-                        <strong>{formatMoney(opportunity.estimatedMonthlySavingsCents, opportunity.currency)}/mo</strong>
-                      </div>
-                      <h3>{opportunity.title}</h3>
-                      <p className="text-muted">{opportunity.description}</p>
-                      {singleSubscriptionId ? (
-                        <button
-                          className="button button-secondary button-small"
-                          onClick={() =>
-                            void detailsModal.openModal({
-                              subscriptionId: singleSubscriptionId,
-                              source: "subscriptions_list",
-                            })
-                          }
-                          type="button"
-                        >
-                          View subscription
-                        </button>
-                      ) : null}
+            {isLoading ? (
+              <div aria-hidden="true" className="stack">
+                <article className="metric-card metric-card-skeleton savings-summary-card">
+                  <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
+                  <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                  <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                </article>
+                <ul className="savings-opportunity-list">
+                  {Array.from({ length: 2 }).map((_, index) => (
+                    <li className="savings-opportunity-item savings-opportunity-item-skeleton" key={index}>
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-sm" />
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
                     </li>
-                  );
-                })}
-              </ul>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <>
+                <article className="metric-card savings-summary-card">
+                  <span className="metric-label">Estimated monthly savings</span>
+                  <strong className="metric-value">{potentialSavingsSummary.value}</strong>
+                  <span className="metric-note">{potentialSavingsSummary.note}</span>
+                </article>
+                {filteredSavingsOpportunities.length === 0 ? (
+                  <p className="text-muted mt-sm">No savings opportunities match the current control filters.</p>
+                ) : (
+                  <ul className="savings-opportunity-list">
+                    {filteredSavingsOpportunities.map((opportunity) => {
+                      const singleSubscriptionId =
+                        opportunity.subscriptionIds.length === 1 ? opportunity.subscriptionIds[0] : null;
+
+                      return (
+                        <li className="savings-opportunity-item" key={opportunity.id}>
+                          <div className="savings-opportunity-header">
+                            <span className="pill savings-rule-pill">{formatSavingsOpportunityType(opportunity.type)}</span>
+                            <strong>{formatMoney(opportunity.estimatedMonthlySavingsCents, opportunity.currency)}/mo</strong>
+                          </div>
+                          <h3>{opportunity.title}</h3>
+                          <p className="text-muted">{opportunity.description}</p>
+                          {singleSubscriptionId ? (
+                            <button
+                              className="button button-secondary button-small"
+                              onClick={() =>
+                                void detailsModal.openModal({
+                                  subscriptionId: singleSubscriptionId,
+                                  source: "subscriptions_list",
+                                })
+                              }
+                              type="button"
+                            >
+                              View subscription
+                            </button>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </>
             )}
-            {potentialSavings.assumptions.length > 0 ? (
+            {!isLoading && potentialSavings.assumptions.length > 0 ? (
               <div className="savings-assumptions">
                 <span className="metric-note">Assumptions</span>
                 <ul>
@@ -1057,9 +1207,23 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Top Cost Drivers</h2>
-              <span className="metric-note">{filteredTopCostDrivers.length} matching rows</span>
+              <span className="metric-note">
+                {isLoading ? "Loading drivers..." : `${filteredTopCostDrivers.length} matching rows`}
+              </span>
             </div>
-            {filteredTopCostDrivers.length === 0 ? (
+            {isLoading ? (
+              <ol aria-hidden="true" className="cost-driver-list">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <li className="cost-driver-item cost-driver-item-skeleton" key={index}>
+                    <span className="cost-driver-rank" />
+                    <div className="cost-driver-copy">
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            ) : filteredTopCostDrivers.length === 0 ? (
               <p className="text-muted">No cost drivers match the current control filters.</p>
             ) : (
               <ol className="cost-driver-list">
@@ -1095,7 +1259,7 @@ export default function DashboardSectionsClient({
                 ))}
               </ol>
             )}
-            {topCostDriverCurrencyCount > 1 ? (
+            {!isLoading && topCostDriverCurrencyCount > 1 ? (
               <p className="text-muted mt-sm">Ranking is normalized to monthly amounts without FX conversion.</p>
             ) : null}
           </article>
@@ -1105,9 +1269,23 @@ export default function DashboardSectionsClient({
           <article className="dashboard-card">
             <div className="dashboard-card-header">
               <h2>Recent Activity</h2>
-              <span className="metric-note">{filteredRecentActivity.length} matching rows</span>
+              <span className="metric-note">
+                {isLoading ? "Loading activity..." : `${filteredRecentActivity.length} matching rows`}
+              </span>
             </div>
-            {filteredRecentActivity.length === 0 ? (
+            {isLoading ? (
+              <div className="stack" aria-hidden="true">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div className="status-item subscription-entry-button subscription-entry-skeleton" key={index}>
+                    <div className="subscription-header">
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
+                      <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
+                    </div>
+                    <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
+                  </div>
+                ))}
+              </div>
+            ) : filteredRecentActivity.length === 0 ? (
               <p className="text-muted">No recent subscriptions match the current control filters.</p>
             ) : (
               <div className="stack">

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -14,18 +14,23 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
   }
 
-  const data = await getDashboardPayloadForUser(user.id);
+  try {
+    const data = await getDashboardPayloadForUser(user.id);
 
-  return NextResponse.json(
-    {
-      data,
-      fetchedAt: new Date().toISOString(),
-    },
-    {
-      status: 200,
-      headers: {
-        "Cache-Control": "no-store",
+    return NextResponse.json(
+      {
+        data,
+        fetchedAt: new Date().toISOString(),
       },
-    },
-  );
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  } catch (error) {
+    console.error("Failed to build dashboard payload", error);
+    return NextResponse.json({ error: "Unable to load dashboard data." }, { status: 500 });
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -285,6 +285,7 @@ a {
   border-radius: 16px;
   box-shadow: var(--card-shadow);
   padding: 1.1rem 1.2rem;
+  min-width: 0;
 }
 
 .card h1,
@@ -312,6 +313,7 @@ a {
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 0.95rem 1rem;
+  min-width: 0;
 }
 
 .metric-label {
@@ -393,6 +395,10 @@ a {
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.dashboard-card-header > * {
+  min-width: 0;
 }
 
 .dashboard-card-header h2 {
@@ -483,6 +489,15 @@ a {
 .spend-legend-value {
   color: var(--text-muted);
   font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  flex-wrap: wrap;
 }
 
 .attention-list {
@@ -691,6 +706,85 @@ a {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.83rem;
+  overflow-wrap: anywhere;
+}
+
+.metric-card-skeleton,
+.attention-item-skeleton,
+.savings-opportunity-item-skeleton,
+.cost-driver-item-skeleton,
+.subscription-entry-skeleton {
+  pointer-events: none;
+}
+
+.dashboard-skeleton-line {
+  display: block;
+  width: 100%;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--panel-soft), var(--text) 7%) 0%,
+    color-mix(in srgb, var(--panel-soft), var(--text) 15%) 50%,
+    color-mix(in srgb, var(--panel-soft), var(--text) 7%) 100%
+  );
+  background-size: 200% 100%;
+  animation: dashboard-skeleton-shimmer 1.25s ease-in-out infinite;
+}
+
+.dashboard-skeleton-line-xs {
+  width: 34%;
+}
+
+.dashboard-skeleton-line-sm {
+  width: 52%;
+}
+
+.dashboard-skeleton-line-md {
+  width: 68%;
+}
+
+.dashboard-skeleton-line-lg {
+  width: 88%;
+}
+
+.dashboard-skeleton-swatch {
+  background: color-mix(in srgb, var(--panel-soft), var(--text) 12%);
+  box-shadow: none;
+}
+
+.spend-donut-figure-skeleton {
+  gap: 0.6rem;
+}
+
+.spend-donut-skeleton {
+  width: 160px;
+  height: 160px;
+  border-radius: 999px;
+  display: block;
+  border: 12px solid color-mix(in srgb, var(--panel-soft), var(--text) 10%);
+  animation: dashboard-skeleton-pulse 1.25s ease-in-out infinite;
+}
+
+@keyframes dashboard-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes dashboard-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.62;
+  }
+
+  50% {
+    opacity: 1;
+  }
 }
 
 .stack {
@@ -732,6 +826,12 @@ button:disabled,
 .button:disabled {
   opacity: 0.66;
   cursor: not-allowed;
+  transform: none;
+}
+
+.button[aria-disabled="true"] {
+  opacity: 0.66;
+  pointer-events: none;
   transform: none;
 }
 
@@ -1032,6 +1132,10 @@ button:disabled,
   border-bottom: 0;
 }
 
+.upcoming-renewals-table tbody tr:last-child th {
+  border-bottom: 0;
+}
+
 .upcoming-renewals-table tbody tr:hover {
   background: color-mix(in srgb, var(--panel-soft), var(--panel) 45%);
 }
@@ -1082,6 +1186,7 @@ button:disabled,
   padding: 0;
   text-align: left;
   justify-content: flex-start;
+  overflow-wrap: anywhere;
 }
 
 .renewal-service-button:hover {
@@ -1100,6 +1205,10 @@ button:disabled,
   align-items: center;
   gap: 0.46rem;
   flex-wrap: wrap;
+}
+
+.renewal-payment-cell .text-muted {
+  overflow-wrap: anywhere;
 }
 
 .payment-indicator {
@@ -1228,6 +1337,7 @@ button:disabled,
   .upcoming-renewals-table,
   .upcoming-renewals-table tbody,
   .upcoming-renewals-table tr,
+  .upcoming-renewals-table th,
   .upcoming-renewals-table td {
     display: block;
     width: 100%;
@@ -1251,6 +1361,21 @@ button:disabled,
     align-items: center;
   }
 
+  .upcoming-renewals-table th {
+    border-bottom: 0;
+    padding: 0.42rem 0.62rem;
+    display: grid;
+    grid-template-columns: minmax(110px, 38%) minmax(0, 1fr);
+    gap: 0.4rem;
+    align-items: center;
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 0.9rem;
+    color: var(--text);
+    background: transparent;
+  }
+
+  .upcoming-renewals-table th::before,
   .upcoming-renewals-table td::before {
     content: attr(data-label);
     font-size: 0.74rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,7 @@
 import Link from "next/link";
 
-import DashboardSectionsClient from "@/app/DashboardSectionsClient";
+import DashboardDataClient from "@/app/DashboardDataClient";
 import { getCurrentUser } from "@/lib/auth";
-import { getDashboardPayloadForUser } from "@/lib/dashboard";
 
 export default async function DashboardPage() {
   const user = await getCurrentUser();
@@ -48,24 +47,6 @@ export default async function DashboardPage() {
     );
   }
 
-  const dashboardPayload = await getDashboardPayloadForUser(user.id);
-  const availableCurrencies = [
-    ...new Set([
-      ...dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency),
-      ...dashboardPayload.spendBreakdownByCategory.flatMap((entry) =>
-        entry.totalsByCurrency.map((total) => total.currency),
-      ),
-      ...dashboardPayload.attentionNeeded
-        .map((entry) => entry.currency)
-        .filter((value): value is string => value !== null),
-      ...dashboardPayload.upcomingRenewals.map((entry) => entry.currency),
-      ...dashboardPayload.topCostDrivers.map((entry) => entry.currency),
-      ...dashboardPayload.potentialSavings.totalsByCurrency.map((entry) => entry.currency),
-      ...dashboardPayload.potentialSavings.opportunities.map((entry) => entry.currency),
-      ...dashboardPayload.recentSubscriptions.map((entry) => entry.currency),
-    ]),
-  ];
-
   return (
     <section className="page-stack">
       <header className="page-header">
@@ -78,80 +59,7 @@ export default async function DashboardPage() {
         </div>
       </header>
 
-      <DashboardSectionsClient
-        availableCurrencies={availableCurrencies}
-        attentionNeeded={dashboardPayload.attentionNeeded.map((item) => ({
-          id: item.id,
-          type: item.type,
-          severity: item.severity,
-          title: item.title,
-          message: item.message,
-          dueDate: item.dueDate,
-          subscriptionIds: item.subscriptionIds,
-          estimatedMonthlyImpactCents: item.estimatedMonthlyImpactCents,
-          currency: item.currency,
-        }))}
-        kpis={dashboardPayload.kpis}
-        monthlySpendTotalsByCurrency={dashboardPayload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => ({
-          currency: entry.currency,
-          monthlyEquivalentSpendCents: entry.monthlyEquivalentSpendCents,
-        }))}
-        potentialSavings={{
-          estimatedMonthlySavingsCents: dashboardPayload.potentialSavings.estimatedMonthlySavingsCents,
-          currency: dashboardPayload.potentialSavings.currency,
-          totalsByCurrency: dashboardPayload.potentialSavings.totalsByCurrency.map((entry) => ({
-            currency: entry.currency,
-            estimatedMonthlySavingsCents: entry.estimatedMonthlySavingsCents,
-          })),
-          opportunities: dashboardPayload.potentialSavings.opportunities.map((opportunity) => ({
-            id: opportunity.id,
-            type: opportunity.type,
-            title: opportunity.title,
-            description: opportunity.description,
-            currency: opportunity.currency,
-            estimatedMonthlySavingsCents: opportunity.estimatedMonthlySavingsCents,
-            subscriptionIds: opportunity.subscriptionIds,
-          })),
-          assumptions: dashboardPayload.potentialSavings.assumptions,
-        }}
-        recentSubscriptions={dashboardPayload.recentSubscriptions.map((subscription) => ({
-          id: subscription.id,
-          name: subscription.name,
-          isActive: subscription.isActive,
-          amountCents: subscription.amountCents,
-          currency: subscription.currency,
-          createdAt: subscription.createdAt,
-        }))}
-        topCostDrivers={dashboardPayload.topCostDrivers.map((driver) => ({
-          id: driver.id,
-          name: driver.name,
-          currency: driver.currency,
-          billingInterval: driver.billingInterval,
-          monthlyEquivalentAmountCents: driver.monthlyEquivalentAmountCents,
-          annualProjectionCents: driver.annualProjectionCents,
-          nextBillingDate: driver.nextBillingDate,
-        }))}
-        upcomingCharges={dashboardPayload.upcomingRenewals.map((subscription) => ({
-          id: subscription.id,
-          name: subscription.name,
-          isActive: subscription.isActive,
-          amountCents: subscription.amountCents,
-          currency: subscription.currency,
-          billingInterval: subscription.billingInterval,
-          paymentMethod: subscription.paymentMethod,
-          renewalDate: subscription.renewalDate,
-          createdAt: subscription.createdAt,
-          tag: subscription.tag,
-        }))}
-        spendBreakdownByCategory={dashboardPayload.spendBreakdownByCategory.map((category) => ({
-          category: category.category,
-          subscriptionCount: category.subscriptionCount,
-          totalsByCurrency: category.totalsByCurrency.map((total) => ({
-            currency: total.currency,
-            monthlyEquivalentSpendCents: total.monthlyEquivalentSpendCents,
-          })),
-        }))}
-      />
+      <DashboardDataClient />
     </section>
   );
 }

--- a/lib/dashboard-view-state.ts
+++ b/lib/dashboard-view-state.ts
@@ -1,0 +1,105 @@
+import type { DashboardPayload } from "@/lib/dashboard";
+
+export type DashboardRequestStatus = "loading" | "ready" | "error";
+
+export type DashboardRequestState = {
+  status: DashboardRequestStatus;
+  data: DashboardPayload | null;
+  errorMessage: string | null;
+};
+
+export type DashboardRequestEvent =
+  | {
+      type: "fetch_start";
+    }
+  | {
+      type: "fetch_success";
+      data: DashboardPayload;
+    }
+  | {
+      type: "fetch_error";
+      errorMessage: string;
+    };
+
+export type DashboardRenderState = "loading" | "empty" | "populated" | "error";
+
+export const INITIAL_DASHBOARD_REQUEST_STATE: DashboardRequestState = {
+  status: "loading",
+  data: null,
+  errorMessage: null,
+};
+
+export function hasDashboardContent(data: DashboardPayload): boolean {
+  if (data.kpis.subscriptions.total > 0) {
+    return true;
+  }
+
+  if (data.attentionNeeded.length > 0) {
+    return true;
+  }
+
+  if (data.upcomingRenewals.length > 0) {
+    return true;
+  }
+
+  if (data.topCostDrivers.length > 0) {
+    return true;
+  }
+
+  if (data.potentialSavings.opportunities.length > 0) {
+    return true;
+  }
+
+  if (data.recentSubscriptions.length > 0) {
+    return true;
+  }
+
+  if (data.spendBreakdownByCategory.some((category) => category.totalsByCurrency.length > 0)) {
+    return true;
+  }
+
+  return data.kpis.monthlyEquivalentSpend.totalsByCurrency.length > 0;
+}
+
+export function getDashboardRenderState(state: DashboardRequestState): DashboardRenderState {
+  if (state.status === "error" && state.data === null) {
+    return "error";
+  }
+
+  if (state.status === "loading" && state.data === null) {
+    return "loading";
+  }
+
+  if (state.data === null) {
+    return "empty";
+  }
+
+  return hasDashboardContent(state.data) ? "populated" : "empty";
+}
+
+export function reduceDashboardRequestState(
+  currentState: DashboardRequestState,
+  event: DashboardRequestEvent,
+): DashboardRequestState {
+  if (event.type === "fetch_start") {
+    return {
+      status: "loading",
+      data: currentState.data,
+      errorMessage: null,
+    };
+  }
+
+  if (event.type === "fetch_success") {
+    return {
+      status: "ready",
+      data: event.data,
+      errorMessage: null,
+    };
+  }
+
+  return {
+    status: "error",
+    data: currentState.data,
+    errorMessage: event.errorMessage,
+  };
+}

--- a/tests/dashboard/dashboard-view-state.test.ts
+++ b/tests/dashboard/dashboard-view-state.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { buildDashboardPayload, type DashboardSubscriptionSourceRecord } from "../../lib/dashboard";
+import {
+  getDashboardRenderState,
+  INITIAL_DASHBOARD_REQUEST_STATE,
+  reduceDashboardRequestState,
+} from "../../lib/dashboard-view-state";
+
+function makeSubscription(
+  overrides: Partial<DashboardSubscriptionSourceRecord> & Pick<DashboardSubscriptionSourceRecord, "id" | "name">,
+): DashboardSubscriptionSourceRecord {
+  const { id, name, ...rest } = overrides;
+
+  return {
+    amountCents: 1200,
+    currency: "usd",
+    billingInterval: "MONTHLY",
+    nextBillingDate: new Date("2026-03-20T00:00:00.000Z"),
+    isActive: true,
+    paymentMethod: "Visa 1234",
+    signedUpBy: null,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    ...rest,
+    id,
+    name,
+  };
+}
+
+describe("dashboard view state", () => {
+  test("covers loading, empty, populated, and error render states", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const emptyPayload = buildDashboardPayload([], now);
+    const populatedPayload = buildDashboardPayload([makeSubscription({ id: "github", name: "GitHub Team" })], now);
+
+    const loadingState = reduceDashboardRequestState(INITIAL_DASHBOARD_REQUEST_STATE, { type: "fetch_start" });
+    assert.equal(getDashboardRenderState(loadingState), "loading");
+
+    const emptyState = reduceDashboardRequestState(loadingState, {
+      type: "fetch_success",
+      data: emptyPayload,
+    });
+    assert.equal(getDashboardRenderState(emptyState), "empty");
+
+    const populatedState = reduceDashboardRequestState(emptyState, {
+      type: "fetch_success",
+      data: populatedPayload,
+    });
+    assert.equal(getDashboardRenderState(populatedState), "populated");
+
+    const errorState = reduceDashboardRequestState(INITIAL_DASHBOARD_REQUEST_STATE, {
+      type: "fetch_error",
+      errorMessage: "Unable to reach dashboard API.",
+    });
+    assert.equal(getDashboardRenderState(errorState), "error");
+  });
+
+  test("keeps populated state while refreshing to avoid unnecessary skeleton regressions", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const payload = buildDashboardPayload([makeSubscription({ id: "canva", name: "Canva Pro" })], now);
+
+    const readyState = reduceDashboardRequestState(INITIAL_DASHBOARD_REQUEST_STATE, {
+      type: "fetch_success",
+      data: payload,
+    });
+
+    const refreshingState = reduceDashboardRequestState(readyState, { type: "fetch_start" });
+
+    assert.equal(refreshingState.status, "loading");
+    assert.ok(refreshingState.data);
+    assert.equal(getDashboardRenderState(refreshingState), "populated");
+  });
+
+  test("retains previous payload after a fetch error", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+    const payload = buildDashboardPayload([makeSubscription({ id: "figma", name: "Figma Professional" })], now);
+
+    const readyState = reduceDashboardRequestState(INITIAL_DASHBOARD_REQUEST_STATE, {
+      type: "fetch_success",
+      data: payload,
+    });
+
+    const errorState = reduceDashboardRequestState(readyState, {
+      type: "fetch_error",
+      errorMessage: "Dashboard service timed out.",
+    });
+
+    assert.equal(errorState.status, "error");
+    assert.equal(errorState.errorMessage, "Dashboard service timed out.");
+    assert.equal(errorState.data?.kpis.subscriptions.total, 1);
+    assert.equal(getDashboardRenderState(errorState), "populated");
+  });
+});


### PR DESCRIPTION
## Summary
- add a client-side dashboard data loader with explicit `loading`, `empty`, `populated`, and `error` render states
- add section-level skeleton states for KPI cards, spend chart area, alerts, renewals table, and insight widgets
- harden accessibility and responsive behavior (table row headers, live status announcements, improved overflow handling)
- add deterministic dashboard view-state reducer + regression tests for core state transitions
- make `/api/dashboard` return a structured JSON error payload on server failures

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run test:dashboard`
- `npm run test:mail`
- `npm run test:invites`
- `npm run build`

Closes #38