### PR TITLE
Implement subscription reminder dispatch maintenance job (issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,15 @@ Useful commands:
   - test email
   - invite issuance
   - registration verification (template only)
-  - subscription reminder (template only)
+  - subscription reminder
 - Manual validation workflow:
   - go to `/tools`
   - use `Send Test Email` to send to the authenticated account email
   - endpoint is rate-limited to 3 sends per user per hour
 - Delivery attempts are recorded in Prisma `EmailDeliveryLog` (`SENT`, `FAILED`, `SKIPPED`).
+- Reminder dispatch dedupe state is recorded in Prisma `SubscriptionReminderDispatch` (unique per `userId + billingDateKey`).
 - Invite issuance from `/tools` attempts immediate email delivery and falls back to manual share when provider is unavailable or send fails.
+- Daily maintenance dispatches due subscription reminder batches using each user's saved reminder settings.
 - Daily maintenance prunes stale email logs using `EMAIL_DELIVERY_LOG_RETENTION_DAYS`.
 - Local template preview command:
   - `npm run email:dev`

--- a/app/api/internal/daily-maintenance/route.ts
+++ b/app/api/internal/daily-maintenance/route.ts
@@ -34,6 +34,15 @@ export async function GET(request: NextRequest) {
       staleSignInAttemptsDeleted: result.staleSignInAttemptsDeleted,
       expiredPendingInvitesMarked: result.expiredPendingInvitesMarked,
       emailDeliveryLogsDeleted: result.emailDeliveryLogsDeleted,
+      subscriptionReminders: {
+        candidateSubscriptionsScanned: result.subscriptionReminders.candidateSubscriptionsScanned,
+        dueSubscriptions: result.subscriptionReminders.dueSubscriptions,
+        dueUserBatches: result.subscriptionReminders.dueUserBatches,
+        dispatchesAttempted: result.subscriptionReminders.dispatchesAttempted,
+        dispatchesSent: result.subscriptionReminders.dispatchesSent,
+        dispatchesFailed: result.subscriptionReminders.dispatchesFailed,
+        dispatchesSkippedDuplicate: result.subscriptionReminders.dispatchesSkippedDuplicate,
+      },
     },
     ranAt: result.ranAt,
   });

--- a/app/tools/actions.ts
+++ b/app/tools/actions.ts
@@ -197,6 +197,6 @@ export async function runDailyMaintenanceAction(): Promise<void> {
 
   const result = await runDailyMaintenanceJobs();
   redirect(
-    `/tools?job=daily_maintenance&attempts_deleted=${result.staleSignInAttemptsDeleted}&invites_expired=${result.expiredPendingInvitesMarked}&email_logs_deleted=${result.emailDeliveryLogsDeleted}`,
+    `/tools?job=daily_maintenance&attempts_deleted=${result.staleSignInAttemptsDeleted}&invites_expired=${result.expiredPendingInvitesMarked}&email_logs_deleted=${result.emailDeliveryLogsDeleted}&reminder_due_users=${result.subscriptionReminders.dueUserBatches}&reminder_sent=${result.subscriptionReminders.dispatchesSent}&reminder_failed=${result.subscriptionReminders.dispatchesFailed}&reminder_deduped=${result.subscriptionReminders.dispatchesSkippedDuplicate}`,
   );
 }

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -15,6 +15,10 @@ type ToolsPageProps = {
     attempts_deleted?: string;
     invites_expired?: string;
     email_logs_deleted?: string;
+    reminder_due_users?: string;
+    reminder_sent?: string;
+    reminder_failed?: string;
+    reminder_deduped?: string;
   };
 };
 
@@ -51,7 +55,11 @@ function getResultMessage(searchParams?: ToolsPageProps["searchParams"]): string
     const attemptsDeleted = parseCount(searchParams.attempts_deleted) ?? 0;
     const invitesExpired = parseCount(searchParams.invites_expired) ?? 0;
     const emailLogsDeleted = parseCount(searchParams.email_logs_deleted) ?? 0;
