### PR TITLE
Remove Recent Activity section from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ Open http://localhost:3000.
 - `/subscriptions` provides modal add/edit flows with client-side search, status filtering, and sort controls.
 - subscription details are available in a shared read-only modal opened from:
   - dashboard -> `Upcoming Charges`
-  - dashboard -> `Recent Activity`
   - subscriptions list -> subscription card row (click, Enter, or Space)
 - the details modal fetches fresh data on open via `/api/subscriptions/[subscriptionId]/details` and includes loading, empty, and error states.
 - modal telemetry events are posted to `/api/telemetry` for open/close/view-history interactions with source context.

--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -30,7 +30,6 @@ function buildAvailableCurrencies(payload: DashboardPayload): string[] {
       ...payload.topCostDrivers.map((entry) => entry.currency),
       ...payload.potentialSavings.totalsByCurrency.map((entry) => entry.currency),
       ...payload.potentialSavings.opportunities.map((entry) => entry.currency),
-      ...payload.recentSubscriptions.map((entry) => entry.currency),
     ]),
   ];
 }
@@ -161,16 +160,6 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
           })) ?? [],
         assumptions: payload?.potentialSavings.assumptions ?? [],
       }}
-      recentSubscriptions={
-        payload?.recentSubscriptions.map((subscription) => ({
-          id: subscription.id,
-          name: subscription.name,
-          isActive: subscription.isActive,
-          amountCents: subscription.amountCents,
-          currency: subscription.currency,
-          createdAt: subscription.createdAt,
-        })) ?? []
-      }
       renderState={renderState}
       spendBreakdownByCategory={
         payload?.spendBreakdownByCategory.map((category) => ({

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -20,7 +20,6 @@ import {
   DASHBOARD_ALL_CURRENCIES,
   DASHBOARD_DATE_RANGE_OPTIONS,
   DEFAULT_DASHBOARD_DATE_RANGE,
-  filterDashboardRecentActivity,
   mapDashboardSpendBreakdownByCurrency,
   filterDashboardUpcomingRenewals,
   resolveInitialDashboardCurrency,
@@ -39,15 +38,6 @@ type DashboardUpcomingChargeListItem = {
   renewalDate: string;
   createdAt: string;
   tag: DashboardUpcomingRenewalTag;
-};
-
-type DashboardRecentActivityListItem = {
-  id: string;
-  name: string;
-  isActive: boolean;
-  amountCents: number;
-  currency: string;
-  createdAt: string;
 };
 
 type DashboardAttentionListItem = {
@@ -100,7 +90,6 @@ type DashboardSectionsClientProps = {
   topCostDrivers: DashboardTopCostDriverListItem[];
   potentialSavings: DashboardPotentialSavingsData;
   upcomingCharges: DashboardUpcomingChargeListItem[];
-  recentSubscriptions: DashboardRecentActivityListItem[];
   monthlySpendTotalsByCurrency: Array<{
     currency: string;
     monthlyEquivalentSpendCents: number;
@@ -415,7 +404,6 @@ export default function DashboardSectionsClient({
   topCostDrivers,
   potentialSavings,
   upcomingCharges,
-  recentSubscriptions,
   monthlySpendTotalsByCurrency,
   spendBreakdownByCategory,
   initialCurrency,
@@ -464,19 +452,6 @@ export default function DashboardSectionsClient({
   }, [filteredUpcomingCharges, showAllUpcomingRenewals]);
   const hasClippedUpcomingRenewals = filteredUpcomingCharges.length > UPCOMING_RENEWALS_VISIBLE_ROWS;
   const hiddenUpcomingRenewalsCount = Math.max(filteredUpcomingCharges.length - visibleUpcomingCharges.length, 0);
-  const filteredRecentActivity = useMemo(
-    () =>
-      filterDashboardRecentActivity(
-        recentSubscriptions,
-        {
-          currency,
-          dateRange,
-          searchQuery,
-        },
-        now,
-      ),
-    [currency, dateRange, now, recentSubscriptions, searchQuery],
-  );
   const filteredAttentionNeeded = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase();
     const selectedCurrency = currency.toUpperCase();
@@ -1255,58 +1230,6 @@ export default function DashboardSectionsClient({
           </article>
         </section>
 
-        <section className="dashboard-grid">
-          <article className="dashboard-card">
-            <div className="dashboard-card-header">
-              <h2>Recent Activity</h2>
-              <span className="metric-note">
-                {isLoading ? "Loading activity..." : `${filteredRecentActivity.length} matching rows`}
-              </span>
-            </div>
-            {isLoading ? (
-              <div className="stack" aria-hidden="true">
-                {Array.from({ length: 3 }).map((_, index) => (
-                  <div className="status-item subscription-entry-button subscription-entry-skeleton" key={index}>
-                    <div className="subscription-header">
-                      <DashboardSkeletonLine className="dashboard-skeleton-line-md" />
-                      <DashboardSkeletonLine className="dashboard-skeleton-line-xs" />
-                    </div>
-                    <DashboardSkeletonLine className="dashboard-skeleton-line-lg" />
-                  </div>
-                ))}
-              </div>
-            ) : filteredRecentActivity.length === 0 ? (
-              <p className="text-muted">No recent subscriptions match the current control filters.</p>
-            ) : (
-              <div className="stack">
-                {filteredRecentActivity.map((subscription) => (
-                  <button
-                    aria-label={`View details for ${subscription.name}`}
-                    className="status-item subscription-entry-button"
-                    key={subscription.id}
-                    onClick={() =>
-                      void detailsModal.openModal({
-                        subscriptionId: subscription.id,
-                        source: "recent_activity",
-                      })
-                    }
-                    type="button"
-                  >
-                    <div className="subscription-header">
-                      <h2>{subscription.name}</h2>
-                      <span className={subscription.isActive ? "pill pill-ok" : "pill pill-fail"}>
-                        {subscription.isActive ? "ACTIVE" : "INACTIVE"}
-                      </span>
-                    </div>
-                    <p className="subscription-meta">
-                      Added {formatDate(subscription.createdAt)} - {formatMoney(subscription.amountCents, subscription.currency)}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            )}
-          </article>
-        </section>
       </div>
 
       <SubscriptionDetailsModal

--- a/app/api/telemetry/route.ts
+++ b/app/api/telemetry/route.ts
@@ -25,7 +25,7 @@ const EVENT_NAMES: TelemetryEventName[] = [
   "subscription_details_view_full_history",
 ];
 
-const SOURCES: SubscriptionModalOpenSource[] = ["upcoming_charges", "recent_activity", "subscriptions_list"];
+const SOURCES: SubscriptionModalOpenSource[] = ["upcoming_charges", "subscriptions_list"];
 
 const CLOSE_REASONS: SubscriptionModalCloseReason[] = ["backdrop", "escape_key", "close_button", "unknown"];
 

--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -81,8 +81,6 @@ function sourceLabel(value: SubscriptionModalOpenSource | null): string {
   switch (value) {
     case "upcoming_charges":
       return "Opened from upcoming charges";
-    case "recent_activity":
-      return "Opened from recent activity";
     case "subscriptions_list":
       return "Opened from subscriptions list";
     default:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,8 +88,7 @@ UI behavior:
 Current modal coverage:
 
 1. Dashboard `Upcoming Charges`
-2. Dashboard `Recent Activity`
-3. `/subscriptions` subscription row cards
+2. `/subscriptions` subscription row cards
 
 Modal behavior:
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -37,11 +37,10 @@ Implemented:
   - subscriptions page now supports modal add/edit flows plus client-side search, status filtering, and sorting.
   - shared read-only `Subscription Details` modal now opens from:
     - dashboard `Upcoming Charges`
-    - dashboard `Recent Activity`
     - `/subscriptions` card rows (click + keyboard Enter/Space)
   - details modal data is served by `/api/subscriptions/[subscriptionId]/details` using a shared contract in `lib/subscription-details.ts`.
   - details modal includes loading/empty/error states, focus trap, `Esc` close, and non-edit actions (`View Full History`, `Copy Subscription ID`, `Close`).
-  - modal interaction telemetry posts to `/api/telemetry` with source context (`upcoming_charges`, `recent_activity`, `subscriptions_list`).
+  - modal interaction telemetry posts to `/api/telemetry` with source context (`upcoming_charges`, `subscriptions_list`).
   - `paymentMethod` is now required and acts as a learning field (suggests prior values entered by the same user).
   - `signedUpBy` is optional and also acts as a learning field (suggests prior user-entered values).
   - optional billing workflow links are captured per subscription:

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -63,10 +63,9 @@ Subscriptions UX:
 Dashboard details modal UX:
 
 1. Open `/` while signed in and click an item in `Upcoming Charges`; confirm `Subscription Details` modal opens.
-2. Open an item from `Recent Activity`; confirm the same modal component opens with the selected subscription.
-3. While opening modal, confirm loading state is visible and details render after request.
-4. Temporarily break the details request (for example, by forcing `401/404`) and confirm error/empty state copy is shown.
-5. In browser devtools network tab, confirm telemetry source values are `upcoming_charges` and `recent_activity`.
+2. While opening modal, confirm loading state is visible and details render after request.
+3. Temporarily break the details request (for example, by forcing `401/404`) and confirm error/empty state copy is shown.
+4. In browser devtools network tab, confirm telemetry source value is `upcoming_charges`.
 
 Settings UX:
 

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -36,12 +36,6 @@ type DashboardUpcomingRenewalRecord = {
   renewalDate: string;
 };
 
-type DashboardRecentActivityRecord = {
-  name: string;
-  currency: string;
-  createdAt: string;
-};
-
 type DashboardSpendBreakdownCategoryRecord = {
   category: string;
   subscriptionCount: number;
@@ -153,19 +147,6 @@ function isWithinUpcomingWindow(dateValue: string, now: Date, rangeDays: number)
   return deltaMs >= 0 && deltaMs <= maxMs;
 }
 
-function isWithinRecentWindow(dateValue: string, now: Date, rangeDays: number): boolean {
-  const parsedDate = new Date(dateValue);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return false;
-  }
-
-  const deltaMs = now.getTime() - parsedDate.getTime();
-  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
-
-  return deltaMs >= 0 && deltaMs <= maxMs;
-}
-
 export function filterDashboardUpcomingRenewals<T extends DashboardUpcomingRenewalRecord>(
   records: T[],
   controls: DashboardControlState,
@@ -184,27 +165,6 @@ export function filterDashboardUpcomingRenewals<T extends DashboardUpcomingRenew
     }
 
     return matchesSearchFilter([record.name, record.paymentMethod, record.currency], normalizedQuery);
-  });
-}
-
-export function filterDashboardRecentActivity<T extends DashboardRecentActivityRecord>(
-  records: T[],
-  controls: DashboardControlState,
-  now: Date,
-): T[] {
-  const rangeDays = toDateRangeDays(controls.dateRange);
-  const normalizedQuery = toNormalizedSearchQuery(controls.searchQuery);
-
-  return records.filter((record) => {
-    if (!matchesCurrencyFilter(record.currency, controls.currency)) {
-      return false;
-    }
-
-    if (!isWithinRecentWindow(record.createdAt, now, rangeDays)) {
-      return false;
-    }
-
-    return matchesSearchFilter([record.name, record.currency], normalizedQuery);
   });
 }
 

--- a/lib/dashboard-view-state.ts
+++ b/lib/dashboard-view-state.ts
@@ -50,10 +50,6 @@ export function hasDashboardContent(data: DashboardPayload): boolean {
     return true;
   }
 
-  if (data.recentSubscriptions.length > 0) {
-    return true;
-  }
-
   if (data.spendBreakdownByCategory.some((category) => category.totalsByCurrency.length > 0)) {
     return true;
   }

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -9,7 +9,6 @@ export const DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS = 30;
 const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1000;
 const WEEKLY_TO_MONTHLY_FACTOR = 4.33;
 const TOP_COST_DRIVERS_LIMIT = 5;
-const RECENT_SUBSCRIPTIONS_LIMIT = 5;
 const ATTENTION_PROMO_WINDOW_DAYS = 7;
 const ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS = 45;
 const ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS = 120;
@@ -154,16 +153,6 @@ export type DashboardPotentialSavings = {
   assumptions: string[];
 };
 
-export type DashboardRecentSubscription = {
-  id: string;
-  name: string;
-  isActive: boolean;
-  amountCents: number;
-  currency: string;
-  nextBillingDate: string | null;
-  createdAt: string;
-};
-
 export type DashboardNextCharge = {
   id: string;
   name: string;
@@ -186,7 +175,6 @@ export type DashboardPayload = {
   topCostDrivers: DashboardTopCostDriver[];
   potentialSavings: DashboardPotentialSavings;
   nextCharge: DashboardNextCharge;
-  recentSubscriptions: DashboardRecentSubscription[];
 };
 
 type NormalizedSubscription = DashboardSubscriptionSourceRecord & {
@@ -821,21 +809,6 @@ export function buildDashboardPayload(
       }
     : null;
 
-  const recentSubscriptions: DashboardRecentSubscription[] = [...normalizedSubscriptions]
-    .sort((first, second) => {
-      return second.createdAtDate.getTime() - first.createdAtDate.getTime() || first.name.localeCompare(second.name);
-    })
-    .slice(0, RECENT_SUBSCRIPTIONS_LIMIT)
-    .map((subscription) => ({
-      id: subscription.id,
-      name: subscription.name,
-      isActive: subscription.isActive,
-      amountCents: subscription.amountCents,
-      currency: subscription.currency,
-      nextBillingDate: subscription.nextBillingDateDate ? subscription.nextBillingDateDate.toISOString() : null,
-      createdAt: subscription.createdAtDate.toISOString(),
-    }));
-
   return {
     generatedAt: now.toISOString(),
     dateWindows: {
@@ -850,7 +823,6 @@ export function buildDashboardPayload(
     topCostDrivers,
     potentialSavings,
     nextCharge,
-    recentSubscriptions,
   };
 }
 

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -2,7 +2,7 @@ import { inferSubscriptionCategory } from "@/lib/subscription-classification";
 
 export type BillingIntervalCode = "WEEKLY" | "MONTHLY" | "YEARLY" | "CUSTOM";
 
-export type SubscriptionModalOpenSource = "upcoming_charges" | "recent_activity" | "subscriptions_list";
+export type SubscriptionModalOpenSource = "upcoming_charges" | "subscriptions_list";
 
 export type SubscriptionModalCloseReason = "backdrop" | "escape_key" | "close_button" | "unknown";
 

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -46,7 +46,6 @@ describe("buildDashboardPayload", () => {
     assert.deepEqual(payload.upcomingRenewals, []);
     assert.deepEqual(payload.topCostDrivers, []);
     assert.deepEqual(payload.potentialSavings.opportunities, []);
-    assert.deepEqual(payload.recentSubscriptions, []);
     assert.equal(payload.nextCharge, null);
   });
 

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -5,7 +5,6 @@ import {
   buildDashboardCurrencyOptions,
   DASHBOARD_ALL_CURRENCIES,
   DEFAULT_DASHBOARD_DATE_RANGE,
-  filterDashboardRecentActivity,
   filterDashboardUpcomingRenewals,
   getDashboardCategoryColor,
   mapDashboardSpendBreakdownByCurrency,
@@ -84,60 +83,6 @@ describe("dashboard controls filtering", () => {
     assert.deepEqual(
       filteredUsdVisa.map((record) => record.name),
       ["GitHub Team"],
-    );
-  });
-
-  test("filters recent activity by date window, currency, and search", () => {
-    const now = new Date("2026-03-11T00:00:00.000Z");
-    const records = [
-      {
-        name: "Notion",
-        currency: "USD",
-        createdAt: "2026-03-09T00:00:00.000Z",
-      },
-      {
-        name: "Spotify",
-        currency: "AUD",
-        createdAt: "2026-02-25T00:00:00.000Z",
-      },
-      {
-        name: "Old Service",
-        currency: "USD",
-        createdAt: "2026-01-15T00:00:00.000Z",
-      },
-      {
-        name: "Future Service",
-        currency: "USD",
-        createdAt: "2026-04-01T00:00:00.000Z",
-      },
-    ];
-
-    const allResults = filterDashboardRecentActivity(
-      records,
-      {
-        currency: DASHBOARD_ALL_CURRENCIES,
-        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
-        searchQuery: "",
-      },
-      now,
-    );
-    const filteredAud = filterDashboardRecentActivity(
-      records,
-      {
-        currency: "AUD",
-        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
-        searchQuery: "spot",
-      },
-      now,
-    );
-
-    assert.deepEqual(
-      allResults.map((record) => record.name),
-      ["Notion", "Spotify"],
-    );
-    assert.deepEqual(
-      filteredAud.map((record) => record.name),
-      ["Spotify"],
     );
   });
 


### PR DESCRIPTION
## Summary
- remove the dashboard `Recent Activity` section
- delete the now-unused dashboard recent-subscription filtering/payload wiring
- update telemetry/docs/tests to match the reduced dashboard surface

## Verification
- `npm run test:dashboard`
- `npm run typecheck`

Closes #72