### PR TITLE
Wire registration verification into auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Useful commands:
 - Email templates are authored with React Email in `lib/mail/templates/`:
   - test email
   - invite issuance
-  - registration verification (template only)
+  - registration verification
   - subscription reminder
 - Manual validation workflow:
   - go to `/tools`
@@ -164,6 +164,7 @@ Useful commands:
 - Delivery attempts are recorded in Prisma `EmailDeliveryLog` (`SENT`, `FAILED`, `SKIPPED`).
 - Reminder dispatch dedupe state is recorded in Prisma `SubscriptionReminderDispatch` (unique per `userId + billingDateKey`).
 - Invite issuance from `/tools` attempts immediate email delivery and falls back to manual share when provider is unavailable or send fails.
+- Registration sign-up now issues single-use verification links, logs delivery as `registration_verification`, and rate-limits resend attempts per recipient.
 - Daily maintenance dispatches due subscription reminder batches using each user's saved reminder settings.
 - Daily maintenance prunes stale email logs using `EMAIL_DELIVERY_LOG_RETENTION_DAYS`.
 - Local template preview command:
@@ -247,12 +248,14 @@ Open http://localhost:3000.
 ## Basic auth (MVP)
 
 - Sign up at `/auth/sign-up` (email + password, minimum 8 chars).
+- New accounts must verify email ownership before a session can be created.
 - Optional invitation-only mode:
   - set `INVITES_REQUIRED=true` to require valid invite token on sign-up.
   - invite token must be pending, unexpired, and tied to the same normalized email.
   - `/tools` invite issuance now issues and attempts email send in one step; if email cannot be sent, manual token/URL share remains available.
   - keep `INVITES_REQUIRED=false` for rollback to open sign-up.
 - Sign in at `/auth/sign-in`.
+- Verification completion lives at `/auth/verify`, and resend/self-service status lives at `/auth/verify/requested`.
 - Session is stored as an HTTP-only cookie with an opaque token backed by the `Session` database table.
 - Session token hashes are keyed with `AUTH_SECRET`.
 - Session policy:
@@ -261,6 +264,7 @@ Open http://localhost:3000.
   - max concurrent sessions per user: 5
   - sign-out revokes current session only
 - Sign-in is rate limited by email + IP (5 attempts per 15 minutes, then 30-minute block).
