### PR TITLE
Auto-apply default currency on Dashboard entry

### DIFF
--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -16,6 +16,10 @@ type DashboardApiResponse = {
   error?: string;
 };
 
+type DashboardDataClientProps = {
+  initialCurrency?: string | null;
+};
+
 function buildAvailableCurrencies(payload: DashboardPayload): string[] {
   return [
     ...new Set([
@@ -61,7 +65,7 @@ async function loadDashboardPayload(signal?: AbortSignal): Promise<DashboardPayl
   return parsedResponse.data;
 }
 
-export default function DashboardDataClient() {
+export default function DashboardDataClient({ initialCurrency }: DashboardDataClientProps) {
   const [requestState, setRequestState] = useState(INITIAL_DASHBOARD_REQUEST_STATE);
 
   const refreshDashboard = useCallback(async (signal?: AbortSignal) => {
@@ -125,6 +129,7 @@ export default function DashboardDataClient() {
         currency: item.currency,
       })) ?? []}
       availableCurrencies={availableCurrencies}
+      initialCurrency={initialCurrency}
       kpis={payload?.kpis ?? null}
       loadErrorMessage={requestState.errorMessage}
       monthlySpendTotalsByCurrency={

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -16,12 +16,14 @@ import type {
   DashboardUpcomingRenewalTag,
 } from "@/lib/dashboard";
 import {
+  buildDashboardCurrencyOptions,
   DASHBOARD_ALL_CURRENCIES,
   DASHBOARD_DATE_RANGE_OPTIONS,
   DEFAULT_DASHBOARD_DATE_RANGE,
   filterDashboardRecentActivity,
   mapDashboardSpendBreakdownByCurrency,
   filterDashboardUpcomingRenewals,
+  resolveInitialDashboardCurrency,
   type DashboardDateRangeValue,
 } from "@/lib/dashboard-controls";
 import type { DashboardRenderState } from "@/lib/dashboard-view-state";
@@ -111,6 +113,7 @@ type DashboardSectionsClientProps = {
       monthlyEquivalentSpendCents: number;
     }>;
   }>;
+  initialCurrency?: string | null;
   renderState?: DashboardRenderState;
   loadErrorMessage?: string | null;
   onRetryLoad?: () => void;
@@ -415,6 +418,7 @@ export default function DashboardSectionsClient({
   recentSubscriptions,
   monthlySpendTotalsByCurrency,
   spendBreakdownByCategory,
+  initialCurrency,
   renderState,
   loadErrorMessage,
   onRetryLoad,
@@ -426,7 +430,7 @@ export default function DashboardSectionsClient({
   const isLoading = resolvedRenderState === "loading";
   const isError = resolvedRenderState === "error";
   const controlsDisabled = isLoading;
-  const [currency, setCurrency] = useState<string>(DASHBOARD_ALL_CURRENCIES);
+  const [currency, setCurrency] = useState<string>(() => resolveInitialDashboardCurrency(initialCurrency));
   const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
   const [searchQuery, setSearchQuery] = useState("");
   const [showAllUpcomingRenewals, setShowAllUpcomingRenewals] = useState(false);
@@ -586,21 +590,7 @@ export default function DashboardSectionsClient({
   const topCostDriverCurrencyCount = useMemo(() => {
     return new Set(filteredTopCostDrivers.map((driver) => driver.currency.toUpperCase())).size;
   }, [filteredTopCostDrivers]);
-  const currencyOptions = useMemo(() => {
-    const normalized = [
-      ...new Set(
-        availableCurrencies
-          .map((value) => value.trim().toUpperCase())
-          .filter((value) => value.length > 0),
-      ),
-    ].sort((first, second) => first.localeCompare(second));
-
-    if (!normalized.includes("USD")) {
-      return normalized;
-    }
-
-    return ["USD", ...normalized.filter((value) => value !== "USD")];
-  }, [availableCurrencies]);
+  const currencyOptions = useMemo(() => buildDashboardCurrencyOptions(availableCurrencies, currency), [availableCurrencies, currency]);
   const monthlyEquivalentSpend = buildSpendMetricContent(kpis?.monthlyEquivalentSpend, "monthly");
   const annualProjection = buildSpendMetricContent(kpis?.annualProjection, "annual");
   const renewalsInNextSevenDays: KpiCardContent = !kpis

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import DashboardDataClient from "@/app/DashboardDataClient";
 import { getCurrentUser } from "@/lib/auth";
+import { db } from "@/lib/db";
 
 export default async function DashboardPage() {
   const user = await getCurrentUser();
@@ -47,6 +48,15 @@ export default async function DashboardPage() {
     );
   }
 
+  const settings = await db.userSettings.findUnique({
+    where: {
+      userId: user.id,
+    },
+    select: {
+      defaultCurrency: true,
+    },
+  });
+
   return (
     <section className="page-stack">
       <header className="page-header">
@@ -59,7 +69,7 @@ export default async function DashboardPage() {
         </div>
       </header>
 
-      <DashboardDataClient />
+      <DashboardDataClient initialCurrency={settings?.defaultCurrency ?? null} />
     </section>
   );
 }

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -58,6 +58,42 @@ export type DashboardSpendBreakdownRow = {
   color: string;
 };
 
+function normalizeCurrencyCode(value: string | null | undefined): string | null {
+  const normalized = String(value ?? "").trim().toUpperCase();
+
+  if (!/^[A-Z]{3}$/.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function resolveInitialDashboardCurrency(defaultCurrency: string | null | undefined): string {
+  if (String(defaultCurrency ?? "").trim().toLowerCase() === DASHBOARD_ALL_CURRENCIES) {
+    return DASHBOARD_ALL_CURRENCIES;
+  }
+
+  return normalizeCurrencyCode(defaultCurrency) ?? DASHBOARD_ALL_CURRENCIES;
+}
+
+export function buildDashboardCurrencyOptions(availableCurrencies: string[], selectedCurrency: string): string[] {
+  const normalizedCurrencies = [
+    ...new Set(availableCurrencies.map((value) => normalizeCurrencyCode(value)).filter((value): value is string => value !== null)),
+  ].sort((first, second) => first.localeCompare(second));
+  const normalizedSelectedCurrency = normalizeCurrencyCode(selectedCurrency);
+
+  if (normalizedSelectedCurrency && !normalizedCurrencies.includes(normalizedSelectedCurrency)) {
+    normalizedCurrencies.push(normalizedSelectedCurrency);
+    normalizedCurrencies.sort((first, second) => first.localeCompare(second));
+  }
+
+  if (!normalizedCurrencies.includes("USD")) {
+    return normalizedCurrencies;
+  }
+
+  return ["USD", ...normalizedCurrencies.filter((value) => value !== "USD")];
+}
+
 function toNormalizedSearchQuery(value: string): string {
   return value.trim().toLowerCase();
 }

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -2,17 +2,31 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
 import {
+  buildDashboardCurrencyOptions,
   DASHBOARD_ALL_CURRENCIES,
   DEFAULT_DASHBOARD_DATE_RANGE,
   filterDashboardRecentActivity,
   filterDashboardUpcomingRenewals,
   getDashboardCategoryColor,
   mapDashboardSpendBreakdownByCurrency,
+  resolveInitialDashboardCurrency,
 } from "../../lib/dashboard-controls";
 
 describe("dashboard controls filtering", () => {
   test("uses last 30 days as the default date range", () => {
     assert.equal(DEFAULT_DASHBOARD_DATE_RANGE, "30d");
+  });
+
+  test("resolves dashboard initial currency from user default", () => {
+    assert.equal(resolveInitialDashboardCurrency("aud"), "AUD");
+    assert.equal(resolveInitialDashboardCurrency(""), DASHBOARD_ALL_CURRENCIES);
+    assert.equal(resolveInitialDashboardCurrency("all"), DASHBOARD_ALL_CURRENCIES);
+  });
+
+  test("builds currency options with selected currency and USD priority", () => {
+    const options = buildDashboardCurrencyOptions(["aud", " eur ", "usd", "AUD"], "cad");
+
+    assert.deepEqual(options, ["USD", "AUD", "CAD", "EUR"]);
   });
 
   test("filters upcoming renewals by currency, search, and upcoming date window", () => {


### PR DESCRIPTION
Closes #57

## Summary
- read the authenticated user’s `defaultCurrency` from `userSettings` on Dashboard page load
- pass that value into dashboard client components as the initial currency selection
- initialize dashboard currency control from the user default instead of always `All currencies`
- ensure currency options include the currently selected currency and keep USD prioritized in the list

## Tests
- `npm run test:dashboard`
- `npm run typecheck`