### PR TITLE
docs: audit roadmap completion status and refresh contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ When the user asks for a task to be done, follow this sequence:
 - GitHub MCP server must be installed and authenticated before starting feature work.
 - The MCP token must include permissions required to create and update issues in this repository.
 - If MCP issue creation is unavailable, report that as a blocker in handoff notes and avoid silent backlog loss.
+- On Windows hosts, execute local repository commands via Git Bash (for example, `C:\Program Files\Git\bin\bash.exe -lc "<command>"`) instead of PowerShell.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Subscription Stalker is a web app that helps users keep track of recurring subsc
 - npm 9+
 - Docker Desktop (for local Postgres + migration testing)
 - GitHub MCP configured if you use AI agents for backlog/TODO handling
+- On Windows, run local project commands in Git Bash (`C:\Program Files\Git\bin\bash.exe`) instead of PowerShell to avoid script execution-policy issues with `npm`.
 
 ## Backlog and TODO workflow
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,6 +1,6 @@
 # Handoff
 
-Last updated: 2026-03-10
+Last updated: 2026-03-13
 
 ## Current status
 
@@ -62,12 +62,18 @@ Implemented:
 - Form submit UX feedback:
   - all primary form/server-action flows use pending submit states and disabled fieldsets via shared `PendingFormControls`.
 - Dashboard:
-  - shows active subscription count, estimated monthly spend, next charge summary, and quick actions.
+  - API-driven aggregation contract exposed via `/api/dashboard`.
+  - shows active subscription count, estimated monthly spend, renewals-in-next-7-days, and category/savings signals.
   - upcoming/recent items are interactive entry points into the shared details modal.
+- Email and notification baseline:
+  - provider-agnostic mail wrapper with `resend` / `console` / `mock`.
+  - `EmailDeliveryLog` persistence for send outcomes (`SENT`, `FAILED`, `SKIPPED`).
+  - daily maintenance dispatches due subscription reminders and dedupes reruns using `SubscriptionReminderDispatch`.
+  - `/tools` supports authenticated test-email sends and manual daily-batch execution.
 
 Not implemented yet:
 
-- Email/notification workflows.
+- Registration verification email flow is still template-only and not yet wired into sign-up/sign-in gating.
 - Full end-to-end browser coverage.
 
 ## Critical deployment notes
@@ -82,7 +88,7 @@ Not implemented yet:
 
 1. Add role-based operator permissions for `/tools` invite issuance.
 2. Add optional "sign out all sessions" account control.
-3. Add notifications/reminders workflow from settings preferences.
+3. Wire registration verification email/token flow into auth lifecycle.
 
 ## Files to understand first
 
@@ -92,3 +98,4 @@ Not implemented yet:
 4. `lib/status.ts`
 5. `scripts/vercel-build.mjs`
 6. `app/auth/actions.ts`
+7. `lib/subscription-reminders.ts`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ Acceptance criteria:
 - Persist display mode preferences (`DEVICE`, `LIGHT`, `DARK`).
 - Pre-fill form from DB values.
 
-## P2: Dashboard signal
+## P2: Dashboard signal (completed)
 
 Goal:
 
@@ -38,7 +38,7 @@ Acceptance criteria:
 - Active subscription count.
 - Monthly estimated spend summary.
 
-## P3: Notification baseline
+## P3: Notification baseline (completed)
 
 Goal:
 
@@ -100,3 +100,23 @@ Acceptance criteria:
 - `/tools` can issue single-use invite links for manual sharing.
 - Sign-up enforces invite token + email match when `INVITES_REQUIRED=true`.
 - Invite consumption is atomic and safe under concurrent registration attempts.
+
+## P8: Household account linking and sharing
+
+Goal:
+
+- Let users link family/spouse/partner accounts so subscriptions can be shared with clear ownership and permissions.
+
+Summary:
+
+- Introduce a household model where users can invite and link trusted accounts, choose whether each subscription is personal or shared, and enforce role-based access so shared data stays collaborative but controlled.
+- Tracking issue: #65.
+
+Acceptance criteria:
+
+- Users can create a household and invite another account through a secure linking flow.
+- Invited users can accept the invite and join the linked household.
+- Shared subscriptions are visible to authorized household members.
+- Personal subscriptions remain private to the owner account.
+- Permission rules are enforced for create/update/delete actions on shared subscriptions.
+- Shared records retain audit metadata showing who made changes.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -7,6 +7,7 @@
 3. `npm run build`
 4. `npm run test:invites` (when local Postgres is available)
 5. `npm run test:mail`
+6. `npm run test:dashboard`
 
 For migration/schema changes:
 


### PR DESCRIPTION
## Summary
- mark roadmap milestones `P2` (Dashboard signal) and `P3` (Notification baseline) as completed based on current implementation
- add `P8` household account linking/sharing milestone with tracking issue reference
- refresh `docs/HANDOFF.md` to reflect implemented reminder/email baseline and current remaining gaps
- update `docs/TEST_PLAN.md` required checks to include `npm run test:dashboard`
- add explicit Windows guidance in `README.md` and `AGENTS.md` to run local commands via Git Bash instead of PowerShell

## Validation
- `npm run test:dashboard` (Git Bash)
- `npm run test:mail` (Git Bash)

## Related
- Refs #67
- Refs #65