### PR TITLE
Fix edit subscription modal not closing after successful save

### DIFF
--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -39,6 +39,7 @@ type SubscriptionsClientProps = {
   paymentMethodSuggestions: string[];
   signedUpBySuggestions: string[];
   resultMessage: ActionResultMessage | null;
+  updateSuccessToken: string | null;
   createAction: (formData: FormData) => Promise<void>;
   updateAction: (formData: FormData) => Promise<void>;
   deactivateAction: (formData: FormData) => Promise<void>;
@@ -114,6 +115,7 @@ export default function SubscriptionsClient({
   paymentMethodSuggestions,
   signedUpBySuggestions,
   resultMessage,
+  updateSuccessToken,
   createAction,
   updateAction,
   deactivateAction,
@@ -227,6 +229,14 @@ export default function SubscriptionsClient({
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
   }, [isAddModalOpen, editingSubscriptionId]);
+
+  useEffect(() => {
+    if (!updateSuccessToken) {
+      return;
+    }
+
+    setEditingSubscriptionId(null);
+  }, [updateSuccessToken]);
 
   return (
     <section className="page-stack">

--- a/app/subscriptions/actions.ts
+++ b/app/subscriptions/actions.ts
@@ -251,7 +251,7 @@ export async function updateSubscriptionAction(formData: FormData): Promise<void
     redirect("/subscriptions?error=not_found");
   }
 
-  redirect("/subscriptions?result=updated");
+  redirect(`/subscriptions?result=updated&eventId=${Date.now()}`);
 }
 
 export async function deactivateSubscriptionAction(formData: FormData): Promise<void> {

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -12,6 +12,7 @@ type SubscriptionsPageProps = {
   searchParams?: {
     error?: string;
     result?: string;
+    eventId?: string;
   };
 };
 
@@ -68,9 +69,19 @@ function getResultMessage(searchParams?: SubscriptionsPageProps["searchParams"])
   return null;
 }
 
+function getUpdateSuccessToken(searchParams?: SubscriptionsPageProps["searchParams"]): string | null {
+  if (searchParams?.result !== "updated") {
+    return null;
+  }
+
+  const eventId = searchParams.eventId?.trim();
+  return eventId && eventId.length > 0 ? eventId : "updated";
+}
+
 export default async function SubscriptionsPage({ searchParams }: SubscriptionsPageProps) {
   const user = await requireAuthenticatedUser();
   const resultMessage = getResultMessage(searchParams);
+  const updateSuccessToken = getUpdateSuccessToken(searchParams);
   const [subscriptions, paymentMethodSuggestions, signedUpBySuggestions] = await Promise.all([
     db.subscription.findMany({
       where: {
@@ -112,6 +123,7 @@ export default async function SubscriptionsPage({ searchParams }: SubscriptionsP
       createAction={createSubscriptionAction}
       deactivateAction={deactivateSubscriptionAction}
       resultMessage={resultMessage}
+      updateSuccessToken={updateSuccessToken}
       subscriptions={subscriptions.map((subscription) => ({
         id: subscription.id,
         name: subscription.name,


### PR DESCRIPTION
## Summary
- add a success event token to the update subscription redirect URL
- thread that token through `/subscriptions` page props into `SubscriptionsClient`
- close the edit subscription modal when a successful update token is received

## Why
Issue #11 reports that `Save Changes` updates the subscription but leaves the edit modal open. The modal now closes only after a successful update result is returned.

## Validation
- `npm run typecheck`
- `npm run lint`

Closes #11