### PR TITLE
Invite signup: prefill email from invitation URL query

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -5,11 +5,13 @@ import { signUpAction } from "@/app/auth/actions";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
 import { getCurrentUser } from "@/lib/auth";
 import { isInvitesRequired } from "@/lib/env";
+import { parseInviteEmailPrefill } from "@/lib/invite-email";
 
 type SignUpPageProps = {
   searchParams?: {
     error?: string;
     invite?: string;
+    email?: string;
   };
 };
 
@@ -51,6 +53,7 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
   const invitesRequired = isInvitesRequired();
   const errorMessage = getErrorMessage(searchParams?.error, invitesRequired);
   const inviteToken = String(searchParams?.invite ?? "").trim();
+  const inviteEmailPrefill = parseInviteEmailPrefill(searchParams?.email);
 
   return (
     <section className="auth-wrap">
@@ -70,7 +73,14 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
             </label>
             <label className="form-field">
               Email
-              <input name="email" type="email" autoComplete="email" placeholder="name@example.com" required />
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                defaultValue={inviteEmailPrefill}
+                placeholder="name@example.com"
+                required
+              />
             </label>
             <label className="form-field">
               Password

--- a/lib/invite-email.ts
+++ b/lib/invite-email.ts
@@ -1,0 +1,19 @@
+const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizeInviteEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function isValidInviteEmail(value: string): boolean {
+  return INVITE_EMAIL_PATTERN.test(value);
+}
+
+export function parseInviteEmailPrefill(value: string | null | undefined): string {
+  const normalized = normalizeInviteEmail(String(value ?? ""));
+
+  if (!isValidInviteEmail(normalized)) {
+    return "";
+  }
+
+  return normalized;
+}

--- a/lib/invite-link.ts
+++ b/lib/invite-link.ts
@@ -1,0 +1,11 @@
+import { normalizeInviteEmail } from "./invite-email";
+
+export function buildInviteUrl(baseUrl: string, inviteToken: string, inviteEmail: string): string {
+  const trimmedBaseUrl = baseUrl.replace(/\/$/, "");
+  const params = new URLSearchParams({
+    invite: inviteToken,
+    email: normalizeInviteEmail(inviteEmail),
+  });
+
+  return `${trimmedBaseUrl}/auth/sign-up?${params.toString()}`;
+}

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -4,6 +4,8 @@ import { InviteStatus } from "@prisma/client";
 
 import { db } from "./db";
 import { normalizeEnvValue } from "./env";
+import { isValidInviteEmail, normalizeInviteEmail } from "./invite-email";
+import { buildInviteUrl } from "./invite-link";
 
 export const DEFAULT_INVITE_EXPIRY_DAYS = 7;
 export const MIN_INVITE_EXPIRY_DAYS = 1;
@@ -62,14 +64,6 @@ function getInviteSecret(): string {
   return secret;
 }
 
-export function normalizeInviteEmail(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-export function isValidInviteEmail(value: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
 export function parseInviteExpiryDays(rawValue: string | null | undefined): number | null {
   const normalized = String(rawValue ?? "").trim();
 
@@ -92,11 +86,6 @@ export function parseInviteExpiryDays(rawValue: string | null | undefined): numb
 
 export function hashInviteToken(token: string): string {
   return createHmac("sha256", getInviteSecret()).update(token).digest("hex");
-}
-
-function buildInviteUrl(baseUrl: string, inviteToken: string): string {
-  const trimmedBaseUrl = baseUrl.replace(/\/$/, "");
-  return `${trimmedBaseUrl}/auth/sign-up?invite=${encodeURIComponent(inviteToken)}`;
 }
 
 function logInviteEvent(event: string, payload: Record<string, unknown>): void {
@@ -224,7 +213,7 @@ export async function issueInvite(params: {
     email: created.invite.email,
     expiresAt: created.invite.expiresAt.toISOString(),
     inviteToken,
-    inviteUrl: buildInviteUrl(params.baseUrl, inviteToken),
+    inviteUrl: buildInviteUrl(params.baseUrl, inviteToken, created.invite.email),
     rotatedExistingInvite: created.rotatedExistingInvite,
   };
 }

--- a/tests/invites/invite-email-prefill.test.ts
+++ b/tests/invites/invite-email-prefill.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { parseInviteEmailPrefill } from "../../lib/invite-email";
+
+describe("parseInviteEmailPrefill", () => {
+  test("normalizes and returns valid invite email values", () => {
+    const prefill = parseInviteEmailPrefill("  Invited.User+demo@Example.com  ");
+
+    assert.equal(prefill, "invited.user+demo@example.com");
+  });
+
+  test("returns empty string for invalid invite email values", () => {
+    const prefill = parseInviteEmailPrefill("not-an-email");
+
+    assert.equal(prefill, "");
+  });
+});

--- a/tests/invites/invite-flow.test.ts
+++ b/tests/invites/invite-flow.test.ts
@@ -112,6 +112,10 @@ describe("invite flow", () => {
       assert.equal(storedInvite.email, targetEmail.toLowerCase());
       assert.notEqual(storedInvite.tokenHash, issued.inviteToken);
       assert.equal(storedInvite.tokenHash, hashInviteToken(issued.inviteToken));
+
+      const inviteUrl = new URL(issued.inviteUrl);
+      assert.equal(inviteUrl.searchParams.get("invite"), issued.inviteToken);
+      assert.equal(inviteUrl.searchParams.get("email"), targetEmail.toLowerCase());
     });
 
   test("rejects invite token when submitted email does not match invite email", async () => {

--- a/tests/invites/invite-link.test.ts
+++ b/tests/invites/invite-link.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { buildInviteUrl } from "../../lib/invite-link";
+
+describe("buildInviteUrl", () => {
+  test("includes invite token and normalized invite email in query params", () => {
+    const inviteUrl = buildInviteUrl("https://example.com/", "abc123", "Invited.User+demo@Example.com");
+    const parsed = new URL(inviteUrl);
+
+    assert.equal(parsed.pathname, "/auth/sign-up");
+    assert.equal(parsed.searchParams.get("invite"), "abc123");
+    assert.equal(parsed.searchParams.get("email"), "invited.user+demo@example.com");
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #62 by passing invitee email in invitation links and pre-filling the sign-up email input from that query value.

## Changes
- Added `lib/invite-email.ts` for invite-email normalization/validation and query-prefill parsing.
- Added `lib/invite-link.ts` to build invite URLs with both `invite` and `email` query params.
- Updated `lib/invites.ts` to use the new URL builder during invite issuance.
- Updated `app/auth/sign-up/page.tsx` to read `searchParams.email` and set email input `defaultValue` via validated normalization.
- Added tests:
  - `tests/invites/invite-link.test.ts`
  - `tests/invites/invite-email-prefill.test.ts`
  - integration assertion in `tests/invites/invite-flow.test.ts` for URL query params.

## Validation
- `node --import tsx --test tests/invites/invite-link.test.ts tests/invites/invite-email-prefill.test.ts`
- `npm.cmd run test:mail`
- `npm.cmd run typecheck`

## Notes
- `npm.cmd run test:invites` still fails in this environment because the database is unavailable for `invite-flow.test.ts` setup (`Database is unavailable for invite tests.`).