### PR TITLE
Implement billing details and notes/category cards in subscription modal

### DIFF
--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -90,6 +90,25 @@ function sourceLabel(value: SubscriptionModalOpenSource | null): string {
   }
 }
 
+function getNotesPreview(notesMarkdown: string | null): { preview: string | null; truncated: boolean } {
+  const normalized = notesMarkdown?.trim() ?? "";
+
+  if (!normalized) {
+    return { preview: null, truncated: false };
+  }
+
+  const condensed = normalized.replace(/\n{3,}/g, "\n\n");
+
+  if (condensed.length <= 220) {
+    return { preview: condensed, truncated: false };
+  }
+
+  return {
+    preview: `${condensed.slice(0, 217).trimEnd()}...`,
+    truncated: true,
+  };
+}
+
 export default function SubscriptionDetailsModal({
   isOpen,
   loadState,
@@ -180,6 +199,7 @@ export default function SubscriptionDetailsModal({
   }, [details]);
 
   const historyIsExternal = historyHref.startsWith("http://") || historyHref.startsWith("https://");
+  const notesPreview = getNotesPreview(details?.notesMarkdown ?? null);
 
   async function handleCopySubscriptionId(): Promise<void> {
     if (!details) {
@@ -263,68 +283,118 @@ export default function SubscriptionDetailsModal({
               </div>
             </article>
 
-            <article className="surface details-section">
-              <h3>Billing Snapshot</h3>
-              <dl className="details-definition-list">
-                <div>
-                  <dt>Amount and cadence</dt>
-                  <dd>
-                    {formatMoney(details.amountCents, details.currency)} / {details.billingIntervalLabel.toLowerCase()}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Next charge date</dt>
-                  <dd>
-                    {details.status === "CANCELED"
-                      ? formatDate(details.cancellationEffectiveDate)
-                      : formatDate(details.nextBillingDate)}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Last charge</dt>
-                  <dd>
-                    {formatDate(details.lastChargeDate)}{" "}
-                    {details.lastChargeAmountCents !== null
-                      ? `(${formatMoney(details.lastChargeAmountCents, details.currency)})`
-                      : ""}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Payment method</dt>
-                  <dd>{details.paymentMethodMasked}</dd>
-                </div>
-                <div>
-                  <dt>Trial end date</dt>
-                  <dd>{formatDate(details.trialEndDate)}</dd>
-                </div>
-              </dl>
-            </article>
+            <div className="details-card-grid">
+              <article className="surface details-section">
+                <h3>Billing Details</h3>
+                <dl className="details-definition-list">
+                  <div>
+                    <dt>Billing date</dt>
+                    <dd>
+                      {details.status === "CANCELED"
+                        ? formatDate(details.cancellationEffectiveDate)
+                        : formatDate(details.nextBillingDate)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Billing cadence</dt>
+                    <dd>{details.billingIntervalLabel}</dd>
+                  </div>
+                  <div>
+                    <dt>Payment method</dt>
+                    <dd>{details.paymentMethodMasked}</dd>
+                  </div>
+                  <div>
+                    <dt>{details.spendSummary.label}</dt>
+                    <dd>{formatMoney(details.spendSummary.amountCents, details.spendSummary.currency)}</dd>
+                  </div>
+                  <div>
+                    <dt>Current status</dt>
+                    <dd>
+                      <span className={details.status === "ACTIVE" ? "pill pill-ok" : "pill pill-fail"}>{details.status}</span>
+                    </dd>
+                  </div>
+                </dl>
+              </article>
 
-            <article className="surface details-section">
-              <h3>Plan and Lifecycle</h3>
-              <dl className="details-definition-list">
-                <div>
-                  <dt>Plan / tier</dt>
-                  <dd>{details.planName ?? "Not captured"}</dd>
+              <article className="surface details-section">
+                <div className="details-section-heading">
+                  <h3>Notes & Category</h3>
+                  <span className="pill">{details.inferredCategory}</span>
                 </div>
-                <div>
-                  <dt>Start date</dt>
-                  <dd>{formatDate(details.startDate)}</dd>
+                <p className="text-muted details-card-caption">
+                  Signed up by: {details.signedUpBy ?? "Not captured"}
+                </p>
+                {notesPreview.preview ? (
+                  <>
+                    <pre className="details-notes details-notes-preview">{notesPreview.preview}</pre>
+                    {notesPreview.truncated ? (
+                      <p className="text-muted details-card-caption">Showing a preview of the saved notes.</p>
+                    ) : null}
+                  </>
+                ) : (
+                  <p className="text-muted details-card-empty">No notes saved for this subscription.</p>
+                )}
+              </article>
+            </div>
+
+            <div className="details-card-grid">
+              <article className="surface details-section">
+                <h3>Plan and Lifecycle</h3>
+                <dl className="details-definition-list">
+                  <div>
+                    <dt>Plan / tier</dt>
+                    <dd>{details.planName ?? "Not captured"}</dd>
+                  </div>
+                  <div>
+                    <dt>Start date</dt>
+                    <dd>{formatDate(details.startDate)}</dd>
+                  </div>
+                  <div>
+                    <dt>Renewal date</dt>
+                    <dd>{formatDate(details.renewalDate)}</dd>
+                  </div>
+                  <div>
+                    <dt>Auto-renew</dt>
+                    <dd>{details.autoRenew ? "On" : "Off"}</dd>
+                  </div>
+                  <div>
+                    <dt>Cancellation details</dt>
+                    <dd>{details.cancellationReason ?? (details.status === "CANCELED" ? "Cancellation recorded" : "None")}</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article className="surface details-section">
+                <div className="details-section-heading">
+                  <h3>Account References</h3>
+                  <div className="inline-actions details-tag-list" aria-label="Subscription metadata tags">
+                    {details.metadataTags.map((tag) => (
+                      <span className="pill" key={tag}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
                 </div>
-                <div>
-                  <dt>Renewal date</dt>
-                  <dd>{formatDate(details.renewalDate)}</dd>
-                </div>
-                <div>
-                  <dt>Auto-renew</dt>
-                  <dd>{details.autoRenew ? "On" : "Off"}</dd>
-                </div>
-                <div>
-                  <dt>Cancellation details</dt>
-                  <dd>{details.cancellationReason ?? (details.status === "CANCELED" ? "Cancellation recorded" : "None")}</dd>
-                </div>
-              </dl>
-            </article>
+                <dl className="details-definition-list">
+                  <div>
+                    <dt>Subscription ID</dt>
+                    <dd>{details.internalIdentifiers.subscriptionId}</dd>
+                  </div>
+                  <div>
+                    <dt>Provider reference</dt>
+                    <dd>{details.internalIdentifiers.providerReference ?? "Not captured"}</dd>
+                  </div>
+                  <div>
+                    <dt>Billing console URL</dt>
+                    <dd>{details.links.billingConsoleUrl ?? "Not captured"}</dd>
+                  </div>
+                  <div>
+                    <dt>Cancel URL</dt>
+                    <dd>{details.links.cancelSubscriptionUrl ?? "Not captured"}</dd>
+                  </div>
+                </dl>
+              </article>
+            </div>
 
             <article className="surface details-section">
               <h3>Recent Activity Timeline</h3>
@@ -348,34 +418,6 @@ export default function SubscriptionDetailsModal({
                   ))}
                 </ol>
               )}
-            </article>
-
-            <article className="surface details-section">
-              <h3>Subscription Metadata</h3>
-              <p className="text-muted">
-                Tags: {details.metadataTags.length > 0 ? details.metadataTags.join(", ") : "No tags available"}
-              </p>
-              <p className="text-muted">Signed up by: {details.signedUpBy ?? "Not captured"}</p>
-              <p className="text-muted">Notes: {details.notesMarkdown?.trim() ? "Available below" : "Not captured"}</p>
-              {details.notesMarkdown?.trim() ? <pre className="details-notes">{details.notesMarkdown}</pre> : null}
-              <dl className="details-definition-list">
-                <div>
-                  <dt>Subscription ID</dt>
-                  <dd>{details.internalIdentifiers.subscriptionId}</dd>
-                </div>
-                <div>
-                  <dt>Provider reference</dt>
-                  <dd>{details.internalIdentifiers.providerReference ?? "Not captured"}</dd>
-                </div>
-                <div>
-                  <dt>Billing console URL</dt>
-                  <dd>{details.links.billingConsoleUrl ?? "Not captured"}</dd>
-                </div>
-                <div>
-                  <dt>Cancel URL</dt>
-                  <dd>{details.links.cancelSubscriptionUrl ?? "Not captured"}</dd>
-                </div>
-              </dl>
             </article>
 
             <footer className="inline-actions details-action-row">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1512,6 +1512,12 @@ button:disabled,
   gap: 0.85rem;
 }
 
+.details-card-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .details-section {
   display: grid;
   gap: 0.65rem;
@@ -1520,6 +1526,14 @@ button:disabled,
 .details-section h3 {
   margin: 0;
   font-size: 1rem;
+}
+
+.details-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
 }
 
 .details-title-row {
@@ -1565,6 +1579,15 @@ button:disabled,
   margin: 0;
 }
 
+.details-card-caption,
+.details-card-empty {
+  margin: 0;
+}
+
+.details-tag-list {
+  justify-content: flex-end;
+}
+
 .details-timeline {
   margin: 0;
   padding-left: 1.05rem;
@@ -1600,6 +1623,11 @@ button:disabled,
   word-break: break-word;
   font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 0.8rem;
+}
+
+.details-notes-preview {
+  max-height: 10.8rem;
+  overflow: hidden;
 }
 
 .details-action-row {
@@ -1655,6 +1683,10 @@ ul {
   }
 
   .dashboard-grid-two-up {
+    grid-template-columns: 1fr;
+  }
+
+  .details-card-grid {
     grid-template-columns: 1fr;
   }
 

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,6 +1,7 @@
 import { BillingInterval } from "@prisma/client";
 
 import { db } from "@/lib/db";
+import { inferSubscriptionCategory } from "@/lib/subscription-classification";
 
 export const DASHBOARD_RENEWALS_WINDOW_DAYS = 7;
 export const DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS = 30;
@@ -34,14 +35,6 @@ const WORK_TAG_HINT_KEYWORDS = [
   "netlify",
 ] as const;
 const GAMING_TAG_HINT_KEYWORDS = ["xbox", "playstation", "steam", "nintendo", "epic", "game pass", "ea play"] as const;
-
-const CATEGORY_RULES: ReadonlyArray<{ category: string; keywords: readonly string[] }> = [
-  { category: "Streaming", keywords: ["netflix", "hulu", "disney", "paramount", "spotify", "youtube", "apple tv", "prime video"] },
-  { category: "Productivity", keywords: ["notion", "slack", "figma", "github", "canva", "office", "microsoft 365", "workspace"] },
-  { category: "Cloud & Hosting", keywords: ["aws", "azure", "gcp", "cloudflare", "vercel", "netlify", "digitalocean", "render"] },
-  { category: "Gaming", keywords: ["xbox", "playstation", "steam", "nintendo", "epic"] },
-  { category: "Utilities", keywords: ["vpn", "internet", "mobile", "phone", "electricity", "water", "gas"] },
-];
 
 const ATTENTION_SEVERITY_RANK: Record<DashboardAttentionSeverity, number> = {
   high: 3,
@@ -303,22 +296,6 @@ function includesAnyKeyword(value: string, keywords: readonly string[]): boolean
   return keywords.some((keyword) => lowered.includes(keyword));
 }
 
-function inferCategory(name: string): string {
-  const lowered = name.trim().toLowerCase();
-
-  if (!lowered) {
-    return "Other";
-  }
-
-  for (const rule of CATEGORY_RULES) {
-    if (rule.keywords.some((keyword) => lowered.includes(keyword))) {
-      return rule.category;
-    }
-  }
-
-  return "Other";
-}
-
 function canonicalizeServiceName(name: string): string {
   const normalized = name
     .trim()
@@ -496,7 +473,7 @@ export function buildDashboardPayload(
       monthlyEquivalentAmountCents: normalizeToMonthlyAmountCents(subscription.amountCents, subscription.billingInterval),
       annualProjectionCents: normalizeToAnnualAmountCents(subscription.amountCents, subscription.billingInterval),
       canonicalServiceKey: canonicalizeServiceName(subscription.name),
-      inferredCategory: inferCategory(subscription.name),
+      inferredCategory: inferSubscriptionCategory(subscription.name),
     };
   });
 

--- a/lib/subscription-classification.ts
+++ b/lib/subscription-classification.ts
@@ -1,0 +1,23 @@
+const CATEGORY_RULES: ReadonlyArray<{ category: string; keywords: readonly string[] }> = [
+  { category: "Streaming", keywords: ["netflix", "hulu", "disney", "paramount", "spotify", "youtube", "apple tv", "prime video"] },
+  { category: "Productivity", keywords: ["notion", "slack", "figma", "github", "canva", "office", "microsoft 365", "workspace"] },
+  { category: "Cloud & Hosting", keywords: ["aws", "azure", "gcp", "cloudflare", "vercel", "netlify", "digitalocean", "render"] },
+  { category: "Gaming", keywords: ["xbox", "playstation", "steam", "nintendo", "epic"] },
+  { category: "Utilities", keywords: ["vpn", "internet", "mobile", "phone", "electricity", "water", "gas"] },
+];
+
+export function inferSubscriptionCategory(name: string): string {
+  const lowered = name.trim().toLowerCase();
+
+  if (!lowered) {
+    return "Other";
+  }
+
+  for (const rule of CATEGORY_RULES) {
+    if (rule.keywords.some((keyword) => lowered.includes(keyword))) {
+      return rule.category;
+    }
+  }
+
+  return "Other";
+}

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -1,3 +1,5 @@
+import { inferSubscriptionCategory } from "@/lib/subscription-classification";
+
 export type BillingIntervalCode = "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM";
 
 export type SubscriptionModalOpenSource = "upcoming_charges" | "recent_activity" | "subscriptions_list";
@@ -12,6 +14,12 @@ export type SubscriptionDetailsEvent = {
   timestamp: string;
   amountCents: number | null;
   currency: string | null;
+};
+
+export type SubscriptionDetailsSpendMetric = {
+  label: string;
+  amountCents: number | null;
+  currency: string;
 };
 
 export type SubscriptionDetailsContract = {
@@ -36,6 +44,8 @@ export type SubscriptionDetailsContract = {
   cancellationEffectiveDate: string | null;
   cancellationReason: string | null;
   signedUpBy: string | null;
+  inferredCategory: string;
+  spendSummary: SubscriptionDetailsSpendMetric;
   metadataTags: string[];
   notesMarkdown: string | null;
   links: {
@@ -222,6 +232,7 @@ export function buildSubscriptionDetails(record: SubscriptionDetailsSourceRecord
   const normalizedMonthlyAmountCents = estimateNormalizedMonthlyAmountCents(record.amountCents, record.billingInterval);
   const normalizedYearlyAmountCents = estimateNormalizedYearlyAmountCents(record.amountCents, record.billingInterval);
   const nextBillingDateIso = toOptionalIsoString(record.nextBillingDate);
+  const inferredCategory = inferSubscriptionCategory(record.name);
 
   return {
     id: record.id,
@@ -245,6 +256,12 @@ export function buildSubscriptionDetails(record: SubscriptionDetailsSourceRecord
     cancellationEffectiveDate: record.isActive ? null : nextBillingDateIso,
     cancellationReason: null,
     signedUpBy: record.signedUpBy?.trim() ? record.signedUpBy.trim() : null,
+    inferredCategory,
+    spendSummary: {
+      label: "Projected annual spend",
+      amountCents: normalizedYearlyAmountCents,
+      currency: record.currency,
+    },
     metadataTags: buildMetadataTags(record),
     notesMarkdown: record.notesMarkdown,
     links: {

--- a/tests/subscription-details/build-subscription-details.test.ts
+++ b/tests/subscription-details/build-subscription-details.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import type { SubscriptionDetailsSourceRecord } from "../../lib/subscription-details";
+import { buildSubscriptionDetails } from "../../lib/subscription-details";
+
+function makeRecord(
+  overrides: Partial<SubscriptionDetailsSourceRecord> & Pick<SubscriptionDetailsSourceRecord, "id" | "name">,
+): SubscriptionDetailsSourceRecord {
+  const { id, name, ...rest } = overrides;
+
+  return {
+    id,
+    name,
+    paymentMethod: "Visa 4242",
+    signedUpBy: "Alex",
+    billingConsoleUrl: "https://example.com/manage",
+    cancelSubscriptionUrl: "https://example.com/cancel",
+    billingHistoryUrl: "https://example.com/history",
+    notesMarkdown: "Primary workspace subscription.\nRenew before team seats expand.",
+    amountCents: 2000,
+    currency: "USD",
+    billingInterval: "MONTHLY",
+    nextBillingDate: new Date("2026-03-20T12:00:00.000Z"),
+    isActive: true,
+    createdAt: new Date("2026-01-10T08:00:00.000Z"),
+    updatedAt: new Date("2026-03-10T09:30:00.000Z"),
+    ...rest,
+  };
+}
+
+describe("buildSubscriptionDetails", () => {
+  test("adds inferred category and annual spend summary for standard cadences", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "github-team",
+        name: "GitHub Team",
+      }),
+    );
+
+    assert.equal(details.inferredCategory, "Productivity");
+    assert.deepEqual(details.spendSummary, {
+      label: "Projected annual spend",
+      amountCents: 24_000,
+      currency: "USD",
+    });
+  });
+
+  test("falls back cleanly when category and annualized spend cannot be inferred", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "custom-service",
+        name: "Internal Retainer",
+        billingInterval: "CUSTOM",
+        paymentMethod: "1234",
+        notesMarkdown: "   ",
+      }),
+    );
+
+    assert.equal(details.inferredCategory, "Other");
+    assert.equal(details.paymentMethodMasked, "••••");
+    assert.deepEqual(details.spendSummary, {
+      label: "Projected annual spend",
+      amountCents: null,
+      currency: "USD",
+    });
+    assert.equal(details.notesMarkdown, "   ");
+  });
+});


### PR DESCRIPTION
## Summary
- implement issue #44 by adding dedicated Billing Details and Notes & Category cards to the subscription details modal
- extend the subscription details contract with inferred category and a projected annual spend metric
- share category inference logic with dashboard code and add unit coverage for the new contract derivations

## Testing
- `npm run typecheck`
- `npm run test:dashboard`
- `npm exec -- node --import tsx --test tests/subscription-details/*.test.ts`

Closes #44