### PR TITLE
Issue #21: wire invite issuance to invitation email flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Useful commands:
   - `mock` provider for automated tests (`MAIL_PROVIDER=mock`)
 - Email templates are authored with React Email in `lib/mail/templates/`:
   - test email
+  - invite issuance
   - registration verification (template only)
   - subscription reminder (template only)
 - Manual validation workflow:
@@ -160,6 +161,7 @@ Useful commands:
   - use `Send Test Email` to send to the authenticated account email
   - endpoint is rate-limited to 3 sends per user per hour
 - Delivery attempts are recorded in Prisma `EmailDeliveryLog` (`SENT`, `FAILED`, `SKIPPED`).
+- Invite issuance from `/tools` attempts immediate email delivery and falls back to manual share when provider is unavailable or send fails.
 - Daily maintenance prunes stale email logs using `EMAIL_DELIVERY_LOG_RETENTION_DAYS`.
 - Local template preview command:
   - `npm run email:dev`
@@ -245,6 +247,7 @@ Open http://localhost:3000.
 - Optional invitation-only mode:
   - set `INVITES_REQUIRED=true` to require valid invite token on sign-up.
   - invite token must be pending, unexpired, and tied to the same normalized email.
+  - `/tools` invite issuance now issues and attempts email send in one step; if email cannot be sent, manual token/URL share remains available.
   - keep `INVITES_REQUIRED=false` for rollback to open sign-up.
 - Sign in at `/auth/sign-in`.
 - Session is stored as an HTTP-only cookie with an opaque token backed by the `Session` database table.

--- a/app/tools/InviteIssuanceCard.tsx
+++ b/app/tools/InviteIssuanceCard.tsx
@@ -20,7 +20,7 @@ function IssueInviteSubmitButton(): JSX.Element {
 
   return (
     <button disabled={pending} type="submit">
-      {pending ? "Issuing Invite..." : "Issue Invite"}
+      {pending ? "Issuing Invite..." : "Issue + Send Invite"}
     </button>
   );
 }