+- Unverified accounts cannot complete sign-in or keep an authenticated session until verification succeeds.
 - Auth server actions enforce same-origin request checks.
 - Expired sessions are pruned on sign-in.
 - Manual maintenance actions are available at `/tools` for test runs.

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -7,6 +7,7 @@ import { db } from "@/lib/db";
 import { isInvitesRequired } from "@/lib/env";
 import { createUserWithInvite } from "@/lib/invites";
 import {
+  authenticateWithPassword,
   clearAuthSession,
   clearSignInRateLimit,
   consumeSignInRateLimit,
@@ -14,8 +15,8 @@ import {
   pruneExpiredSessions,
   pruneStaleSignInAttempts,
   setAuthSession,
-  verifyPassword,
 } from "@/lib/auth";
+import { issueRegistrationVerificationForUser } from "@/lib/registration-verification";
 
 function normalizeEmail(value: FormDataEntryValue | null): string {
   return String(value ?? "").trim().toLowerCase();
@@ -59,6 +60,46 @@ async function isSameOriginRequest(): Promise<boolean> {
   }
 }
 
+async function getRequestBaseUrl(): Promise<string> {
+  const headerStore = await headers();
+  const origin = headerStore.get("origin");
+
+  if (origin) {
+    return origin;
+  }
+
+  const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
+  const proto = headerStore.get("x-forwarded-proto") ?? (process.env.NODE_ENV === "development" ? "http" : "https");
+
+  if (host) {
+    return `${proto}://${host}`;
+  }
+
+  return "http://localhost:3000";
+}
+
+function buildVerificationRequestedRedirect(params: {
+  email: string;
+  source: "signup" | "signin" | "resend";
+  delivery?: string | null;
+  retryAfterSeconds?: number | null;
+}): string {
+  const searchParams = new URLSearchParams({
+    email: params.email,
+    source: params.source,
+  });
+
+  if (params.delivery) {
+    searchParams.set("delivery", params.delivery);
+  }
+
+  if (typeof params.retryAfterSeconds === "number" && params.retryAfterSeconds > 0) {
+    searchParams.set("retry_after", String(params.retryAfterSeconds));
+  }
+
+  return `/auth/verify/requested?${searchParams.toString()}`;
+}
+
 export async function signUpAction(formData: FormData): Promise<void> {
   if (!(await isSameOriginRequest())) {
     redirect("/auth/sign-up?error=invalid_request");
@@ -96,8 +137,20 @@ export async function signUpAction(formData: FormData): Promise<void> {
       redirect("/auth/sign-up?error=invalid_invite");
     }
 
-    await setAuthSession(registration.user);
-    redirect("/");
+    const verification = await issueRegistrationVerificationForUser({
+      userId: registration.user.id,
+      email: registration.user.email,
+      baseUrl: await getRequestBaseUrl(),
+    });
+
+    redirect(
+      buildVerificationRequestedRedirect({
+        email: registration.user.email,
+        source: "signup",
+        delivery: verification.outcome,
+        retryAfterSeconds: verification.retryAfterSeconds,
+      }),
+    );
   }
 
   const existingUser = await db.user.findUnique({
@@ -124,8 +177,20 @@ export async function signUpAction(formData: FormData): Promise<void> {
     },
   });
 
-  await setAuthSession(user);
-  redirect("/");
+  const verification = await issueRegistrationVerificationForUser({
+    userId: user.id,
+    email: user.email,
+    baseUrl: await getRequestBaseUrl(),
+  });
+
+  redirect(
+    buildVerificationRequestedRedirect({
+      email: user.email,
+      source: "signup",
+      delivery: verification.outcome,
+      retryAfterSeconds: verification.retryAfterSeconds,
+    }),
+  );
 }
 
 export async function signInAction(formData: FormData): Promise<void> {
@@ -151,22 +216,25 @@ export async function signInAction(formData: FormData): Promise<void> {
     redirect(`/auth/sign-in?error=rate_limited&retry_after=${retryAfter}`);
   }
 
-  const user = await db.user.findUnique({
-    where: { email },
-    select: {
-      id: true,
-      email: true,
-      passwordHash: true,
-    },
-  });
+  const authentication = await authenticateWithPassword(email, password);
 
-  if (!user?.passwordHash || !verifyPassword(password, user.passwordHash)) {
+  if (!authentication.ok && authentication.reason === "email_unverified") {
+    await clearSignInRateLimit(email, ipAddress);
+    redirect(
+      buildVerificationRequestedRedirect({
+        email: authentication.user?.email ?? email,
+        source: "signin",
+      }),
+    );
+  }
+
+  if (!authentication.ok) {
     redirect("/auth/sign-in?error=invalid_credentials");
   }
 
   await clearSignInRateLimit(email, ipAddress);
   await pruneExpiredSessions();
-  await setAuthSession({ id: user.id, email: user.email });
+  await setAuthSession(authentication.user);
   redirect("/");
 }
 

--- a/app/auth/verify/actions.ts
+++ b/app/auth/verify/actions.ts
@@ -1,0 +1,100 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { resendRegistrationVerificationForEmail } from "@/lib/registration-verification";
+
+function normalizeEmail(value: FormDataEntryValue | null): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+async function isSameOriginRequest(): Promise<boolean> {
+  const headerStore = await headers();
+  const origin = headerStore.get("origin");
+  const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
+
+  if (!origin) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  if (!host) {
+    return false;
+  }
+
+  const proto = headerStore.get("x-forwarded-proto") ?? (process.env.NODE_ENV === "development" ? "http" : "https");
+
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host.toLowerCase() === host.toLowerCase() && originUrl.protocol === `${proto}:`;
+  } catch {
+    return false;
+  }
+}
+
+async function getRequestBaseUrl(): Promise<string> {
+  const headerStore = await headers();
+  const origin = headerStore.get("origin");
+
+  if (origin) {
+    return origin;
+  }
+
+  const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
+  const proto = headerStore.get("x-forwarded-proto") ?? (process.env.NODE_ENV === "development" ? "http" : "https");
+
+  if (host) {
+    return `${proto}://${host}`;
+  }
+
+  return "http://localhost:3000";
+}
+
+function buildVerificationRequestedRedirect(params: {
+  email: string;
+  delivery?: string | null;
+  retryAfterSeconds?: number | null;
+}): string {
+  const searchParams = new URLSearchParams({
+    source: "resend",
+  });
+
+  if (params.email) {
+    searchParams.set("email", params.email);
+  }
+
+  if (params.delivery) {
+    searchParams.set("delivery", params.delivery);
+  }
+
+  if (typeof params.retryAfterSeconds === "number" && params.retryAfterSeconds > 0) {
+    searchParams.set("retry_after", String(params.retryAfterSeconds));
+  }
+
+  return `/auth/verify/requested?${searchParams.toString()}`;
+}
+
+export async function resendRegistrationVerificationAction(formData: FormData): Promise<void> {
+  const email = normalizeEmail(formData.get("email"));
+
+  if (!(await isSameOriginRequest())) {
+    redirect(buildVerificationRequestedRedirect({ email, delivery: "invalid_request" }));
+  }
+
+  if (!email) {
+    redirect(buildVerificationRequestedRedirect({ email, delivery: "missing_email" }));
+  }
+
+  const result = await resendRegistrationVerificationForEmail({
+    email,
+    baseUrl: await getRequestBaseUrl(),
+  });
+
+  redirect(
+    buildVerificationRequestedRedirect({
+      email,
+      delivery: result.outcome,
+      retryAfterSeconds: result.retryAfterSeconds,
+    }),
+  );
+}

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+import { consumeRegistrationVerificationToken } from "@/lib/registration-verification";
+
+type VerifyPageProps = {
+  searchParams?: {
+    token?: string;
+  };
+};
+
+function buildRequestedHref(email: string | null): string {
+  if (!email) {
+    return "/auth/verify/requested";
+  }
+
+  return `/auth/verify/requested?${new URLSearchParams({ email }).toString()}`;
+}
+
+function getVerificationMessage(result: Awaited<ReturnType<typeof consumeRegistrationVerificationToken>>): {
+  title: string;
+  body: string;
+} {
+  if (result.ok) {
+    return {
+      title: "Email verified",
+      body: "Your account is now verified. Sign in to access the app.",
+    };
+  }
+
+  if (result.reason === "missing_token") {
+    return {
+      title: "Verification link required",
+      body: "Open the verification link from your email, or request a new verification message.",
+    };
+  }
+
+  if (result.reason === "expired_token") {
+    return {
+      title: "Verification link expired",
+      body: "This verification link has expired. Request a new email to finish setting up your account.",
+    };
+  }
+
+  if (result.reason === "replayed_token") {
+    return {
+      title: "Verification link already used",
+      body: "This verification link was already consumed. Sign in if your account is verified, or request a new email.",
+    };
+  }
+
+  if (result.reason === "revoked_token") {
+    return {
+      title: "Verification link replaced",
+      body: "A newer verification email has already replaced this link. Use the latest email, or request another one.",
+    };
+  }
+
+  if (result.reason === "already_verified") {
+    return {
+      title: "Account already verified",
+      body: "Your account has already been verified. Continue to sign in.",
+    };
+  }
+
+  return {
+    title: "Invalid verification link",
+    body: "This verification link is invalid. Request a new verification email and try again.",
+  };
+}
+
+export default async function VerifyPage({ searchParams }: VerifyPageProps) {
+  const token = String(searchParams?.token ?? "").trim();
+  const result = await consumeRegistrationVerificationToken(token);
+  const message = getVerificationMessage(result);
+  const requestedHref = buildRequestedHref(result.email);
+
+  return (
+    <section className="auth-wrap">
+      <article className="card auth-card">
+        <p className="eyebrow">Email Verification</p>
+        <h1>{message.title}</h1>
+        <p className="page-lead">{message.body}</p>
+        <p className="auth-switch">
+          <Link href="/auth/sign-in">Go to sign in</Link>
+        </p>
+        {!result.ok ? (
+          <p className="auth-switch">
+            <Link href={requestedHref}>Request another verification email</Link>
+          </p>
+        ) : null}
+      </article>
+    </section>
+  );
+}

--- a/app/auth/verify/requested/page.tsx
+++ b/app/auth/verify/requested/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+
+import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
+
+import { resendRegistrationVerificationAction } from "../actions";
+
+type VerificationRequestedPageProps = {
+  searchParams?: {
+    email?: string;
+    source?: string;
+    delivery?: string;
+    retry_after?: string;
+  };
+};
+
+function normalizeEmail(value: string | undefined): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function getHeading(source: string | undefined): { title: string; body: string } {
+  if (source === "signin") {
+    return {
+      title: "Verify your email before signing in",
+      body: "Your password was correct, but the account still needs email verification before a session can be created.",
+    };
+  }
+
+  if (source === "resend") {
+    return {
+      title: "Verification email status",
+      body: "If the address belongs to an unverified account, you can request another verification email below.",
+    };
+  }
+
+  return {
+    title: "Check your inbox",
+    body: "A verification email is required before your account can access the app.",
+  };
+}
+
+function getStatusMessage(delivery: string | undefined, retryAfter: string | undefined, email: string): string | null {
+  if (!delivery) {
+    return email ? `We’re waiting for verification on ${email}.` : null;
+  }
+
+  if (delivery === "sent") {
+    return email ? `Verification email sent to ${email}.` : "Verification email sent.";
+  }
+
+  if (delivery === "skipped") {
+    return "Email delivery is currently unavailable, so the verification message could not be sent automatically.";
+  }
+
+  if (delivery === "failed") {
+    return "Verification email delivery failed. Retry below to send a fresh link.";
+  }
+
+  if (delivery === "rate_limited") {
+    const retrySeconds = Number(retryAfter ?? "0");
+
+    if (Number.isFinite(retrySeconds) && retrySeconds > 0) {
+      return `Too many verification emails were requested recently. Try again in ${retrySeconds} seconds.`;
+    }
+
+    return "Too many verification emails were requested recently. Try again shortly.";
+  }
+
+  if (delivery === "ignored") {
+    return "If the address belongs to an unverified account, a fresh verification email can be requested here.";
+  }
+
+  if (delivery === "invalid_request") {
+    return "Invalid resend request. Retry from this page.";
+  }
+
+  if (delivery === "missing_email") {
+    return "Enter an email address to resend the verification email.";
+  }
+
+  return null;
+}
+
+export default function VerificationRequestedPage({ searchParams }: VerificationRequestedPageProps) {
+  const email = normalizeEmail(searchParams?.email);
+  const heading = getHeading(searchParams?.source);
+  const statusMessage = getStatusMessage(searchParams?.delivery, searchParams?.retry_after, email);
+
+  return (
+    <section className="auth-wrap">
+      <article className="card auth-card">
+        <p className="eyebrow">Email Verification</p>
+        <h1>{heading.title}</h1>
+        <p className="page-lead">{heading.body}</p>
+        {statusMessage ? <p className="status-help mt-md">{statusMessage}</p> : null}
+        <form className="mt-md" action={resendRegistrationVerificationAction}>
+          <PendingFieldset className="form-grid form-pending-group">
+            <label className="form-field">
+              Email
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                defaultValue={email}
+                placeholder="name@example.com"
+                required
+              />
+            </label>
+            <PendingSubmitButton className="button" idleLabel="Resend Verification Email" pendingLabel="Sending..." />
+          </PendingFieldset>
+        </form>
+        <p className="auth-switch">
+          <Link href="/auth/sign-in">Back to sign in</Link>
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,7 @@ Main concerns:
 
 - `/` dashboard (auth-aware message).
 - `/auth/sign-in`, `/auth/sign-up` (server-action forms; sign-up accepts optional `invite` token context).
+- `/auth/verify`, `/auth/verify/requested` (public verification completion + resend flow).
 - `/subscriptions` (authenticated).
 - `/settings` (authenticated; action-first settings UI with inline auto-save for simple preferences and modal edit flow for account details).
 - `/tools` (authenticated maintenance + invite issuance and invite-email actions with manual-share fallback).
@@ -32,6 +33,7 @@ Main concerns:
 Defined in `prisma/schema.prisma`:
 
 - `User`
+- `User.emailVerifiedAt` tracks whether the account can enter authenticated flows.
 - `UserSettings` (1:1 with user; `defaultCurrency`, `remindersEnabled`, `reminderDaysBefore`, `displayMode`)
 - `DisplayMode` enum (`DEVICE`, `LIGHT`, `DARK`)
 - `Subscription` (many per user; includes learning fields `paymentMethod` required and `signedUpBy` optional, plus optional billing links and markdown notes)
@@ -39,6 +41,7 @@ Defined in `prisma/schema.prisma`:
 - `SignInAttempt` (rate-limit tracking by hashed email+IP key)
 - `Invite` (single-use invitation registry with token hash, status lifecycle, and audit fields)
 - `InviteStatus` enum (`PENDING`, `CONSUMED`, `EXPIRED`, `REVOKED`)
+- `EmailVerificationToken` (single-use registration verification token hash, expiry, consume/revoke timestamps)
 - `EmailDeliveryLog` (delivery attempts with template metadata and provider outcome)
 - `EmailDeliveryStatus` enum (`SENT`, `FAILED`, `SKIPPED`)
 - `SubscriptionReminderDispatch` (idempotent reminder dispatch lock/status per `user + billing date`)
@@ -99,17 +102,19 @@ Modal behavior:
 
 1. Sign-up/sign-in server action validates credentials.
 2. Passwords are stored as `scrypt` hashes.
-3. On success:
+3. Sign-up creates the user record, issues a verification token, sends `registration_verification`, and redirects to `/auth/verify/requested` instead of creating a session.
+4. Verification links land on `/auth/verify`, atomically consume the token, mark `User.emailVerifiedAt`, and revoke older outstanding verification tokens.
+5. Verified sign-in success:
    - generate random session token.
    - store HMAC-SHA256 token hash in `Session` table with `expiresAt` and `lastSeenAt`.
    - set HTTP-only cookie with raw token.
-4. Requests read cookie, hash token, look up session, enforce absolute and idle expiry.
-5. Session touch updates `lastSeenAt` at a fixed interval.
-6. Sign-in enforces rate limiting (email+IP), prunes stale attempts, and prunes expired sessions.
-7. Sign-out deletes matching session row and clears cookie.
-8. Auth actions require same-origin request validation.
-9. If `INVITES_REQUIRED=true`, sign-up additionally requires a valid invite token bound to submitted email.
-10. Invite consumption and user creation run in one DB transaction to ensure one-time use under concurrency.
+6. Requests read cookie, hash token, look up session, enforce absolute and idle expiry, and clear sessions for users whose email is still unverified.
+7. Session touch updates `lastSeenAt` at a fixed interval.
+8. Sign-in enforces rate limiting (email+IP), prunes stale attempts, and prunes expired sessions.
+9. Sign-out deletes matching session row and clears cookie.
+10. Auth actions require same-origin request validation.
+11. If `INVITES_REQUIRED=true`, sign-up additionally requires a valid invite token bound to submitted email.
+12. Invite consumption and user creation run in one DB transaction to ensure one-time use under concurrency.
 
 ## Settings flow
 
@@ -152,9 +157,11 @@ Status payload also includes email readiness:
 2. React Email template rendering (`lib/mail/templates`).
 3. `sendEmail` logging into `EmailDeliveryLog` for all attempts.
 4. `sendInviteEmail` helper for invite issuance delivery (`invite_issuance` template) with explicit `sent`/`skipped`/`failed` outcomes.
-5. Rate-limit helper for `/api/mail/test` (3 sends per user per hour).
-6. `runSubscriptionReminderDispatchJob` selects due subscriptions based on `UserSettings`, groups by user, and sends `subscription_reminder` emails.
-7. `SubscriptionReminderDispatch` enforces idempotency for reminder reruns (`userId + billingDateKey` uniqueness).
+5. `sendRegistrationVerificationEmail` helper for registration verification delivery (`registration_verification` template) with explicit `sent`/`skipped`/`failed` outcomes.
+6. Registration verification resend throttling is enforced per recipient using recent `EmailDeliveryLog` entries.
+7. Rate-limit helper for `/api/mail/test` (3 sends per user per hour).
+8. `runSubscriptionReminderDispatchJob` selects due subscriptions based on `UserSettings`, groups by user, and sends `subscription_reminder` emails.
+9. `SubscriptionReminderDispatch` enforces idempotency for reminder reruns (`userId + billingDateKey` uniqueness).
 
 Current guarantees:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -67,6 +67,7 @@ Email service:
 - Test endpoint: `POST /api/mail/test` (authenticated, 3 requests/user/hour).
 - Readiness is exposed at `/api/status` and `/status` under the `email` section.
 - Invite issuance at `/tools` sends `invite_issuance` email attempts through the same logging path; if provider is `console` or send fails, operators should manually share the one-time invite URL/token shown in UI.
+- Registration verification sends `registration_verification` email attempts during sign-up and resend requests, and resend attempts are throttled per recipient in an hourly window.
 
 ## Common runbook
 
@@ -94,10 +95,15 @@ Email service:
    - verify `/tools` invite issuance succeeds for authenticated operators and reports invite email send outcome.
    - confirm sign-up rejects missing/invalid invite tokens.
    - verify `EmailDeliveryLog` writes `invite_issuance` rows for invite send attempts.
-6. Verify email health path:
+6. Verify registration email flow:
+   - create a fresh account and confirm the app redirects to `/auth/verify/requested` instead of signing the user in.
+   - confirm `EmailDeliveryLog` writes `registration_verification` with expected status.
+   - open the emailed `/auth/verify` link and confirm sign-in succeeds only after verification.
+   - request repeated resends and confirm the flow rate-limits after the configured hourly threshold.
+7. Verify email health path:
    - trigger `Send Test Email` from `/tools` as an authenticated user.
    - confirm `EmailDeliveryLog` row is written with expected status.
-7. Verify reminder maintenance path:
+8. Verify reminder maintenance path:
    - trigger `Run Daily Batch` from `/tools`.
    - confirm output includes reminder due/sent/failed/deduped counters.
    - confirm `EmailDeliveryLog` includes `templateName=subscription_reminder` for successful reminder sends.
@@ -130,6 +136,12 @@ Invite sign-up rejects with invalid invite:
 - verify `INVITES_REQUIRED` expected value in environment.
 - confirm invite token was freshly issued from `/tools` and not previously consumed.
 - confirm submitted sign-up email exactly matches invite target email after lowercase normalization.
+
+Registration verification issues:
+
+- inspect `EmailDeliveryLog` for `templateName=registration_verification` rows and recent `FAILED`/`SKIPPED` statuses.
+- if resend attempts are unexpectedly blocked, check recent verification mail volume for the target recipient in the last hour.
+- if `/auth/verify` rejects a link, confirm the token was not already consumed, revoked by a newer resend, or expired.
 
 Test email fails:
 

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -5,9 +5,10 @@
 1. `npm run typecheck`
 2. `npm run lint`
 3. `npm run build`
-4. `npm run test:invites` (when local Postgres is available)
-5. `npm run test:mail`
-6. `npm run test:dashboard`
+4. `npm run test:auth` (when local Postgres is available)
+5. `npm run test:invites` (when local Postgres is available)
+6. `npm run test:mail`
+7. `npm run test:dashboard`
 
 For migration/schema changes:
 
@@ -21,17 +22,20 @@ For migration/schema changes:
 Auth:
 
 1. Sign up with new user.
-2. Sign out.
-3. Sign in with same user.
-4. Confirm `/subscriptions` loads when signed in.
-5. Confirm `/subscriptions` redirects to sign-in when signed out.
-6. Submit repeated bad credentials and confirm rate-limit response appears.
-7. Confirm sign-in rejects cross-origin requests (invalid request path).
-8. If `INVITES_REQUIRED=true`, confirm sign-up rejects missing invite token with safe generic error.
-9. From `/tools`, issue an invite for `invite-test@example.com`; complete sign-up using invite link and matching email.
-10. Confirm invite issuance reports email send status in `/tools`; if provider is unavailable, confirm fallback message instructs manual share.
-11. Retry sign-up with the same invite token and confirm rejection.
-12. Issue invite for one email and attempt sign-up with different email; confirm rejection.
+2. Confirm sign-up redirects to `/auth/verify/requested` and does not create an authenticated session yet.
+3. Open the verification email link and confirm `/auth/verify` reports success.
+4. Sign in with the same user and confirm success only after verification.
+5. Confirm `/subscriptions` loads when signed in.
+6. Confirm `/subscriptions` redirects to sign-in when signed out.
+7. Submit repeated bad credentials and confirm rate-limit response appears.
+8. Confirm sign-in with a correct password but unverified account redirects back to the verification flow.
+9. Confirm sign-in rejects cross-origin requests (invalid request path).
+10. Confirm repeated verification resends eventually show the rate-limit response.
+11. If `INVITES_REQUIRED=true`, confirm sign-up rejects missing invite token with safe generic error.
+12. From `/tools`, issue an invite for `invite-test@example.com`; complete sign-up using invite link and matching email.
+13. Confirm invite issuance reports email send status in `/tools`; if provider is unavailable, confirm fallback message instructs manual share.
+14. Retry sign-up with the same invite token and confirm rejection.
+15. Issue invite for one email and attempt sign-up with different email; confirm rejection.
 
 Subscriptions UX:
 
@@ -89,10 +93,12 @@ Email:
 2. Confirm success response instructs to check inbox/spam.
 3. Trigger 4 sends within one hour and confirm the fourth request is rate-limited.
 4. In Prisma Studio, verify `EmailDeliveryLog` rows are created with expected `templateName` and `status`.
-5. From `/tools`, issue an invite and verify an `EmailDeliveryLog` entry with `templateName=invite_issuance` is created.
-6. Disable provider key (or force `MAIL_PROVIDER=console`) and issue another invite; confirm `/tools` shows fallback/manual-share status while still returning token/URL.
-7. Set a subscription with `nextBillingDate` equal to today's date plus the user's `reminderDaysBefore`, run `Run Daily Batch`, and verify an `EmailDeliveryLog` row with `templateName=subscription_reminder` is created.
-8. Run `Run Daily Batch` again on the same day and confirm reminder dedupe in output (no duplicate reminder send for the same user + billing cycle).
+5. Sign up a fresh account and verify an `EmailDeliveryLog` entry with `templateName=registration_verification` is created.
+6. Trigger repeated resend attempts for the same account and confirm `registration_verification` rows stop increasing once rate-limited.
+7. From `/tools`, issue an invite and verify an `EmailDeliveryLog` entry with `templateName=invite_issuance` is created.
+8. Disable provider key (or force `MAIL_PROVIDER=console`) and issue another invite; confirm `/tools` shows fallback/manual-share status while still returning token/URL.
+9. Set a subscription with `nextBillingDate` equal to today's date plus the user's `reminderDaysBefore`, run `Run Daily Batch`, and verify an `EmailDeliveryLog` row with `templateName=subscription_reminder` is created.
+10. Run `Run Daily Batch` again on the same day and confirm reminder dedupe in output (no duplicate reminder send for the same user + billing cycle).
 
 Deploy:
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,6 +11,7 @@ import { redirect } from "next/navigation";
 
 import { db } from "./db";
 import { normalizeEnvValue } from "./env";
+import { isVerifiedAuthUser } from "./registration-verification";
 
 export type AuthUser = {
   id: string;
@@ -21,6 +22,17 @@ export type SignInRateLimitResult = {
   allowed: boolean;
   retryAfterSeconds: number | null;
 };
+
+export type PasswordAuthenticationResult =
+  | {
+      ok: true;
+      user: AuthUser;
+    }
+  | {
+      ok: false;
+      reason: "invalid_credentials" | "email_unverified";
+      user: AuthUser | null;
+    };
 
 const SESSION_COOKIE_NAME = "sub_stalker_session";
 const SESSION_ABSOLUTE_TTL_SECONDS = 60 * 60 * 24 * 7;
@@ -232,6 +244,48 @@ export function verifyPassword(password: string, storedHash: string): boolean {
   return safeEqual(existingHash, hash);
 }
 
+export async function authenticateWithPassword(
+  email: string,
+  password: string,
+): Promise<PasswordAuthenticationResult> {
+  const user = await db.user.findUnique({
+    where: { email },
+    select: {
+      id: true,
+      email: true,
+      passwordHash: true,
+      emailVerifiedAt: true,
+    },
+  });
+
+  if (!user?.passwordHash || !verifyPassword(password, user.passwordHash)) {
+    return {
+      ok: false,
+      reason: "invalid_credentials",
+      user: null,
+    };
+  }
+
+  if (!isVerifiedAuthUser(user)) {
+    return {
+      ok: false,
+      reason: "email_unverified",
+      user: {
+        id: user.id,
+        email: user.email,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    user: {
+      id: user.id,
+      email: user.email,
+    },
+  };
+}
+
 export async function setAuthSession(user: AuthUser): Promise<void> {
   const cookieStore = await cookies();
   const now = Date.now();
@@ -297,12 +351,24 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
         select: {
           id: true,
           email: true,
+          emailVerifiedAt: true,
         },
       },
     },
   });
 
   if (!session) {
+    return null;
+  }
+
+  if (!isVerifiedAuthUser(session.user)) {
+    await db.session.deleteMany({
+      where: {
+        tokenHash,
+      },
+    });
+
+    clearCookie(cookieStore);
     return null;
   }
 
@@ -330,7 +396,10 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
     });
   }
 