-    return `Daily maintenance completed. Stale sign-in attempts deleted: ${attemptsDeleted}. Expired invites marked: ${invitesExpired}. Email delivery logs pruned: ${emailLogsDeleted}.`;
+    const reminderDueUsers = parseCount(searchParams.reminder_due_users) ?? 0;
+    const reminderSent = parseCount(searchParams.reminder_sent) ?? 0;
+    const reminderFailed = parseCount(searchParams.reminder_failed) ?? 0;
+    const reminderDeduped = parseCount(searchParams.reminder_deduped) ?? 0;
+    return `Daily maintenance completed. Stale sign-in attempts deleted: ${attemptsDeleted}. Expired invites marked: ${invitesExpired}. Email delivery logs pruned: ${emailLogsDeleted}. Reminder users due: ${reminderDueUsers}. Reminders sent: ${reminderSent}. Reminder send failures: ${reminderFailed}. Reminder duplicates skipped: ${reminderDeduped}.`;
   }
 
   return null;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,8 @@ Defined in `prisma/schema.prisma`:
 - `InviteStatus` enum (`PENDING`, `CONSUMED`, `EXPIRED`, `REVOKED`)
 - `EmailDeliveryLog` (delivery attempts with template metadata and provider outcome)
 - `EmailDeliveryStatus` enum (`SENT`, `FAILED`, `SKIPPED`)
+- `SubscriptionReminderDispatch` (idempotent reminder dispatch lock/status per `user + billing date`)
+- `ReminderDispatchStatus` enum (`PENDING`, `SENT`, `FAILED`)
 
 ## Learning fields
 
@@ -151,6 +153,8 @@ Status payload also includes email readiness:
 3. `sendEmail` logging into `EmailDeliveryLog` for all attempts.
 4. `sendInviteEmail` helper for invite issuance delivery (`invite_issuance` template) with explicit `sent`/`skipped`/`failed` outcomes.
 5. Rate-limit helper for `/api/mail/test` (3 sends per user per hour).
+6. `runSubscriptionReminderDispatchJob` selects due subscriptions based on `UserSettings`, groups by user, and sends `subscription_reminder` emails.
+7. `SubscriptionReminderDispatch` enforces idempotency for reminder reruns (`userId + billingDateKey` uniqueness).
 
 Current guarantees:
 
@@ -174,3 +178,4 @@ Additional scheduled operation:
 
 - Daily Vercel cron calls `/api/internal/daily-maintenance` (guarded by `CRON_SECRET`).
 - Daily maintenance marks expired pending invites as `EXPIRED`.
+- Daily maintenance dispatches due subscription reminder batches and reports reminder counters in run output.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -51,6 +51,8 @@ Scheduled cleanup:
 - Endpoint requires `Authorization: Bearer <CRON_SECRET>`.
 - For ad-hoc testing, use `/tools` manual actions instead of increasing cron frequency.
 - Daily maintenance marks expired pending invites as `EXPIRED`.
+- Daily maintenance dispatches due subscription reminder emails grouped per user.
+- Daily maintenance is idempotent for reminders via `SubscriptionReminderDispatch` (`userId + billingDateKey`).
 - Daily maintenance prunes `EmailDeliveryLog` rows older than the retention window.
 - Invite issuance is conservatively throttled per authenticated operator (hourly window).
 
@@ -95,6 +97,11 @@ Email service:
 6. Verify email health path:
    - trigger `Send Test Email` from `/tools` as an authenticated user.
    - confirm `EmailDeliveryLog` row is written with expected status.
+7. Verify reminder maintenance path:
+   - trigger `Run Daily Batch` from `/tools`.
+   - confirm output includes reminder due/sent/failed/deduped counters.
+   - confirm `EmailDeliveryLog` includes `templateName=subscription_reminder` for successful reminder sends.
+   - confirm rerunning the same day increments reminder dedupe count without sending duplicates.
 
 ### If deployment fails
 
@@ -130,3 +137,10 @@ Test email fails:
 - if provider is `console`, set `MAIL_PROVIDER_API_KEY` and redeploy.
 - confirm `MAIL_FROM_ADDRESS` is valid for current provider/domain setup.
 - inspect `EmailDeliveryLog` entries in Prisma Studio for recent `FAILED` rows.