@@ -30,8 +30,10 @@ export default function InviteIssuanceCard({ issueInviteAction }: InviteIssuance
 
   return (
     <article className="surface surface-soft">
-      <h2>Issue Invitation Link</h2>
-      <p className="text-muted">Create a single-use invite token for manual sharing. Raw tokens are never stored.</p>
+      <h2>Issue Invitation Email</h2>
+      <p className="text-muted">
+        Create a single-use invite token and send it in one step. If delivery fails, manual share fallback is shown.
+      </p>
 
       <form action={formAction} className="mt-md form-grid">
         <label className="form-field">
@@ -58,7 +60,17 @@ export default function InviteIssuanceCard({ issueInviteAction }: InviteIssuance
 
       {state.status === "success" ? (
         <div className="stack mt-md" aria-live="polite">
-          <p className="status-help">{state.message}</p>
+          <p className={state.inviteEmailOutcome === "failed" ? "status-error" : "status-help"}>
+            {state.message}
+          </p>
+          {state.inviteEmailOutcome !== "sent" ? (
+            <p className="text-muted">
+              Email fallback is active. Share the one-time token or full invite URL below.
+            </p>
+          ) : null}
+          {state.inviteEmailOutcome === "failed" && state.inviteEmailError ? (
+            <p className="text-muted">Send error: {state.inviteEmailError}</p>
+          ) : null}
           <p className="text-muted">
             Email: <strong>{state.email}</strong>
             <br />

--- a/app/tools/actions.ts
+++ b/app/tools/actions.ts
@@ -11,6 +11,7 @@ import {
   parseInviteExpiryDays,
 } from "@/lib/invites";
 import { isInvitesRequired } from "@/lib/env";
+import { sendInviteEmail } from "@/lib/mail";
 import { runDailyMaintenanceJobs } from "@/lib/maintenance";
 
 export type InviteIssuanceActionState =
@@ -29,6 +30,8 @@ export type InviteIssuanceActionState =
       inviteToken: string;
       inviteUrl: string;
       rotatedExistingInvite: boolean;
+      inviteEmailOutcome: "sent" | "skipped" | "failed";
+      inviteEmailError: string | null;
     };
 
 async function isSameOriginRequest(): Promise<boolean> {
@@ -118,17 +121,33 @@ export async function issueInviteAction(
       createdByUserId: user.id,
       baseUrl,
     });
+    const inviteEmailResult = await sendInviteEmail({
+      to: result.email,
+      userId: user.id,
+      inviteUrl: result.inviteUrl,
+      expiresAt: new Date(result.expiresAt),
+    });
+    const issuanceMessage = result.rotatedExistingInvite
+      ? "Invite issued, previous pending invite rotated."
+      : "Invite issued successfully.";
+
+    const message =
+      inviteEmailResult.outcome === "sent"
+        ? `${issuanceMessage} Invitation email sent to ${result.email}.`
+        : inviteEmailResult.outcome === "skipped"
+          ? `${issuanceMessage} Email provider is unavailable, so share the invite link manually.`
+          : `${issuanceMessage} Invite email failed, so share the invite link manually.`;
 
     return {
       status: "success",
-      message: result.rotatedExistingInvite
-        ? "Invite issued and previous pending invite was rotated."
-        : "Invite issued successfully.",
+      message,
       email: result.email,
       expiresAt: result.expiresAt,
       inviteToken: result.inviteToken,
       inviteUrl: result.inviteUrl,
       rotatedExistingInvite: result.rotatedExistingInvite,
+      inviteEmailOutcome: inviteEmailResult.outcome,
+      inviteEmailError: inviteEmailResult.error,
     };
   } catch (error) {
     if (error instanceof InviteIssuanceRateLimitError) {

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -98,7 +98,7 @@ export default async function ToolsPage({ searchParams }: ToolsPageProps) {
           <InviteIssuanceCard issueInviteAction={issueInviteAction} />
         ) : (
           <article className="surface surface-soft">
-            <h2>Issue Invitation Link</h2>
+            <h2>Issue Invitation Email</h2>
             <p className="text-muted">
               Invitation issuance is disabled because <code>INVITES_REQUIRED=false</code>.
             </p>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Main concerns:
 - `/auth/sign-in`, `/auth/sign-up` (server-action forms; sign-up accepts optional `invite` token context).
 - `/subscriptions` (authenticated).
 - `/settings` (authenticated; action-first settings UI with inline auto-save for simple preferences and modal edit flow for account details).
-- `/tools` (authenticated maintenance + invite issuance actions).
+- `/tools` (authenticated maintenance + invite issuance and invite-email actions with manual-share fallback).
 - `/status` (human-readable operational status).
 - `/api/status` (machine-readable operational status).
 - `/api/mail/test` (authenticated test-email send, rate-limited per user).
@@ -149,7 +149,8 @@ Status payload also includes email readiness:
 1. Provider abstraction and runtime selection (`resend`, `console`, `mock`).
 2. React Email template rendering (`lib/mail/templates`).
 3. `sendEmail` logging into `EmailDeliveryLog` for all attempts.
-4. Rate-limit helper for `/api/mail/test` (3 sends per user per hour).
+4. `sendInviteEmail` helper for invite issuance delivery (`invite_issuance` template) with explicit `sent`/`skipped`/`failed` outcomes.
+5. Rate-limit helper for `/api/mail/test` (3 sends per user per hour).
 
 Current guarantees:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -64,6 +64,7 @@ Email service:
 - Current production expectation uses Resend free-tier limits (100/day, 3,000/month); monitor volume growth before expanding automated reminder sends.
 - Test endpoint: `POST /api/mail/test` (authenticated, 3 requests/user/hour).
 - Readiness is exposed at `/api/status` and `/status` under the `email` section.
+- Invite issuance at `/tools` sends `invite_issuance` email attempts through the same logging path; if provider is `console` or send fails, operators should manually share the one-time invite URL/token shown in UI.
 
 ## Common runbook
 
@@ -88,8 +89,9 @@ Email service:
 4. Verify session cleanup endpoint health:
    - ensure cron requests succeed in Vercel logs.
 5. If invite-only onboarding is enabled:
-   - verify `/tools` invite issuance succeeds for authenticated operators.
+   - verify `/tools` invite issuance succeeds for authenticated operators and reports invite email send outcome.
    - confirm sign-up rejects missing/invalid invite tokens.
+   - verify `EmailDeliveryLog` writes `invite_issuance` rows for invite send attempts.
 6. Verify email health path:
    - trigger `Send Test Email` from `/tools` as an authenticated user.
    - confirm `EmailDeliveryLog` row is written with expected status.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -28,8 +28,9 @@ Auth:
 7. Confirm sign-in rejects cross-origin requests (invalid request path).
 8. If `INVITES_REQUIRED=true`, confirm sign-up rejects missing invite token with safe generic error.
 9. From `/tools`, issue an invite for `invite-test@example.com`; complete sign-up using invite link and matching email.
-10. Retry sign-up with the same invite token and confirm rejection.
-11. Issue invite for one email and attempt sign-up with different email; confirm rejection.
+10. Confirm invite issuance reports email send status in `/tools`; if provider is unavailable, confirm fallback message instructs manual share.
+11. Retry sign-up with the same invite token and confirm rejection.
+12. Issue invite for one email and attempt sign-up with different email; confirm rejection.
 
 Subscriptions UX:
 
@@ -87,6 +88,8 @@ Email:
 2. Confirm success response instructs to check inbox/spam.
 3. Trigger 4 sends within one hour and confirm the fourth request is rate-limited.
 4. In Prisma Studio, verify `EmailDeliveryLog` rows are created with expected `templateName` and `status`.
+5. From `/tools`, issue an invite and verify an `EmailDeliveryLog` entry with `templateName=invite_issuance` is created.
+6. Disable provider key (or force `MAIL_PROVIDER=console`) and issue another invite; confirm `/tools` shows fallback/manual-share status while still returning token/URL.
 
 Deploy:
 

--- a/lib/mail/index.ts
+++ b/lib/mail/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./config";
 import { clearMockEmailLog, createMailProvider, getMockEmailLog } from "./providers";
 import {
+  renderInviteIssuanceTemplate,
   renderRegistrationVerificationTemplate,
   renderSubscriptionReminderTemplate,
   renderTestEmailTemplate,
@@ -66,11 +67,11 @@ function resolveDeliveryStatus(provider: MailProviderName, result: EmailResult):
     return EmailDeliveryStatus.FAILED;
   }
 
-  if (provider === "resend") {
-    return EmailDeliveryStatus.SENT;
+  if (provider === "console") {
+    return EmailDeliveryStatus.SKIPPED;
   }
 
-  return EmailDeliveryStatus.SKIPPED;
+  return EmailDeliveryStatus.SENT;
 }
 
 function normalizeRecipientEmail(value: string): string {
@@ -197,6 +198,74 @@ export async function sendSubscriptionReminderEmail(input: {
     templateName: rendered.templateName,
     userId: input.userId,
   });
+}
+
+export type InviteEmailSendOutcome = "sent" | "skipped" | "failed";
+
+export type InviteEmailSendResult = {
+  outcome: InviteEmailSendOutcome;
+  provider: MailProviderName;
+  messageId: string | null;
+  error: string | null;
+};
+
+type SendInviteEmailDependencies = {
+  providerName?: MailProviderName;
+  sendEmailFn?: (payload: EmailPayload) => Promise<EmailResult>;
+};
+
+export async function sendInviteEmail(
+  input: {
+    to: string;
+    userId?: string;
+    inviteUrl: string;
+    expiresAt: Date;
+    appName?: string;
+  },
+  dependencies: SendInviteEmailDependencies = {},
+): Promise<InviteEmailSendResult> {
+  const rendered = await renderInviteIssuanceTemplate({
+    appName: input.appName,
+    recipientEmail: input.to,
+    inviteUrl: input.inviteUrl,
+    expiresAt: input.expiresAt,
+  });
+
+  const providerName = dependencies.providerName ?? getMailProvider();
+  const sendEmailFn = dependencies.sendEmailFn ?? sendEmail;
+  const result = await sendEmailFn({
+    to: input.to,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+    templateName: rendered.templateName,
+    userId: input.userId,
+  });
+
+  if (!result.success) {
+    return {
+      outcome: "failed",
+      provider: providerName,
+      messageId: result.messageId ?? null,
+      error: result.error ?? "Unknown email send failure.",
+    };
+  }
+
+  if (providerName === "console") {
+    return {
+      outcome: "skipped",
+      provider: providerName,
+      messageId: result.messageId ?? null,
+      error: null,
+    };
+  }
+
+  return {
+    outcome: "sent",
+    provider: providerName,
+    messageId: result.messageId ?? null,
+    error: null,
+  };
 }
 
 export type TestEmailRateLimitState = {

--- a/lib/mail/templates/InviteIssuanceEmail.tsx
+++ b/lib/mail/templates/InviteIssuanceEmail.tsx
@@ -3,10 +3,11 @@ import { Button, Heading, Link, Text } from "@react-email/components";
 
 import EmailLayout from "./Layout";
 
-type RegistrationVerificationEmailTemplateProps = {
+type InviteIssuanceEmailTemplateProps = {
   appName: string;
-  verificationUrl: string;
-  expiresInMinutes: number;
+  recipientEmail: string;
+  inviteUrl: string;
+  expiresAt: string;
 };
 
 const buttonStyle = {
@@ -20,33 +21,31 @@ const buttonStyle = {
   padding: "12px 18px",
 };
 
-export default function RegistrationVerificationEmailTemplate({
+export default function InviteIssuanceEmailTemplate({
   appName,
-  verificationUrl,
-  expiresInMinutes,
-}: RegistrationVerificationEmailTemplateProps) {
+  recipientEmail,
+  inviteUrl,
+  expiresAt,
+}: InviteIssuanceEmailTemplateProps) {
   return (
-    <EmailLayout
-      appName={appName}
-      previewText={`Verify your ${appName} account email address.`}
-    >
+    <EmailLayout appName={appName} previewText={`Your ${appName} invite is ready.`}>
       <Heading style={{ margin: "0 0 14px 0", fontSize: "24px", lineHeight: "1.3" }}>
-        Verify your email address
+        You are invited to {appName}
       </Heading>
       <Text style={{ margin: "0 0 12px 0", fontSize: "15px", lineHeight: "1.6" }}>
-        Confirm ownership of this inbox to activate your {appName} account.
+        This invite was issued for <strong>{recipientEmail}</strong>. Use the link below to complete sign-up.
       </Text>
-      <Button href={verificationUrl} style={buttonStyle}>
-        Verify email
+      <Button href={inviteUrl} style={buttonStyle}>
+        Accept invite
       </Button>
       <Text style={{ margin: "14px 0 0 0", fontSize: "14px", lineHeight: "1.6" }}>
-        This link expires in {expiresInMinutes} minutes.
+        This invite expires on {expiresAt}.
       </Text>
       <Text style={{ margin: "14px 0 0 0", fontSize: "13px", lineHeight: "1.6" }}>
         If the button does not work, open this URL:
       </Text>
       <Text style={{ margin: "4px 0 0 0", fontSize: "13px", lineHeight: "1.6" }}>
-        <Link href={verificationUrl}>{verificationUrl}</Link>
+        <Link href={inviteUrl}>{inviteUrl}</Link>
       </Text>
     </EmailLayout>
   );

--- a/lib/mail/templates/Layout.tsx
+++ b/lib/mail/templates/Layout.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import {
   Body,
   Container,

--- a/lib/mail/templates/SubscriptionReminderEmail.tsx
+++ b/lib/mail/templates/SubscriptionReminderEmail.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Heading, Section, Text } from "@react-email/components";
 
 import EmailLayout from "./Layout";

--- a/lib/mail/templates/TestEmail.tsx
+++ b/lib/mail/templates/TestEmail.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Heading, Text } from "@react-email/components";
 
 import EmailLayout from "./Layout";

--- a/lib/mail/templates/index.tsx
+++ b/lib/mail/templates/index.tsx
@@ -1,5 +1,7 @@
+import * as React from "react";
 import { render } from "@react-email/render";
 
+import InviteIssuanceEmailTemplate from "./InviteIssuanceEmail";
 import RegistrationVerificationEmailTemplate from "./RegistrationVerificationEmail";
 import SubscriptionReminderEmailTemplate, {
   type SubscriptionReminderItem,
@@ -25,6 +27,13 @@ function formatCurrency(amountCents: number, currency: string): string {
 function formatDate(value: Date): string {
   return new Intl.DateTimeFormat("en-US", {
     dateStyle: "medium",
+  }).format(value);
+}
+
+function formatDateTime(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
   }).format(value);
 }
 
@@ -79,6 +88,30 @@ export async function renderRegistrationVerificationTemplate(input: {
     subject,
     ...rendered,
     templateName: "registration_verification",
+  };
+}
+
+export async function renderInviteIssuanceTemplate(input: {
+  appName?: string;
+  recipientEmail: string;
+  inviteUrl: string;
+  expiresAt: Date;
+}): Promise<RenderedEmailTemplate> {
+  const appName = input.appName ?? DEFAULT_APP_NAME;
+  const subject = `${appName}: your invite link`;
+  const rendered = await renderTemplate(
+    <InviteIssuanceEmailTemplate
+      appName={appName}
+      recipientEmail={input.recipientEmail}
+      inviteUrl={input.inviteUrl}
+      expiresAt={formatDateTime(input.expiresAt)}
+    />,
+  );
+
+  return {
+    subject,
+    ...rendered,
+    templateName: "invite_issuance",
   };
 }
 

--- a/tests/invites/invite-flow.test.ts
+++ b/tests/invites/invite-flow.test.ts
@@ -10,6 +10,7 @@ import {
   hashInviteToken,
   issueInvite,
 } from "../../lib/invites";
+import { sendInviteEmail } from "../../lib/mail";
 
 const createdEmails = new Set<string>();
 
@@ -37,6 +38,14 @@ async function cleanupCreatedRecords(): Promise<void> {
   await db.user.deleteMany({
     where: {
       email: {
+        in: emails,
+      },
+    },
+  });
+
+  await db.emailDeliveryLog.deleteMany({
+    where: {
+      recipientEmail: {
         in: emails,
       },
     },
@@ -316,6 +325,65 @@ describe("invite flow", () => {
           return error.retryAfterSeconds > 0;
         },
       );
+  });
+
+  test("logs invite email sends with invite_issuance template name", async () => {
+      const previousMailProvider = process.env.MAIL_PROVIDER;
+      process.env.MAIL_PROVIDER = "mock";
+
+      try {
+        const operatorEmail = uniqueEmail("operator");
+        const targetEmail = uniqueEmail("invitee");
+
+        const operator = await db.user.create({
+          data: {
+            email: operatorEmail.toLowerCase(),
+            passwordHash: hashPassword("operator-password"),
+            settings: {
+              create: {},
+            },
+          },
+          select: { id: true },
+        });
+
+        const issued = await issueInvite({
+          email: targetEmail,
+          expiresInDays: 7,
+          createdByUserId: operator.id,
+          baseUrl: "http://localhost:3000",
+        });
+
+        const sendResult = await sendInviteEmail({
+          to: issued.email,
+          userId: operator.id,
+          inviteUrl: issued.inviteUrl,
+          expiresAt: new Date(issued.expiresAt),
+        });
+
+        assert.equal(sendResult.outcome, "sent");
+
+        const logEntry = await db.emailDeliveryLog.findFirst({
+          where: {
+            recipientEmail: issued.email,
+            templateName: "invite_issuance",
+          },
+          orderBy: {
+            createdAt: "desc",
+          },
+          select: {
+            status: true,
+            errorMessage: true,
+            userId: true,
+          },
+        });
+
+        assert.ok(logEntry);
+        assert.equal(logEntry.status, "SENT");
+        assert.equal(logEntry.errorMessage, null);
+        assert.equal(logEntry.userId, operator.id);
+      } finally {
+        process.env.MAIL_PROVIDER = previousMailProvider;
+      }
   });
 });
 

--- a/tests/mail/invite-email.test.ts
+++ b/tests/mail/invite-email.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { sendInviteEmail } from "../../lib/mail";
+
+describe("sendInviteEmail", () => {
+  test("returns sent outcome for mock provider and uses invite template payload", async () => {
+    let capturedTemplateName = "";
+    let capturedSubject = "";
+
+    const result = await sendInviteEmail(
+      {
+        to: "invitee@example.com",
+        userId: "user-123",
+        inviteUrl: "https://example.com/auth/sign-up?invite=abc123",
+        expiresAt: new Date("2026-03-20T10:00:00.000Z"),
+      },
+      {
+        providerName: "mock",
+        sendEmailFn: async (payload) => {
+          capturedTemplateName = payload.templateName ?? "";
+          capturedSubject = payload.subject;
+          return {
+            success: true,
+            messageId: "mock-message-1",
+          };
+        },
+      },
+    );
+
+    assert.equal(result.outcome, "sent");
+    assert.equal(result.provider, "mock");
+    assert.equal(result.messageId, "mock-message-1");
+    assert.equal(capturedTemplateName, "invite_issuance");
+    assert.match(capturedSubject, /invite link/i);
+  });
+
+  test("returns skipped outcome when console provider is active", async () => {
+    const result = await sendInviteEmail(
+      {
+        to: "invitee@example.com",
+        inviteUrl: "https://example.com/auth/sign-up?invite=abc123",
+        expiresAt: new Date("2026-03-20T10:00:00.000Z"),
+      },
+      {
+        providerName: "console",
+        sendEmailFn: async () => ({
+          success: true,
+          messageId: "console-message-1",
+        }),
+      },
+    );
+
+    assert.equal(result.outcome, "skipped");
+    assert.equal(result.provider, "console");
+    assert.equal(result.error, null);
+  });
+
+  test("returns failed outcome with error when provider send fails", async () => {
+    const result = await sendInviteEmail(
+      {
+        to: "invitee@example.com",
+        inviteUrl: "https://example.com/auth/sign-up?invite=abc123",
+        expiresAt: new Date("2026-03-20T10:00:00.000Z"),
+      },
+      {
+        providerName: "mock",
+        sendEmailFn: async () => ({
+          success: false,
+          error: "Simulated provider failure",
+        }),
+      },
+    );
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(result.provider, "mock");
+    assert.equal(result.error, "Simulated provider failure");
+  });
+});


### PR DESCRIPTION
## Summary
- add `invite_issuance` React Email template and `sendInviteEmail` helper in `lib/mail`
- wire `/tools` invite issuance action/UI to issue + attempt email delivery in one workflow
- surface explicit delivery outcomes (`sent`, `skipped`, `failed`) with manual-share fallback messaging
- ensure invite send attempts are logged through `sendEmail` into `EmailDeliveryLog`
- update docs for architecture, operations, and test plan changes

## Testing
- `npm run typecheck`
- `npm run test:mail`
- `npm run test:invites`
- `npm run lint`
- `npm run build`

Closes #21