-  return session.user;
+  return {
+    id: session.user.id,
+    email: session.user.email,
+  };
 }
 
 export async function requireAuthenticatedUser(): Promise<AuthUser> {

--- a/lib/mail/index.ts
+++ b/lib/mail/index.ts
@@ -149,20 +149,38 @@ export async function sendTestEmail(input: {
   });
 }
 
+export type RegistrationVerificationEmailSendOutcome = "sent" | "skipped" | "failed";
+
+export type RegistrationVerificationEmailSendResult = {
+  outcome: RegistrationVerificationEmailSendOutcome;
+  provider: MailProviderName;
+  messageId: string | null;
+  error: string | null;
+};
+
+type SendRegistrationVerificationEmailDependencies = {
+  providerName?: MailProviderName;
+  sendEmailFn?: (payload: EmailPayload) => Promise<EmailResult>;
+};
+
 export async function sendRegistrationVerificationEmail(input: {
   to: string;
   userId?: string;
   verificationUrl: string;
   expiresInMinutes?: number;
   appName?: string;
-}): Promise<EmailResult> {
+},
+dependencies: SendRegistrationVerificationEmailDependencies = {},
+): Promise<RegistrationVerificationEmailSendResult> {
   const rendered = await renderRegistrationVerificationTemplate({
     appName: input.appName,
     verificationUrl: input.verificationUrl,
     expiresInMinutes: input.expiresInMinutes,
   });
 
-  return sendEmail({
+  const providerName = dependencies.providerName ?? getMailProvider();
+  const sendEmailFn = dependencies.sendEmailFn ?? sendEmail;
+  const result = await sendEmailFn({
     to: input.to,
     subject: rendered.subject,
     html: rendered.html,
@@ -170,6 +188,31 @@ export async function sendRegistrationVerificationEmail(input: {
     templateName: rendered.templateName,
     userId: input.userId,
   });
+
+  if (!result.success) {
+    return {
+      outcome: "failed",
+      provider: providerName,
+      messageId: result.messageId ?? null,
+      error: result.error ?? "Unknown email send failure.",
+    };
+  }
+
+  if (providerName === "console") {
+    return {
+      outcome: "skipped",
+      provider: providerName,
+      messageId: result.messageId ?? null,
+      error: null,
+    };
+  }
+
+  return {
+    outcome: "sent",
+    provider: providerName,
+    messageId: result.messageId ?? null,
+    error: null,
+  };
 }
 
 export async function sendSubscriptionReminderEmail(input: {

--- a/lib/registration-verification.ts
+++ b/lib/registration-verification.ts
@@ -1,0 +1,479 @@
+import { createHmac, randomBytes } from "node:crypto";
+
+import { Prisma } from "@prisma/client";
+
+import { db } from "./db";
+import { normalizeEnvValue } from "./env";
+import {
+  sendRegistrationVerificationEmail,
+  type RegistrationVerificationEmailSendResult,
+} from "./mail";
+
+export const REGISTRATION_VERIFICATION_TOKEN_BYTES = 32;
+export const REGISTRATION_VERIFICATION_TTL_MINUTES = 60;
+export const REGISTRATION_VERIFICATION_WINDOW_SECONDS = 60 * 60;
+export const REGISTRATION_VERIFICATION_MAX_PER_WINDOW = 3;
+
+type TimeDependencies = {
+  now?: () => Date;
+};
+
+type IssueRegistrationVerificationDependencies = TimeDependencies & {
+  sendRegistrationVerificationEmailFn?: typeof sendRegistrationVerificationEmail;
+};
+
+export type RegistrationVerificationDispatchResult =
+  | ({
+      retryAfterSeconds: null;
+      verificationToken: string;
+      verificationUrl: string;
+      expiresAt: Date;
+    } & RegistrationVerificationEmailSendResult)
+  | {
+      outcome: "rate_limited";
+      provider: null;
+      messageId: null;
+      error: null;
+      retryAfterSeconds: number;
+      verificationToken: null;
+      verificationUrl: null;
+      expiresAt: null;
+    };
+
+export type ResendRegistrationVerificationResult =
+  | RegistrationVerificationDispatchResult
+  | {
+      outcome: "ignored";
+      provider: null;
+      messageId: null;
+      error: null;
+      retryAfterSeconds: null;
+      verificationToken: null;
+      verificationUrl: null;
+      expiresAt: null;
+    };
+
+export type ConsumeRegistrationVerificationResult =
+  | {
+      ok: true;
+      email: string;
+      userId: string;
+    }
+  | {
+      ok: false;
+      reason: "missing_token" | "invalid_token";
+      email: null;
+      userId: null;
+    }
+  | {
+      ok: false;
+      reason: "expired_token" | "replayed_token" | "revoked_token" | "already_verified";
+      email: string;
+      userId: string;
+    };
+
+function getRegistrationVerificationSecret(): string {
+  const secret = normalizeEnvValue(process.env.AUTH_SECRET ?? "");
+
+  if (!secret) {
+    throw new Error("Missing AUTH_SECRET.");
+  }
+
+  return secret;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function logRegistrationVerificationEvent(
+  event: string,
+  payload: Record<string, string | number | boolean | null>,
+): void {
+  console.info(
+    JSON.stringify({
+      event,
+      domain: "registration_verification",
+      timestamp: new Date().toISOString(),
+      ...payload,
+    }),
+  );
+}
+
+function resolveNow(now?: () => Date): Date {
+  return now ? now() : new Date();
+}
+
+function resolveVerificationFailureReason(tokenRecord: {
+  userId: string;
+  expiresAt: Date;
+  consumedAt: Date | null;
+  revokedAt: Date | null;
+  user: {
+    email: string;
+    emailVerifiedAt: Date | null;
+  };
+}, now: Date): Exclude<ConsumeRegistrationVerificationResult, { ok: true; email: string; userId: string }> | null {
+  if (tokenRecord.consumedAt) {
+    return {
+      ok: false,
+      reason: "replayed_token",
+      email: tokenRecord.user.email,
+      userId: tokenRecord.userId,
+    };
+  }
+
+  if (tokenRecord.revokedAt) {
+    return {
+      ok: false,
+      reason: "revoked_token",
+      email: tokenRecord.user.email,
+      userId: tokenRecord.userId,
+    };
+  }
+
+  if (tokenRecord.user.emailVerifiedAt) {
+    return {
+      ok: false,
+      reason: "already_verified",
+      email: tokenRecord.user.email,
+      userId: tokenRecord.userId,
+    };
+  }
+
+  if (tokenRecord.expiresAt <= now) {
+    return {
+      ok: false,
+      reason: "expired_token",
+      email: tokenRecord.user.email,
+      userId: tokenRecord.userId,
+    };
+  }
+
+  return null;
+}
+
+async function enforceRegistrationVerificationRateLimit(
+  recipientEmail: string,
+  now: Date,
+): Promise<number | null> {
+  const normalizedEmail = normalizeEmail(recipientEmail);
+  const windowStart = new Date(now.getTime() - REGISTRATION_VERIFICATION_WINDOW_SECONDS * 1000);
+
+  const [sentInWindow, oldestInWindow] = await Promise.all([
+    db.emailDeliveryLog.count({
+      where: {
+        recipientEmail: normalizedEmail,
+        templateName: "registration_verification",
+        createdAt: {
+          gte: windowStart,
+        },
+      },
+    }),
+    db.emailDeliveryLog.findFirst({
+      where: {
+        recipientEmail: normalizedEmail,
+        templateName: "registration_verification",
+        createdAt: {
+          gte: windowStart,
+        },
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+      select: {
+        createdAt: true,
+      },
+    }),
+  ]);
+
+  if (sentInWindow < REGISTRATION_VERIFICATION_MAX_PER_WINDOW) {
+    return null;
+  }
+
+  if (!oldestInWindow) {
+    return REGISTRATION_VERIFICATION_WINDOW_SECONDS;
+  }
+
+  return Math.max(
+    Math.ceil(
+      (oldestInWindow.createdAt.getTime() + REGISTRATION_VERIFICATION_WINDOW_SECONDS * 1000 - now.getTime()) / 1000,
+    ),
+    1,
+  );
+}
+
+export function hashRegistrationVerificationToken(token: string): string {
+  return createHmac("sha256", getRegistrationVerificationSecret()).update(token).digest("hex");
+}
+
+export function buildRegistrationVerificationUrl(baseUrl: string, token: string): string {
+  const trimmedBaseUrl = baseUrl.replace(/\/$/, "");
+  return `${trimmedBaseUrl}/auth/verify?token=${encodeURIComponent(token)}`;
+}
+
+export async function issueRegistrationVerificationForUser(
+  params: {
+    userId: string;
+    email: string;
+    baseUrl: string;
+  },
+  dependencies: IssueRegistrationVerificationDependencies = {},
+): Promise<RegistrationVerificationDispatchResult> {
+  const now = resolveNow(dependencies.now);
+  const normalizedEmail = normalizeEmail(params.email);
+  const retryAfterSeconds = await enforceRegistrationVerificationRateLimit(normalizedEmail, now);
+
+  if (retryAfterSeconds !== null) {
+    logRegistrationVerificationEvent("verification_dispatch_rejected", {
+      reason: "rate_limited",
+      userId: params.userId,
+      recipientEmail: normalizedEmail,
+      retryAfterSeconds,
+    });
+
+    return {
+      outcome: "rate_limited",
+      provider: null,
+      messageId: null,
+      error: null,
+      retryAfterSeconds,
+      verificationToken: null,
+      verificationUrl: null,
+      expiresAt: null,
+    };
+  }
+
+  const verificationToken = randomBytes(REGISTRATION_VERIFICATION_TOKEN_BYTES).toString("base64url");
+  const tokenHash = hashRegistrationVerificationToken(verificationToken);
+  const expiresAt = new Date(now.getTime() + REGISTRATION_VERIFICATION_TTL_MINUTES * 60 * 1000);
+  const verificationUrl = buildRegistrationVerificationUrl(params.baseUrl, verificationToken);
+
+  await db.$transaction(async (tx) => {
+    await tx.emailVerificationToken.updateMany({
+      where: {
+        userId: params.userId,
+        consumedAt: null,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: now,
+      },
+    });
+
+    await tx.emailVerificationToken.create({
+      data: {
+        userId: params.userId,
+        tokenHash,
+        expiresAt,
+      },
+    });
+  });
+
+  const sendEmailFn = dependencies.sendRegistrationVerificationEmailFn ?? sendRegistrationVerificationEmail;
+  const delivery = await sendEmailFn({
+    to: normalizedEmail,
+    userId: params.userId,
+    verificationUrl,
+    expiresInMinutes: REGISTRATION_VERIFICATION_TTL_MINUTES,
+  });
+
+  logRegistrationVerificationEvent("verification_dispatch_completed", {
+    userId: params.userId,
+    recipientEmail: normalizedEmail,
+    outcome: delivery.outcome,
+    provider: delivery.provider,
+    messageId: delivery.messageId,
+    error: delivery.error,
+  });
+
+  return {
+    ...delivery,
+    retryAfterSeconds: null,
+    verificationToken,
+    verificationUrl,
+    expiresAt,
+  };
+}
+
+export async function resendRegistrationVerificationForEmail(
+  params: {
+    email: string;
+    baseUrl: string;
+  },
+  dependencies: IssueRegistrationVerificationDependencies = {},
+): Promise<ResendRegistrationVerificationResult> {
+  const normalizedEmail = normalizeEmail(params.email);
+  const user = await db.user.findUnique({
+    where: {
+      email: normalizedEmail,
+    },
+    select: {
+      id: true,
+      email: true,
+      emailVerifiedAt: true,
+    },
+  });
+
+  if (!user || user.emailVerifiedAt) {
+    logRegistrationVerificationEvent("verification_dispatch_ignored", {
+      recipientEmail: normalizedEmail,
+      reason: user?.emailVerifiedAt ? "already_verified" : "unknown_account",
+    });
+
+    return {
+      outcome: "ignored",
+      provider: null,
+      messageId: null,
+      error: null,
+      retryAfterSeconds: null,
+      verificationToken: null,
+      verificationUrl: null,
+      expiresAt: null,
+    };
+  }
+
+  return issueRegistrationVerificationForUser(
+    {
+      userId: user.id,
+      email: user.email,
+      baseUrl: params.baseUrl,
+    },
+    dependencies,
+  );
+}
+
+export async function consumeRegistrationVerificationToken(
+  rawToken: string,
+  dependencies: TimeDependencies = {},
+): Promise<ConsumeRegistrationVerificationResult> {
+  const token = rawToken.trim();
+
+  if (!token) {
+    return {
+      ok: false,
+      reason: "missing_token",
+      email: null,
+      userId: null,
+    };
+  }
+
+  const tokenHash = hashRegistrationVerificationToken(token);
+  const now = resolveNow(dependencies.now);
+
+  return db.$transaction(async (tx): Promise<ConsumeRegistrationVerificationResult> => {
+    const lockedTokens = await tx.$queryRaw<
+      Array<{
+        id: string;
+        userId: string;
+        expiresAt: Date;
+        consumedAt: Date | null;
+        revokedAt: Date | null;
+        email: string;
+        emailVerifiedAt: Date | null;
+      }>
+    >(Prisma.sql`
+      SELECT
+        evt."id",
+        evt."userId",
+        evt."expiresAt",
+        evt."consumedAt",
+        evt."revokedAt",
+        u."email" AS "email",
+        u."emailVerifiedAt" AS "emailVerifiedAt"
+      FROM "public"."EmailVerificationToken" evt
+      INNER JOIN "public"."User" u
+        ON u."id" = evt."userId"
+      WHERE evt."tokenHash" = ${tokenHash}
+      FOR UPDATE
+    `);
+
+    const tokenRow = lockedTokens[0];
+    const tokenRecord = tokenRow
+      ? {
+          id: tokenRow.id,
+          userId: tokenRow.userId,
+          expiresAt: tokenRow.expiresAt,
+          consumedAt: tokenRow.consumedAt,
+          revokedAt: tokenRow.revokedAt,
+          user: {
+            email: tokenRow.email,
+            emailVerifiedAt: tokenRow.emailVerifiedAt,
+          },
+        }
+      : null;
+
+    if (!tokenRecord) {
+      logRegistrationVerificationEvent("verification_consumption_rejected", {
+        reason: "invalid_token",
+        tokenHash,
+      });
+
+      return {
+        ok: false,
+        reason: "invalid_token",
+        email: null,
+        userId: null,
+      };
+    }
+
+    const failure = resolveVerificationFailureReason(tokenRecord, now);
+
+    if (failure) {
+      logRegistrationVerificationEvent("verification_consumption_rejected", {
+        reason: failure.reason,
+        userId: tokenRecord.userId,
+        recipientEmail: tokenRecord.user.email,
+      });
+
+      return failure;
+    }
+
+    await tx.emailVerificationToken.update({
+      where: {
+        id: tokenRecord.id,
+      },
+      data: {
+        consumedAt: now,
+      },
+    });
+
+    await tx.user.update({
+      where: {
+        id: tokenRecord.userId,
+      },
+      data: {
+        emailVerifiedAt: tokenRecord.user.emailVerifiedAt ?? now,
+      },
+    });
+
+    await tx.emailVerificationToken.updateMany({
+      where: {
+        userId: tokenRecord.userId,
+        id: {
+          not: tokenRecord.id,
+        },
+        consumedAt: null,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: now,
+      },
+    });
+
+    logRegistrationVerificationEvent("verification_consumption_succeeded", {
+      userId: tokenRecord.userId,
+      recipientEmail: tokenRecord.user.email,
+    });
+
+    return {
+      ok: true,
+      email: tokenRecord.user.email,
+      userId: tokenRecord.userId,
+    };
+  });
+}
+
+export function isVerifiedAuthUser(user: { emailVerifiedAt: Date | null }): boolean {
+  return Boolean(user.emailVerifiedAt);
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test:auth": "npx dotenv -e .env.local -- node --import tsx --test tests/auth/*.test.ts",
     "test:invites": "dotenv -e .env.local -- node --import tsx --test tests/invites/*.test.ts",
     "test:mail": "dotenv -e .env.local -- node --import tsx --test tests/mail/*.test.ts",
     "test:dashboard": "dotenv -e .env.local -- node --import tsx --test tests/dashboard/*.test.ts",

--- a/prisma/migrations/20260313101500_add_email_verification_flow/migration.sql
+++ b/prisma/migrations/20260313101500_add_email_verification_flow/migration.sql
@@ -1,0 +1,39 @@
+ALTER TABLE "public"."User"
+ADD COLUMN "emailVerifiedAt" TIMESTAMP(3);
+
+CREATE TABLE "public"."EmailVerificationToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmailVerificationToken_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EmailVerificationToken_tokenHash_key" ON "public"."EmailVerificationToken"("tokenHash");
+CREATE INDEX "EmailVerificationToken_userId_createdAt_idx" ON "public"."EmailVerificationToken"("userId", "createdAt");
+CREATE INDEX "EmailVerificationToken_userId_consumedAt_revokedAt_exp_idx" ON "public"."EmailVerificationToken"("userId", "consumedAt", "revokedAt", "expiresAt");
+CREATE INDEX "EmailVerificationToken_expiresAt_idx" ON "public"."EmailVerificationToken"("expiresAt");
+
+ALTER TABLE "public"."EmailVerificationToken"
+ADD CONSTRAINT "EmailVerificationToken_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."EmailVerificationToken" ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    role_name TEXT;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['anon', 'authenticated']
+    LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE ALL PRIVILEGES ON TABLE public."EmailVerificationToken" FROM %I', role_name);
+        END IF;
+    END LOOP;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 
@@ -41,51 +41,53 @@ enum ReminderDispatchStatus {
 }
 
 model User {
-  id            String         @id @default(cuid())
-  email         String         @unique
-  passwordHash  String?
-  name          String?
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
-  settings      UserSettings?
-  subscriptions Subscription[]
-  sessions      Session[]
-  invitesCreated Invite[]      @relation("InviteCreatedByUser")
-  invitesConsumed Invite[]     @relation("InviteConsumedByUser")
-  emailDeliveryLogs EmailDeliveryLog[]
+  id                             String                         @id @default(cuid())
+  email                          String                         @unique
+  passwordHash                   String?
+  name                           String?
+  emailVerifiedAt                DateTime?
+  createdAt                      DateTime                       @default(now())
+  updatedAt                      DateTime                       @updatedAt
+  settings                       UserSettings?
+  subscriptions                  Subscription[]
+  sessions                       Session[]
+  invitesCreated                 Invite[]                       @relation("InviteCreatedByUser")
+  invitesConsumed                Invite[]                       @relation("InviteConsumedByUser")
+  emailDeliveryLogs              EmailDeliveryLog[]
+  emailVerificationTokens        EmailVerificationToken[]
   subscriptionReminderDispatches SubscriptionReminderDispatch[]
 }
 
 model UserSettings {
-  id              String   @id @default(cuid())
-  userId          String   @unique
-  defaultCurrency String   @default("USD")
-  remindersEnabled Boolean @default(true)
-  reminderDaysBefore Int   @default(3)
-  displayMode     DisplayMode @default(DEVICE)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                 String      @id @default(cuid())
+  userId             String      @unique
+  defaultCurrency    String      @default("USD")
+  remindersEnabled   Boolean     @default(true)
+  reminderDaysBefore Int         @default(3)
+  displayMode        DisplayMode @default(DEVICE)
+  createdAt          DateTime    @default(now())
+  updatedAt          DateTime    @updatedAt
+  user               User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Subscription {
-  id              String          @id @default(cuid())
-  userId          String
-  name            String
-  paymentMethod   String
-  signedUpBy      String?
-  billingConsoleUrl String?
+  id                    String          @id @default(cuid())
+  userId                String
+  name                  String
+  paymentMethod         String
+  signedUpBy            String?
+  billingConsoleUrl     String?
   cancelSubscriptionUrl String?
-  billingHistoryUrl String?
-  notesMarkdown   String?
-  amountCents     Int
-  currency        String          @default("USD")
-  billingInterval BillingInterval @default(MONTHLY)
-  nextBillingDate DateTime?
-  isActive        Boolean         @default(true)
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
-  user            User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  billingHistoryUrl     String?
+  notesMarkdown         String?
+  amountCents           Int
+  currency              String          @default("USD")
+  billingInterval       BillingInterval @default(MONTHLY)
+  nextBillingDate       DateTime?
+  isActive              Boolean         @default(true)
+  createdAt             DateTime        @default(now())
+  updatedAt             DateTime        @updatedAt
+  user                  User            @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, nextBillingDate])
   @@index([userId, paymentMethod])
@@ -93,26 +95,26 @@ model Subscription {
 }
 
 model Session {
-  id        String   @id @default(cuid())
-  userId    String
-  tokenHash String   @unique
-  expiresAt DateTime
+  id         String   @id @default(cuid())
+  userId     String
+  tokenHash  String   @unique
+  expiresAt  DateTime
   lastSeenAt DateTime @default(now())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, expiresAt])
 }
 
 model SignInAttempt {
-  id              String   @id @default(cuid())
-  key             String   @unique
-  attemptCount    Int      @default(0)
+  id              String    @id @default(cuid())
+  key             String    @unique
+  attemptCount    Int       @default(0)
   windowStartedAt DateTime
   blockedUntil    DateTime?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 }
 
 model Invite {
@@ -150,16 +152,32 @@ model EmailDeliveryLog {
   @@index([createdAt])
 }
 
+model EmailVerificationToken {
+  id         String    @id @default(cuid())
+  userId     String
+  tokenHash  String    @unique
+  expiresAt  DateTime
+  consumedAt DateTime?
+  revokedAt  DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([userId, consumedAt, revokedAt, expiresAt])
+  @@index([expiresAt])
+}
+
 model SubscriptionReminderDispatch {
-  id              String                 @id @default(cuid())
-  userId          String
-  billingDateKey  String
+  id                 String                 @id @default(cuid())
+  userId             String
+  billingDateKey     String
   reminderDaysBefore Int
-  status          ReminderDispatchStatus @default(PENDING)
-  errorMessage    String?
-  createdAt       DateTime               @default(now())
-  updatedAt       DateTime               @updatedAt
-  user            User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status             ReminderDispatchStatus @default(PENDING)
+  errorMessage       String?
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @updatedAt
+  user               User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, billingDateKey])
   @@index([billingDateKey])

--- a/tests/auth/email-verification.test.ts
+++ b/tests/auth/email-verification.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, beforeEach, describe, test } from "node:test";
+
+import { authenticateWithPassword, hashPassword } from "../../lib/auth";
+import { db } from "../../lib/db";
+import { clearMockEmailLog } from "../../lib/mail/providers";
+import {
+  REGISTRATION_VERIFICATION_MAX_PER_WINDOW,
+  consumeRegistrationVerificationToken,
+  hashRegistrationVerificationToken,
+  issueRegistrationVerificationForUser,
+  resendRegistrationVerificationForEmail,
+} from "../../lib/registration-verification";
+
+const createdEmails = new Set<string>();
+const originalMailProvider = process.env.MAIL_PROVIDER;
+
+function uniqueEmail(tag: string): string {
+  const email = `verify-${tag}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}@example.com`;
+  createdEmails.add(email.toLowerCase());
+  return email;
+}
+
+async function cleanupCreatedRecords(): Promise<void> {
+  const emails = [...createdEmails];
+
+  if (emails.length === 0) {
+    return;
+  }
+
+  await db.emailDeliveryLog.deleteMany({
+    where: {
+      recipientEmail: {
+        in: emails,
+      },
+    },
+  });
+
+  await db.user.deleteMany({
+    where: {
+      email: {
+        in: emails,
+      },
+    },
+  });
+
+  createdEmails.clear();
+  clearMockEmailLog();
+}
+
+async function canConnectToDatabase(): Promise<boolean> {
+  try {
+    await db.$queryRaw`SELECT 1`;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createUser(params: {
+  email: string;
+  verified?: boolean;
+  password?: string;
+}): Promise<{ id: string; email: string }> {
+  return db.user.create({
+    data: {
+      email: params.email.toLowerCase(),
+      passwordHash: hashPassword(params.password ?? "test-password"),
+      emailVerifiedAt: params.verified ? new Date() : null,
+      settings: {
+        create: {},
+      },
+    },
+    select: {
+      id: true,
+      email: true,
+    },
+  });
+}
+
+describe("registration verification", () => {
+  before(async () => {
+    assert.equal(await canConnectToDatabase(), true, "Database is unavailable for auth verification tests.");
+  });
+
+  beforeEach(() => {
+    createdEmails.clear();
+    clearMockEmailLog();
+    process.env.MAIL_PROVIDER = "mock";
+  });
+
+  afterEach(async () => {
+    await cleanupCreatedRecords();
+  });
+
+  after(() => {
+    if (originalMailProvider === undefined) {
+      delete process.env.MAIL_PROVIDER;
+      return;
+    }
+
+    process.env.MAIL_PROVIDER = originalMailProvider;
+  });
+
+  test("rejects expired verification tokens", async () => {
+    const user = await createUser({
+      email: uniqueEmail("expired"),
+    });
+
+    const issued = await issueRegistrationVerificationForUser({
+      userId: user.id,
+      email: user.email,
+      baseUrl: "http://localhost:3000",
+    });
+
+    if (issued.outcome === "rate_limited") {
+      assert.fail("Expected initial verification dispatch to avoid rate limiting.");
+    }
+
+    await db.emailVerificationToken.update({
+      where: {
+        tokenHash: hashRegistrationVerificationToken(issued.verificationToken),
+      },
+      data: {
+        expiresAt: new Date(Date.now() - 60_000),
+      },
+    });
+
+    const consumed = await consumeRegistrationVerificationToken(issued.verificationToken);
+    assert.deepEqual(consumed, {
+      ok: false,
+      reason: "expired_token",
+      email: user.email,
+      userId: user.id,
+    });
+
+    const storedUser = await db.user.findUnique({
+      where: {
+        id: user.id,
+      },
+      select: {
+        emailVerifiedAt: true,
+      },
+    });
+
+    assert.equal(storedUser?.emailVerifiedAt, null);
+  });
+
+  test("consumes a verification token once and rejects replay", async () => {
+    const user = await createUser({
+      email: uniqueEmail("replay"),
+    });
+
+    const issued = await issueRegistrationVerificationForUser({
+      userId: user.id,
+      email: user.email,
+      baseUrl: "http://localhost:3000",
+    });
+
+    if (issued.outcome === "rate_limited") {
+      assert.fail("Expected initial verification dispatch to avoid rate limiting.");
+    }
+
+    const firstConsumption = await consumeRegistrationVerificationToken(issued.verificationToken);
+    assert.deepEqual(firstConsumption, {
+      ok: true,
+      email: user.email,
+      userId: user.id,
+    });
+
+    const secondConsumption = await consumeRegistrationVerificationToken(issued.verificationToken);
+    assert.deepEqual(secondConsumption, {
+      ok: false,
+      reason: "replayed_token",
+      email: user.email,
+      userId: user.id,
+    });
+
+    const tokenRecord = await db.emailVerificationToken.findUnique({
+      where: {
+        tokenHash: hashRegistrationVerificationToken(issued.verificationToken),
+      },
+      select: {
+        consumedAt: true,
+      },
+    });
+
+    const storedUser = await db.user.findUnique({
+      where: {
+        id: user.id,
+      },
+      select: {
+        emailVerifiedAt: true,
+      },
+    });
+
+    assert.ok(tokenRecord?.consumedAt instanceof Date);
+    assert.ok(storedUser?.emailVerifiedAt instanceof Date);
+  });
+
+  test("rate limits resend attempts and rotates the active token", async () => {
+    const user = await createUser({
+      email: uniqueEmail("resend"),
+    });
+
+    for (let attempt = 0; attempt < REGISTRATION_VERIFICATION_MAX_PER_WINDOW; attempt += 1) {
+      const result = await resendRegistrationVerificationForEmail({
+        email: user.email,
+        baseUrl: "http://localhost:3000",
+      });
+
+      assert.equal(result.outcome, "sent");
+    }
+
+    const blocked = await resendRegistrationVerificationForEmail({
+      email: user.email,
+      baseUrl: "http://localhost:3000",
+    });
+
+    assert.equal(blocked.outcome, "rate_limited");
+    assert.ok((blocked.retryAfterSeconds ?? 0) > 0);
+
+    const tokens = await db.emailVerificationToken.findMany({
+      where: {
+        userId: user.id,
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+      select: {
+        revokedAt: true,
+      },
+    });
+
+    const deliveryLogs = await db.emailDeliveryLog.count({
+      where: {
+        recipientEmail: user.email,
+        templateName: "registration_verification",
+      },
+    });
+
+    assert.equal(tokens.length, REGISTRATION_VERIFICATION_MAX_PER_WINDOW);
+    assert.ok(tokens.slice(0, -1).every((token) => token.revokedAt instanceof Date));
+    assert.equal(tokens.at(-1)?.revokedAt, null);
+    assert.equal(deliveryLogs, REGISTRATION_VERIFICATION_MAX_PER_WINDOW);
+  });
+
+  test("blocks password authentication until the email is verified", async () => {
+    const password = "correct-horse-battery-staple";
+    const email = uniqueEmail("gate");
+    await createUser({
+      email,
+      password,
+    });
+
+    const blocked = await authenticateWithPassword(email.toLowerCase(), password);
+    assert.equal(blocked.ok, false);
+
+    if (blocked.ok) {
+      assert.fail("Expected unverified user to be blocked.");
+    }
+
+    assert.equal(blocked.reason, "email_unverified");
+    assert.equal(blocked.user?.email, email.toLowerCase());
+    assert.ok(blocked.user?.id);
+
+    await db.user.update({
+      where: {
+        email: email.toLowerCase(),
+      },
+      data: {
+        emailVerifiedAt: new Date(),
+      },
+    });
+
+    const allowed = await authenticateWithPassword(email.toLowerCase(), password);
+    assert.equal(allowed.ok, true);
+
+    if (!allowed.ok) {
+      assert.fail("Expected verified user to authenticate successfully.");
+    }
+
+    assert.equal(allowed.user.email, email.toLowerCase());
+  });
+});


### PR DESCRIPTION
## Summary
- add persisted email verification state and single-use verification tokens
- wire sign-up, sign-in gating, verification completion, and resend flows into auth
- add DB-backed tests plus doc updates for the new registration verification lifecycle

Closes #23.

## Verification
- npm run typecheck
- npm run test:auth
- npm run test:invites
- npm run lint
- npm run build