+
+Reminder job appears stalled or missing sends:
+
+- run `/tools` daily maintenance and inspect reminder counters in output.
+- confirm user settings (`remindersEnabled`, `reminderDaysBefore`) and subscription `nextBillingDate` values align with today's UTC date.
+- inspect `SubscriptionReminderDispatch` for rows already created for the same `userId + billingDateKey`.
+- inspect `EmailDeliveryLog` for `templateName=subscription_reminder` status rows.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -90,6 +90,8 @@ Email:
 4. In Prisma Studio, verify `EmailDeliveryLog` rows are created with expected `templateName` and `status`.
 5. From `/tools`, issue an invite and verify an `EmailDeliveryLog` entry with `templateName=invite_issuance` is created.
 6. Disable provider key (or force `MAIL_PROVIDER=console`) and issue another invite; confirm `/tools` shows fallback/manual-share status while still returning token/URL.
+7. Set a subscription with `nextBillingDate` equal to today's date plus the user's `reminderDaysBefore`, run `Run Daily Batch`, and verify an `EmailDeliveryLog` row with `templateName=subscription_reminder` is created.
+8. Run `Run Daily Batch` again on the same day and confirm reminder dedupe in output (no duplicate reminder send for the same user + billing cycle).
 
 Deploy:
 
@@ -100,6 +102,7 @@ Deploy:
 5. Confirm `/tools` manual maintenance actions run successfully for testing.
 6. Confirm maintenance output includes expired invite counts.
 7. Confirm maintenance output includes pruned email delivery log counts.
+8. Confirm maintenance output includes reminder due/sent/failed/deduped counts.
 
 ## Known gaps
 

--- a/lib/maintenance.ts
+++ b/lib/maintenance.ts
@@ -1,26 +1,33 @@
 import { pruneStaleSignInAttempts } from "./auth";
 import { expirePendingInvites } from "./invites";
 import { pruneEmailDeliveryLogs } from "./mail";
+import {
+  runSubscriptionReminderDispatchJob,
+  type SubscriptionReminderDispatchResult,
+} from "./subscription-reminders";
 
 export type DailyMaintenanceResult = {
   staleSignInAttemptsDeleted: number;
   expiredPendingInvitesMarked: number;
   emailDeliveryLogsDeleted: number;
+  subscriptionReminders: SubscriptionReminderDispatchResult;
   ranAt: string;
 };
 
 export async function runDailyMaintenanceJobs(): Promise<DailyMaintenanceResult> {
-  const [staleSignInAttemptsDeleted, expiredPendingInvitesMarked, emailDeliveryLogsDeleted] =
+  const [staleSignInAttemptsDeleted, expiredPendingInvitesMarked, emailDeliveryLogsDeleted, subscriptionReminders] =
     await Promise.all([
     pruneStaleSignInAttempts(),
     expirePendingInvites(),
     pruneEmailDeliveryLogs(),
+    runSubscriptionReminderDispatchJob(),
   ]);
 
   return {
     staleSignInAttemptsDeleted,
     expiredPendingInvitesMarked,
     emailDeliveryLogsDeleted,
+    subscriptionReminders,
     ranAt: new Date().toISOString(),
   };
 }

--- a/lib/subscription-reminders.ts
+++ b/lib/subscription-reminders.ts
@@ -1,0 +1,393 @@
+import { db } from "./db";
+import { sendSubscriptionReminderEmail, type EmailResult } from "./mail";
+
+const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1000;
+const MAX_REMINDER_DAYS_BEFORE = 30;
+const DEFAULT_REMINDER_DAYS_BEFORE = 3;
+
+type PrismaKnownRequestLike = {
+  code?: unknown;
+};
+
+type ReminderLogger = Pick<typeof console, "info" | "error">;
+
+export type SubscriptionReminderCandidate = {
+  subscriptionId: string;
+  subscriptionName: string;
+  amountCents: number;
+  currency: string;
+  nextBillingDate: Date;
+  userId: string;
+  userEmail: string;
+  remindersEnabled: boolean;
+  reminderDaysBefore: number;
+};
+
+export type SubscriptionReminderBatch = {
+  userId: string;
+  userEmail: string;
+  reminderDaysBefore: number;
+  billingDateKey: string;
+  subscriptions: Array<{
+    id: string;
+    name: string;
+    amountCents: number;
+    currency: string;
+    renewalDate: Date;
+  }>;
+};
+
+export type SubscriptionReminderDispatchResult = {
+  candidateSubscriptionsScanned: number;
+  dueSubscriptions: number;
+  dueUserBatches: number;
+  dispatchesAttempted: number;
+  dispatchesSent: number;
+  dispatchesFailed: number;
+  dispatchesSkippedDuplicate: number;
+  ranAt: string;
+};
+
+type SubscriptionReminderDispatchDependencies = {
+  now?: Date;
+  logger?: ReminderLogger;
+  loadCandidates?: (now: Date) => Promise<SubscriptionReminderCandidate[]>;
+  reserveDispatch?: (batch: SubscriptionReminderBatch) => Promise<boolean>;
+  sendReminder?: (input: {
+    to: string;
+    userId: string;
+    reminderDaysBefore: number;
+    subscriptions: Array<{
+      name: string;
+      amountCents: number;
+      currency: string;
+      renewalDate: Date;
+    }>;
+  }) => Promise<EmailResult>;
+  finalizeDispatch?: (input: {
+    batch: SubscriptionReminderBatch;
+    status: "SENT" | "FAILED";
+    errorMessage: string | null;
+  }) => Promise<void>;
+};
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unknown reminder dispatch error.";
+}
+
+function asPrismaKnownRequestLike(error: unknown): PrismaKnownRequestLike | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  return error as PrismaKnownRequestLike;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const prismaError = asPrismaKnownRequestLike(error);
+
+  if (!prismaError) {
+    return false;
+  }
+
+  return prismaError.code === "P2002";
+}
+
+function utcDayNumber(value: Date): number {
+  return Math.floor(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()) / DAYS_TO_MILLISECONDS);
+}
+
+function toUtcDateKey(value: Date): string {
+  const year = value.getUTCFullYear();
+  const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(value.getUTCDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function startOfUtcDay(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 0, 0, 0, 0));
+}
+
+function endOfUtcDay(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 23, 59, 59, 999));
+}
+
+function addDaysUtc(value: Date, days: number): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate() + days, 0, 0, 0, 0));
+}
+
+function normalizeReminderDaysBefore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_REMINDER_DAYS_BEFORE;
+  }
+
+  const rounded = Math.floor(value);
+
+  if (rounded < 0) {
+    return 0;
+  }
+
+  if (rounded > MAX_REMINDER_DAYS_BEFORE) {
+    return MAX_REMINDER_DAYS_BEFORE;
+  }
+
+  return rounded;
+}
+
+function isDueForReminder(nextBillingDate: Date, now: Date, reminderDaysBefore: number): boolean {
+  const daysUntilBilling = utcDayNumber(nextBillingDate) - utcDayNumber(now);
+  return daysUntilBilling >= 0 && daysUntilBilling === reminderDaysBefore;
+}
+
+export function buildSubscriptionReminderBatches(
+  candidates: SubscriptionReminderCandidate[],
+  now: Date = new Date(),
+): SubscriptionReminderBatch[] {
+  const grouped = new Map<string, SubscriptionReminderBatch>();
+
+  for (const candidate of candidates) {
+    if (!candidate.remindersEnabled) {
+      continue;
+    }
+
+    const reminderDaysBefore = normalizeReminderDaysBefore(candidate.reminderDaysBefore);
+
+    if (!isDueForReminder(candidate.nextBillingDate, now, reminderDaysBefore)) {
+      continue;
+    }
+
+    const billingDateKey = toUtcDateKey(candidate.nextBillingDate);
+    const groupKey = `${candidate.userId}:${billingDateKey}`;
+    const existing = grouped.get(groupKey);
+
+    if (existing) {
+      existing.subscriptions.push({
+        id: candidate.subscriptionId,
+        name: candidate.subscriptionName,
+        amountCents: candidate.amountCents,
+        currency: candidate.currency,
+        renewalDate: candidate.nextBillingDate,
+      });
+      continue;
+    }
+
+    grouped.set(groupKey, {
+      userId: candidate.userId,
+      userEmail: candidate.userEmail,
+      reminderDaysBefore,
+      billingDateKey,
+      subscriptions: [
+        {
+          id: candidate.subscriptionId,
+          name: candidate.subscriptionName,
+          amountCents: candidate.amountCents,
+          currency: candidate.currency,
+          renewalDate: candidate.nextBillingDate,
+        },
+      ],
+    });
+  }
+
+  return [...grouped.values()]
+    .map((batch) => ({
+      ...batch,
+      subscriptions: [...batch.subscriptions].sort((first, second) => {
+        return (
+          first.renewalDate.getTime() - second.renewalDate.getTime() ||
+          first.name.localeCompare(second.name) ||
+          first.id.localeCompare(second.id)
+        );
+      }),
+    }))
+    .sort((first, second) => {
+      return (
+        first.billingDateKey.localeCompare(second.billingDateKey) ||
+        first.userEmail.localeCompare(second.userEmail) ||
+        first.userId.localeCompare(second.userId)
+      );
+    });
+}
+
+async function loadReminderCandidates(now: Date): Promise<SubscriptionReminderCandidate[]> {
+  const windowStart = startOfUtcDay(now);
+  const windowEnd = endOfUtcDay(addDaysUtc(now, MAX_REMINDER_DAYS_BEFORE));
+  const records = await db.subscription.findMany({
+    where: {
+      isActive: true,
+      nextBillingDate: {
+        gte: windowStart,
+        lte: windowEnd,
+      },
+    },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      amountCents: true,
+      currency: true,
+      nextBillingDate: true,
+      user: {
+        select: {
+          email: true,
+          settings: {
+            select: {
+              remindersEnabled: true,
+              reminderDaysBefore: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: [{ userId: "asc" }, { nextBillingDate: "asc" }, { name: "asc" }],
+  });
+
+  return records
+    .filter((record): record is typeof record & { nextBillingDate: Date } => record.nextBillingDate !== null)
+    .map((record) => ({
+      subscriptionId: record.id,
+      subscriptionName: record.name,
+      amountCents: record.amountCents,
+      currency: record.currency,
+      nextBillingDate: record.nextBillingDate,
+      userId: record.userId,
+      userEmail: record.user.email,
+      remindersEnabled: record.user.settings?.remindersEnabled ?? true,
+      reminderDaysBefore: record.user.settings?.reminderDaysBefore ?? DEFAULT_REMINDER_DAYS_BEFORE,
+    }));
+}
+
+async function reserveReminderDispatch(batch: SubscriptionReminderBatch): Promise<boolean> {
+  try {
+    await db.subscriptionReminderDispatch.create({
+      data: {
+        userId: batch.userId,
+        billingDateKey: batch.billingDateKey,
+        reminderDaysBefore: batch.reminderDaysBefore,
+      },
+    });
+    return true;
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function finalizeReminderDispatch(input: {
+  batch: SubscriptionReminderBatch;
+  status: "SENT" | "FAILED";
+  errorMessage: string | null;
+}): Promise<void> {
+  await db.subscriptionReminderDispatch.update({
+    where: {
+      userId_billingDateKey: {
+        userId: input.batch.userId,
+        billingDateKey: input.batch.billingDateKey,
+      },
+    },
+    data: {
+      status: input.status,
+      errorMessage: input.errorMessage,
+    },
+  });
+}
+
+export async function runSubscriptionReminderDispatchJob(
+  dependencies: SubscriptionReminderDispatchDependencies = {},
+): Promise<SubscriptionReminderDispatchResult> {
+  const now = dependencies.now ?? new Date();
+  const logger = dependencies.logger ?? console;
+  const loadCandidates = dependencies.loadCandidates ?? loadReminderCandidates;
+  const reserveDispatch = dependencies.reserveDispatch ?? reserveReminderDispatch;
+  const sendReminder = dependencies.sendReminder ?? sendSubscriptionReminderEmail;
+  const finalizeDispatch = dependencies.finalizeDispatch ?? finalizeReminderDispatch;
+
+  const candidates = await loadCandidates(now);
+  const batches = buildSubscriptionReminderBatches(candidates, now);
+  const result: SubscriptionReminderDispatchResult = {
+    candidateSubscriptionsScanned: candidates.length,
+    dueSubscriptions: batches.reduce((total, batch) => total + batch.subscriptions.length, 0),
+    dueUserBatches: batches.length,
+    dispatchesAttempted: 0,
+    dispatchesSent: 0,
+    dispatchesFailed: 0,
+    dispatchesSkippedDuplicate: 0,
+    ranAt: now.toISOString(),
+  };
+
+  for (const batch of batches) {
+    const reserved = await reserveDispatch(batch);
+
+    if (!reserved) {
+      result.dispatchesSkippedDuplicate += 1;
+      continue;
+    }
+
+    result.dispatchesAttempted += 1;
+
+    let emailResult: EmailResult;
+
+    try {
+      emailResult = await sendReminder({
+        to: batch.userEmail,
+        userId: batch.userId,
+        reminderDaysBefore: batch.reminderDaysBefore,
+        subscriptions: batch.subscriptions.map((subscription) => ({
+          name: subscription.name,
+          amountCents: subscription.amountCents,
+          currency: subscription.currency,
+          renewalDate: subscription.renewalDate,
+        })),
+      });
+    } catch (error) {
+      emailResult = {
+        success: false,
+        error: asErrorMessage(error),
+      };
+    }
+
+    if (emailResult.success) {
+      result.dispatchesSent += 1;
+      await finalizeDispatch({
+        batch,
+        status: "SENT",
+        errorMessage: null,
+      });
+      continue;
+    }
+
+    result.dispatchesFailed += 1;
+    const errorMessage = emailResult.error ?? "Unknown reminder email failure.";
+    await finalizeDispatch({
+      batch,
+      status: "FAILED",
+      errorMessage,
+    });
+    logger.error("[reminders] Reminder email send failed.", {
+      userId: batch.userId,
+      userEmail: batch.userEmail,
+      billingDateKey: batch.billingDateKey,
+      error: errorMessage,
+    });
+  }
+
+  logger.info("[reminders] Reminder dispatch run complete.", {
+    candidateSubscriptionsScanned: result.candidateSubscriptionsScanned,
+    dueSubscriptions: result.dueSubscriptions,
+    dueUserBatches: result.dueUserBatches,
+    dispatchesAttempted: result.dispatchesAttempted,
+    dispatchesSent: result.dispatchesSent,
+    dispatchesFailed: result.dispatchesFailed,
+    dispatchesSkippedDuplicate: result.dispatchesSkippedDuplicate,
+    ranAt: result.ranAt,
+  });
+
+  return result;
+}

--- a/prisma/migrations/20260313083000_add_subscription_reminder_dispatches/migration.sql
+++ b/prisma/migrations/20260313083000_add_subscription_reminder_dispatches/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "public"."ReminderDispatchStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "public"."SubscriptionReminderDispatch" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "billingDateKey" TEXT NOT NULL,
+    "reminderDaysBefore" INTEGER NOT NULL,
+    "status" "public"."ReminderDispatchStatus" NOT NULL DEFAULT 'PENDING',
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SubscriptionReminderDispatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SubscriptionReminderDispatch_userId_billingDateKey_key" ON "public"."SubscriptionReminderDispatch"("userId", "billingDateKey");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionReminderDispatch_billingDateKey_idx" ON "public"."SubscriptionReminderDispatch"("billingDateKey");
+
+-- CreateIndex
+CREATE INDEX "SubscriptionReminderDispatch_status_createdAt_idx" ON "public"."SubscriptionReminderDispatch"("status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "public"."SubscriptionReminderDispatch" ADD CONSTRAINT "SubscriptionReminderDispatch_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Enable RLS
+ALTER TABLE "public"."SubscriptionReminderDispatch" ENABLE ROW LEVEL SECURITY;
+
+-- Supabase API roles may not exist in local/dev databases.
+DO $$
+DECLARE
+    role_name TEXT;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated']
+    LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."SubscriptionReminderDispatch" FROM %I', role_name);
+        END IF;
+    END LOOP;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,12 @@ enum EmailDeliveryStatus {
   SKIPPED
 }
 
+enum ReminderDispatchStatus {
+  PENDING
+  SENT
+  FAILED
+}
+
 model User {
   id            String         @id @default(cuid())
   email         String         @unique
@@ -47,6 +53,7 @@ model User {
   invitesCreated Invite[]      @relation("InviteCreatedByUser")
   invitesConsumed Invite[]     @relation("InviteConsumedByUser")
   emailDeliveryLogs EmailDeliveryLog[]
+  subscriptionReminderDispatches SubscriptionReminderDispatch[]
 }
 
 model UserSettings {
@@ -141,4 +148,20 @@ model EmailDeliveryLog {
   @@index([userId, createdAt])
   @@index([templateName, createdAt])
   @@index([createdAt])
+}
+
+model SubscriptionReminderDispatch {
+  id              String                 @id @default(cuid())
+  userId          String
+  billingDateKey  String
+  reminderDaysBefore Int
+  status          ReminderDispatchStatus @default(PENDING)
+  errorMessage    String?
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
+  user            User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, billingDateKey])
+  @@index([billingDateKey])
+  @@index([status, createdAt])
 }

--- a/tests/mail/subscription-reminder-job.test.ts
+++ b/tests/mail/subscription-reminder-job.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  buildSubscriptionReminderBatches,
+  runSubscriptionReminderDispatchJob,
+  type SubscriptionReminderCandidate,
+  type SubscriptionReminderBatch,
+} from "../../lib/subscription-reminders";
+
+function makeCandidate(
+  overrides: Partial<SubscriptionReminderCandidate> & Pick<SubscriptionReminderCandidate, "subscriptionId" | "userId">,
+): SubscriptionReminderCandidate {
+  const { subscriptionId, userId, ...rest } = overrides;
+
+  return {
+    subscriptionId,
+    subscriptionName: `Subscription ${subscriptionId}`,
+    amountCents: 1500,
+    currency: "USD",
+    nextBillingDate: new Date("2026-03-15T12:00:00.000Z"),
+    userId,
+    userEmail: `${userId}@example.com`,
+    remindersEnabled: true,
+    reminderDaysBefore: 3,
+    ...rest,
+  };
+}
+
+describe("buildSubscriptionReminderBatches", () => {
+  test("selects due subscriptions using user reminder settings and groups by user + billing date", () => {
+    const now = new Date("2026-03-12T08:00:00.000Z");
+    const batches = buildSubscriptionReminderBatches(
+      [
+        makeCandidate({ subscriptionId: "sub-1", userId: "user-a", subscriptionName: "One" }),
+        makeCandidate({ subscriptionId: "sub-2", userId: "user-a", subscriptionName: "Two" }),
+        makeCandidate({
+          subscriptionId: "sub-3",
+          userId: "user-a",
+          nextBillingDate: new Date("2026-03-16T12:00:00.000Z"),
+        }),
+        makeCandidate({
+          subscriptionId: "sub-4",
+          userId: "user-b",
+          remindersEnabled: false,
+        }),
+        makeCandidate({
+          subscriptionId: "sub-5",
+          userId: "user-c",
+          reminderDaysBefore: 0,
+          nextBillingDate: new Date("2026-03-12T12:00:00.000Z"),
+        }),
+      ],
+      now,
+    );
+
+    assert.equal(batches.length, 2);
+    assert.equal(batches[0].userId, "user-c");
+    assert.equal(batches[0].billingDateKey, "2026-03-12");
+    assert.equal(batches[0].subscriptions.length, 1);
+    assert.equal(batches[1].userId, "user-a");
+    assert.equal(batches[1].billingDateKey, "2026-03-15");
+    assert.equal(batches[1].subscriptions.length, 2);
+    assert.deepEqual(
+      batches[1].subscriptions.map((subscription) => subscription.id),
+      ["sub-1", "sub-2"],
+    );
+  });
+});
+
+describe("runSubscriptionReminderDispatchJob", () => {
+  test("skips duplicate reruns for the same user + billing cycle", async () => {
+    const now = new Date("2026-03-12T08:00:00.000Z");
+    const candidates = [
+      makeCandidate({ subscriptionId: "sub-1", userId: "user-a", userEmail: "one@example.com" }),
+    ];
+    const reservedKeys = new Set<string>();
+    const sentBatches: SubscriptionReminderBatch[] = [];
+
+    const reserveDispatch = async (batch: SubscriptionReminderBatch): Promise<boolean> => {
+      const key = `${batch.userId}:${batch.billingDateKey}`;
+
+      if (reservedKeys.has(key)) {
+        return false;
+      }
+
+      reservedKeys.add(key);
+      return true;
+    };
+
+    const sendReminder = async (input: {
+      to: string;
+      userId: string;
+      reminderDaysBefore: number;
+      subscriptions: Array<{
+        name: string;
+        amountCents: number;
+        currency: string;
+        renewalDate: Date;
+      }>;
+    }) => {
+      sentBatches.push({
+        userId: input.userId,
+        userEmail: input.to,
+        reminderDaysBefore: input.reminderDaysBefore,
+        billingDateKey: "2026-03-15",
+        subscriptions: input.subscriptions.map((subscription, index) => ({
+          id: `sent-${index}`,
+          ...subscription,
+        })),
+      });
+
+      return {
+        success: true,
+      };
+    };
+
+    const finalizeDispatches: Array<{ status: "SENT" | "FAILED"; errorMessage: string | null }> = [];
+
+    const runOnce = async () =>
+      runSubscriptionReminderDispatchJob({
+        now,
+        logger: { info: () => undefined, error: () => undefined },
+        loadCandidates: async () => candidates,
+        reserveDispatch,
+        sendReminder,
+        finalizeDispatch: async (input) => {
+          finalizeDispatches.push({ status: input.status, errorMessage: input.errorMessage });
+        },
+      });
+
+    const firstRun = await runOnce();
+    const secondRun = await runOnce();
+
+    assert.equal(firstRun.dispatchesSent, 1);
+    assert.equal(firstRun.dispatchesSkippedDuplicate, 0);
+    assert.equal(secondRun.dispatchesSent, 0);
+    assert.equal(secondRun.dispatchesSkippedDuplicate, 1);
+    assert.equal(sentBatches.length, 1);
+    assert.equal(finalizeDispatches.length, 1);
+    assert.equal(finalizeDispatches[0]?.status, "SENT");
+  });
+
+  test("records failed sends in dispatch metrics and completion state", async () => {
+    const now = new Date("2026-03-12T08:00:00.000Z");
+    const finalized: Array<{ status: "SENT" | "FAILED"; errorMessage: string | null }> = [];
+
+    const result = await runSubscriptionReminderDispatchJob({
+      now,
+      logger: { info: () => undefined, error: () => undefined },
+      loadCandidates: async () => [
+        makeCandidate({ subscriptionId: "sub-1", userId: "user-a", userEmail: "one@example.com" }),
+      ],
+      reserveDispatch: async () => true,
+      sendReminder: async () => ({
+        success: false,
+        error: "Simulated failure",
+      }),
+      finalizeDispatch: async (input) => {
+        finalized.push({ status: input.status, errorMessage: input.errorMessage });
+      },
+    });
+
+    assert.equal(result.dispatchesAttempted, 1);
+    assert.equal(result.dispatchesSent, 0);
+    assert.equal(result.dispatchesFailed, 1);
+    assert.equal(finalized.length, 1);
+    assert.equal(finalized[0]?.status, "FAILED");
+    assert.equal(finalized[0]?.errorMessage, "Simulated failure");
+  });
+});


### PR DESCRIPTION
## Summary
- add `runSubscriptionReminderDispatchJob` to select due active subscriptions, apply per-user reminder settings, group by user/billing cycle, and dispatch `subscription_reminder` emails
- add idempotency lock table `SubscriptionReminderDispatch` with unique `userId + billingDateKey` and status tracking (`PENDING`, `SENT`, `FAILED`)
- integrate reminder job into daily maintenance output (`/api/internal/daily-maintenance`) and `/tools` manual batch feedback
- add reminder-job tests for due query/grouping logic, duplicate-send safeguard behavior, and failed-send metrics
- update operational docs and README for live reminder dispatch behavior and maintenance verification

## Database
- Prisma schema: add `ReminderDispatchStatus` enum and `SubscriptionReminderDispatch` model
- migration: `20260313083000_add_subscription_reminder_dispatches`

## Validation
- `npm.cmd run prisma:generate`
- `npm.cmd run test:mail`
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd run build`

Closes #22