### PR TITLE
Implement subscription details V2 contract (#40)

### DIFF
--- a/app/api/subscriptions/[subscriptionId]/details/route.ts
+++ b/app/api/subscriptions/[subscriptionId]/details/route.ts
@@ -48,6 +48,16 @@ export async function GET(_request: Request, context: SubscriptionDetailsRouteCo
       isActive: true,
       createdAt: true,
       updatedAt: true,
+      user: {
+        select: {
+          settings: {
+            select: {
+              remindersEnabled: true,
+              reminderDaysBefore: true,
+            },
+          },
+        },
+      },
     },
   });
 
@@ -55,7 +65,11 @@ export async function GET(_request: Request, context: SubscriptionDetailsRouteCo
     return NextResponse.json({ error: "Subscription not found." }, { status: 404 });
   }
 
-  const data = buildSubscriptionDetails(subscription);
+  const data = buildSubscriptionDetails({
+    ...subscription,
+    remindersEnabled: subscription.user.settings?.remindersEnabled ?? true,
+    reminderDaysBefore: subscription.user.settings?.reminderDaysBefore ?? 3,
+  });
 
   return NextResponse.json(
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,7 @@ UI behavior:
 1. `/api/subscriptions/[subscriptionId]/details` (server response builder).
 2. Dashboard + subscriptions modal consumers (single read-only component).
 3. Shared timeline and normalized-cost formatting logic.
+4. The nested `v2` operational modal contract described in `docs/SUBSCRIPTION_DETAILS_V2_CONTRACT.md`.
 
 Current modal coverage:
 
@@ -96,6 +97,13 @@ Modal behavior:
 2. Includes loading, empty, and error states.
 3. Uses keyboard accessible dialog behavior (focus trap + `Esc` close).
 4. Supports contextual actions without editing controls (view history, copy ID, close).
+
+V2 contract notes:
+
+1. Legacy flat fields remain in place for the current modal.
+2. The nested `v2` payload adds section-level `ready` / `partial` / `empty` states.
+3. Alert derivation returns both rendered items and rule-evaluation outcomes.
+4. Action capability payloads define permission, confirmation, and required server validation rules before UI wiring.
 
 ## Auth flow
 

--- a/docs/SUBSCRIPTION_DETAILS_V2_CONTRACT.md
+++ b/docs/SUBSCRIPTION_DETAILS_V2_CONTRACT.md
@@ -1,0 +1,102 @@
+# Subscription Details V2 Contract
+
+`lib/subscription-details.ts` now exposes a backward-compatible payload with:
+
+- Legacy flat fields used by the current modal.
+- A nested `v2` contract for the operational modal redesign.
+
+## Contract goals
+
+The V2 payload is designed so new sections can render safely even when the backend only has partial data.
+
+- Every major section exposes a `state` of `ready`, `partial`, or `empty`.
+- Alert derivation returns both rendered `items` and per-rule `ruleOutcomes`.
+- Action capability objects define whether an action is enabled, what permission it assumes, and which server validations must exist before the UI can invoke it.
+
+## Section map
+
+- `v2.header`: service identity, lifecycle status, category, and status chips.
+- `v2.summaryStrip`: current price, renewal summary, payment summary, and reminder status.
+- `v2.attentionNeeded`: derived alert items plus deterministic rule evaluation results.
+- `v2.actionBar`: header actions, quick actions, and footer navigation actions.
+- `v2.billingDetails`: billing cadence, billing date, payment method, spend summary, and trial metadata.
+- `v2.notesCategory`: inferred category, notes markdown, owner metadata, and tags.
+- `v2.paymentHistory`: timeline items plus the upcoming renewal callout.
+- `v2.management`: management URLs and internal identifiers.
+- `v2.lifecycle`: lifecycle stage, dates, cancellation metadata, and review-state support status.
+
+## Lifecycle derivation
+
+Lifecycle stage is derived deterministically from `isActive` and `nextBillingDate`.
+
+- `active`: `isActive === true`
+- `cancel_scheduled`: `isActive === false` and `nextBillingDate` is still in the future
+- `canceled`: `isActive === false` and there is no future effective date left
+
+This rule is intentionally simple so downstream UI labels and chips stay stable without hidden server heuristics.
+
+## Alert derivation
+
+The contract currently evaluates three machine-readable alert rules.
+
+### `promo_ending_soon`
+
+Matched only when all of the following are true:
+
+- the subscription is active
+- the name contains a promo/trial hint keyword
+- `nextBillingDate` exists
+- the account age is at most 45 days
+- the next renewal is within 7 days
+
+If a promo-like subscription is missing `nextBillingDate`, the rule returns `insufficient_data` instead of silently disappearing.
+
+### `price_increase_imminent`
+
+Requires:
+
+- `nextBillingDate`
+- `projectedNextChargeAmountCents`
+
+It matches when the projected next charge is higher than the current amount and the renewal is within 7 days.
+
+### `higher_price_renewal`
+
+Requires:
+
+- `nextBillingDate`
+- `lastChargedAmountCents`
+- `projectedNextChargeAmountCents`
+
+It matches when the projected renewal amount exceeds the last captured charge amount.
+
+## Action policy
+
+Each action advertises:
+
+- `kind`: `client`, `navigate`, or `mutate`
+- `availability`: `enabled` or `disabled`
+- `permission`: currently `owner_read` or `owner_write`
+- `requiresConfirmation`
+- `serverValidation`: explicit backend checks required before wiring the action
+
+Current policy:
+
+- `edit_subscription`: client-triggered, owner-write, no confirmation
+- `mark_cancelled`: mutating, owner-write, confirmation required
+- `open_management_page`: navigate-only, owner-read, requires a valid stored management URL
+- `change_alert`: currently disabled because alerts are only persisted at account level
+- `mark_for_review`: currently disabled because no review-state field exists yet
+- `cancel_soon`: navigate-only, owner-write, requires an active subscription plus a valid cancel URL
+- `view_billing_history`: navigate-only, owner-read, requires a valid history URL
+
+## Partial-data expectations
+
+The V2 contract is expected to degrade safely when fields are missing.
+
+- Missing reminder settings fall back to the app default of 3 days before renewal.
+- Missing price comparison signals do not remove the rule entirely; they produce `insufficient_data`.
+- Missing notes keep `notesCategory.state = "partial"` while still returning inferred category data.
+- Missing management URLs keep the management panel renderable while disabling navigation actions.
+
+This contract intentionally exposes capability gaps instead of hiding them, so later issues can implement sections without redefining payload semantics.

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -6,6 +6,29 @@ export type SubscriptionModalOpenSource = "upcoming_charges" | "subscriptions_li
 
 export type SubscriptionModalCloseReason = "backdrop" | "escape_key" | "close_button" | "unknown";
 
+export type SubscriptionDetailsSectionState = "ready" | "partial" | "empty";
+
+export type SubscriptionDetailsChipTone = "neutral" | "success" | "warning" | "danger";
+
+export type SubscriptionDetailsActionAvailability = "enabled" | "disabled";
+
+export type SubscriptionDetailsActionKind = "client" | "navigate" | "mutate";
+
+export type SubscriptionDetailsActionPlacement = "header" | "quick_actions" | "footer";
+
+export type SubscriptionDetailsActionPermission = "owner_read" | "owner_write";
+
+export type SubscriptionDetailsLifecycleStage = "active" | "cancel_scheduled" | "canceled";
+
+export type SubscriptionDetailsAlertCode =
+  | "promo_ending_soon"
+  | "price_increase_imminent"
+  | "higher_price_renewal";
+
+export type SubscriptionDetailsAlertSeverity = "high" | "medium" | "low";
+
+export type SubscriptionDetailsRuleStatus = "matched" | "not_applicable" | "insufficient_data";
+
 export type SubscriptionDetailsEvent = {
   id: string;
   type: "created" | "updated" | "next_charge" | "deactivated" | "billing_profile";
@@ -22,7 +45,163 @@ export type SubscriptionDetailsSpendMetric = {
   currency: string;
 };
 
+export type SubscriptionDetailsChip = {
+  key: string;
+  label: string;
+  tone: SubscriptionDetailsChipTone;
+};
+
+export type SubscriptionDetailsAlertItem = {
+  code: SubscriptionDetailsAlertCode;
+  severity: SubscriptionDetailsAlertSeverity;
+  title: string;
+  message: string;
+  effectiveDate: string | null;
+  currentAmountCents: number | null;
+  projectedAmountCents: number | null;
+  currency: string | null;
+};
+
+export type SubscriptionDetailsAlertRuleOutcome = {
+  code: SubscriptionDetailsAlertCode;
+  status: SubscriptionDetailsRuleStatus;
+  reason: string;
+  missingFields: string[];
+};
+
+export type SubscriptionDetailsActionCapability = {
+  key:
+    | "edit_subscription"
+    | "mark_cancelled"
+    | "open_management_page"
+    | "change_alert"
+    | "mark_for_review"
+    | "cancel_soon"
+    | "view_billing_history";
+  label: string;
+  placement: SubscriptionDetailsActionPlacement;
+  kind: SubscriptionDetailsActionKind;
+  availability: SubscriptionDetailsActionAvailability;
+  unavailableReason: string | null;
+  href: string | null;
+  permission: SubscriptionDetailsActionPermission;
+  requiresConfirmation: boolean;
+  confirmationLabel: string | null;
+  serverValidation: string[];
+};
+
+export type SubscriptionDetailsV2Contract = {
+  generatedAt: string;
+  sectionStates: Record<
+    "header" | "summaryStrip" | "attentionNeeded" | "actionBar" | "billingDetails" | "notesCategory" | "paymentHistory" | "management" | "lifecycle",
+    SubscriptionDetailsSectionState
+  >;
+  header: {
+    state: SubscriptionDetailsSectionState;
+    title: string;
+    subtitle: string;
+    categoryLabel: string;
+    status: {
+      stage: SubscriptionDetailsLifecycleStage;
+      label: string;
+    };
+    chips: SubscriptionDetailsChip[];
+  };
+  summaryStrip: {
+    state: SubscriptionDetailsSectionState;
+    currentPrice: {
+      amountCents: number;
+      currency: string;
+      intervalLabel: string;
+      monthlyEquivalentAmountCents: number | null;
+    };
+    renewal: {
+      date: string | null;
+      annualizedSpendCents: number | null;
+      projectedAmountCents: number | null;
+      currency: string;
+    };
+    paymentMethod: {
+      masked: string;
+      signedUpBy: string | null;
+    };
+    reminders: {
+      enabled: boolean;
+      daysBefore: number;
+      statusLabel: string;
+    };
+  };
+  attentionNeeded: {
+    state: SubscriptionDetailsSectionState;
+    items: SubscriptionDetailsAlertItem[];
+    ruleOutcomes: SubscriptionDetailsAlertRuleOutcome[];
+  };
+  actionBar: {
+    state: SubscriptionDetailsSectionState;
+    header: SubscriptionDetailsActionCapability[];
+    quickActions: SubscriptionDetailsActionCapability[];
+    footer: SubscriptionDetailsActionCapability[];
+  };
+  billingDetails: {
+    state: SubscriptionDetailsSectionState;
+    amountCents: number;
+    currency: string;
+    billingInterval: BillingIntervalCode;
+    billingIntervalLabel: string;
+    nextBillingDate: string | null;
+    paymentMethodMasked: string;
+    spendSummary: SubscriptionDetailsSpendMetric;
+    trialEndDate: string | null;
+  };
+  notesCategory: {
+    state: SubscriptionDetailsSectionState;
+    inferredCategory: string;
+    signedUpBy: string | null;
+    notesMarkdown: string | null;
+    metadataTags: string[];
+  };
+  paymentHistory: {
+    state: SubscriptionDetailsSectionState;
+    items: SubscriptionDetailsEvent[];
+    upcomingRenewal: {
+      renewalDate: string | null;
+      projectedAmountCents: number | null;
+      currency: string;
+    };
+    maxVisibleItems: number;
+    hasMore: boolean;
+  };
+  management: {
+    state: SubscriptionDetailsSectionState;
+    providerDisplayName: string;
+    billingConsoleUrl: string | null;
+    cancelSubscriptionUrl: string | null;
+    billingHistoryUrl: string | null;
+    internalIdentifiers: {
+      subscriptionId: string;
+      providerReference: string | null;
+    };
+  };
+  lifecycle: {
+    state: SubscriptionDetailsSectionState;
+    stage: SubscriptionDetailsLifecycleStage;
+    label: string;
+    autoRenew: boolean;
+    startDate: string;
+    renewalDate: string | null;
+    cancellationEffectiveDate: string | null;
+    cancellationReason: string | null;
+    reviewState: {
+      isMarked: boolean;
+      canPersist: boolean;
+      unavailableReason: string | null;
+    };
+    chips: SubscriptionDetailsChip[];
+  };
+};
+
 export type SubscriptionDetailsContract = {
+  schemaVersion: "2026-03-v2";
   id: string;
   name: string;
   status: "ACTIVE" | "CANCELED";
@@ -59,6 +238,7 @@ export type SubscriptionDetailsContract = {
   };
   timeline: SubscriptionDetailsEvent[];
   lastUpdatedAt: string;
+  v2: SubscriptionDetailsV2Contract;
 };
 
 export type SubscriptionDetailsSourceRecord = {
@@ -77,22 +257,55 @@ export type SubscriptionDetailsSourceRecord = {
   isActive: boolean;
   createdAt: Date | string;
   updatedAt: Date | string;
+  remindersEnabled?: boolean | null;
+  reminderDaysBefore?: number | null;
+  providerReference?: string | null;
+  projectedNextChargeAmountCents?: number | null;
+  lastChargedAmountCents?: number | null;
+  trialEndDate?: Date | string | null;
+  planName?: string | null;
+  cancellationReason?: string | null;
+  markedForReview?: boolean | null;
 };
 
-function toIsoString(value: Date | string): string {
-  if (value instanceof Date) {
-    return value.toISOString();
+type BuildSubscriptionDetailsOptions = {
+  now?: Date;
+};
+
+const TIMELINE_LIMIT = 10;
+const WEEKLY_TO_MONTHLY_FACTOR = 4.33;
+const DEFAULT_REMINDER_DAYS_BEFORE = 3;
+const MAX_REMINDER_DAYS_BEFORE = 30;
+const DAYS_TO_MILLISECONDS = 24 * 60 * 60 * 1000;
+const ATTENTION_PROMO_WINDOW_DAYS = 7;
+const ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS = 45;
+const PROMO_HINT_KEYWORDS = ["trial", "promo", "intro", "discount", "offer", "starter"] as const;
+
+function toDate(value: Date | string): Date {
+  const parsed = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Invalid date value while building subscription details.");
   }
 
-  return new Date(value).toISOString();
+  return parsed;
 }
 
-function toOptionalIsoString(value: Date | string | null): string | null {
+function toIsoString(value: Date | string): string {
+  return toDate(value).toISOString();
+}
+
+function toOptionalIsoString(value: Date | string | null | undefined): string | null {
   if (!value) {
     return null;
   }
 
   return toIsoString(value);
+}
+
+function normalizeCurrency(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  return normalized || "USD";
 }
 
 function formatBillingIntervalLabel(interval: BillingIntervalCode): string {
@@ -111,7 +324,7 @@ function formatBillingIntervalLabel(interval: BillingIntervalCode): string {
 function estimateNormalizedMonthlyAmountCents(amountCents: number, interval: BillingIntervalCode): number | null {
   switch (interval) {
     case "WEEKLY":
-      return Math.round(amountCents * 4.33);
+      return Math.round(amountCents * WEEKLY_TO_MONTHLY_FACTOR);
     case "MONTHLY":
       return amountCents;
     case "YEARLY":
@@ -148,10 +361,59 @@ function maskPaymentMethod(value: string): string {
   return `•••• ${trimmed.slice(-4)}`;
 }
 
+function normalizeReminderDaysBefore(value: number | null | undefined): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_REMINDER_DAYS_BEFORE;
+  }
+
+  const rounded = Math.floor(value as number);
+
+  if (rounded < 0) {
+    return 0;
+  }
+
+  if (rounded > MAX_REMINDER_DAYS_BEFORE) {
+    return MAX_REMINDER_DAYS_BEFORE;
+  }
+
+  return rounded;
+}
+
+function daysUntil(value: Date, now: Date): number {
+  return Math.max(0, Math.ceil((value.getTime() - now.getTime()) / DAYS_TO_MILLISECONDS));
+}
+
+function daysSince(value: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - value.getTime()) / DAYS_TO_MILLISECONDS));
+}
+
+function formatCurrencyForCopy(amountCents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amountCents / 100);
+}
+
+function formatDateForCopy(value: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(value);
+}
+
+function hasPromoHint(name: string): boolean {
+  const lowered = name.trim().toLowerCase();
+  return PROMO_HINT_KEYWORDS.some((keyword) => lowered.includes(keyword));
+}
+
 function buildTimeline(record: SubscriptionDetailsSourceRecord): SubscriptionDetailsEvent[] {
   const createdAtIso = toIsoString(record.createdAt);
   const updatedAtIso = toIsoString(record.updatedAt);
   const nextBillingDateIso = toOptionalIsoString(record.nextBillingDate);
+  const currency = normalizeCurrency(record.currency);
   const events: SubscriptionDetailsEvent[] = [
     {
       id: `${record.id}-created`,
@@ -160,7 +422,7 @@ function buildTimeline(record: SubscriptionDetailsSourceRecord): SubscriptionDet
       description: "This subscription was created in Sub Stalker.",
       timestamp: createdAtIso,
       amountCents: record.amountCents,
-      currency: record.currency,
+      currency,
     },
     {
       id: `${record.id}-billing-profile`,
@@ -169,7 +431,7 @@ function buildTimeline(record: SubscriptionDetailsSourceRecord): SubscriptionDet
       description: `${formatBillingIntervalLabel(record.billingInterval)} cadence captured with payment method on file.`,
       timestamp: createdAtIso,
       amountCents: record.amountCents,
-      currency: record.currency,
+      currency,
     },
   ];
 
@@ -182,8 +444,8 @@ function buildTimeline(record: SubscriptionDetailsSourceRecord): SubscriptionDet
         ? "Upcoming billing date for the active subscription."
         : "Recorded cancellation date for this inactive subscription.",
       timestamp: nextBillingDateIso,
-      amountCents: record.amountCents,
-      currency: record.currency,
+      amountCents: record.projectedNextChargeAmountCents ?? record.amountCents,
+      currency,
     });
   }
 
@@ -211,14 +473,52 @@ function buildTimeline(record: SubscriptionDetailsSourceRecord): SubscriptionDet
     });
   }
 
-  return events.sort((first, second) => new Date(second.timestamp).getTime() - new Date(first.timestamp).getTime()).slice(0, 10);
+  return events
+    .sort((first, second) => new Date(second.timestamp).getTime() - new Date(first.timestamp).getTime())
+    .slice(0, TIMELINE_LIMIT);
 }
 
-function buildMetadataTags(record: SubscriptionDetailsSourceRecord): string[] {
+function deriveLifecycleStage(record: SubscriptionDetailsSourceRecord, now: Date): SubscriptionDetailsLifecycleStage {
+  if (record.isActive) {
+    return "active";
+  }
+
+  const nextBillingDate = record.nextBillingDate ? toDate(record.nextBillingDate) : null;
+
+  if (nextBillingDate && nextBillingDate.getTime() > now.getTime()) {
+    return "cancel_scheduled";
+  }
+
+  return "canceled";
+}
+
+function lifecycleLabel(stage: SubscriptionDetailsLifecycleStage): string {
+  switch (stage) {
+    case "active":
+      return "Active";
+    case "cancel_scheduled":
+      return "Cancel scheduled";
+    default:
+      return "Canceled";
+  }
+}
+
+function lifecycleTone(stage: SubscriptionDetailsLifecycleStage): SubscriptionDetailsChipTone {
+  switch (stage) {
+    case "active":
+      return "success";
+    case "cancel_scheduled":
+      return "warning";
+    default:
+      return "danger";
+  }
+}
+
+function buildMetadataTags(record: SubscriptionDetailsSourceRecord, stage: SubscriptionDetailsLifecycleStage): string[] {
   const tags = [
     formatBillingIntervalLabel(record.billingInterval),
-    record.currency.toUpperCase(),
-    record.isActive ? "Active" : "Inactive",
+    normalizeCurrency(record.currency),
+    lifecycleLabel(stage),
   ];
 
   if (record.signedUpBy?.trim()) {
@@ -228,18 +528,527 @@ function buildMetadataTags(record: SubscriptionDetailsSourceRecord): string[] {
   return tags;
 }
 
-export function buildSubscriptionDetails(record: SubscriptionDetailsSourceRecord): SubscriptionDetailsContract {
+function buildAlertRuleOutcomes(
+  record: SubscriptionDetailsSourceRecord,
+  now: Date,
+  currency: string,
+): SubscriptionDetailsAlertRuleOutcome[] {
+  const nextBillingDate = record.nextBillingDate ? toDate(record.nextBillingDate) : null;
+  const createdAt = toDate(record.createdAt);
+  const outcomes: SubscriptionDetailsAlertRuleOutcome[] = [];
+
+  if (!record.isActive) {
+    outcomes.push({
+      code: "promo_ending_soon",
+      status: "not_applicable",
+      reason: "Promo-end alerts are only evaluated for active subscriptions.",
+      missingFields: [],
+    });
+  } else if (!hasPromoHint(record.name)) {
+    outcomes.push({
+      code: "promo_ending_soon",
+      status: "not_applicable",
+      reason: "No promo or trial keywords were found in the subscription name.",
+      missingFields: [],
+    });
+  } else if (!nextBillingDate) {
+    outcomes.push({
+      code: "promo_ending_soon",
+      status: "insufficient_data",
+      reason: "A next billing date is required to estimate when a promo window ends.",
+      missingFields: ["nextBillingDate"],
+    });
+  } else {
+    const accountAgeDays = daysSince(createdAt, now);
+    const daysUntilRenewal = daysUntil(nextBillingDate, now);
+
+    if (accountAgeDays > ATTENTION_PROMO_MAX_ACCOUNT_AGE_DAYS) {
+      outcomes.push({
+        code: "promo_ending_soon",
+        status: "not_applicable",
+        reason: "The subscription age exceeds the promo-watch window.",
+        missingFields: [],
+      });
+    } else if (daysUntilRenewal > ATTENTION_PROMO_WINDOW_DAYS) {
+      outcomes.push({
+        code: "promo_ending_soon",
+        status: "not_applicable",
+        reason: "The next renewal is outside the promo-watch window.",
+        missingFields: [],
+      });
+    } else {
+      outcomes.push({
+        code: "promo_ending_soon",
+        status: "matched",
+        reason: `Renewal is due within ${ATTENTION_PROMO_WINDOW_DAYS} days and the subscription name suggests promo pricing.`,
+        missingFields: [],
+      });
+    }
+  }
+
+  if (!nextBillingDate) {
+    outcomes.push({
+      code: "price_increase_imminent",
+      status: "insufficient_data",
+      reason: "A next billing date is required to time price-change messaging.",
+      missingFields: ["nextBillingDate"],
+    });
+  } else if (record.projectedNextChargeAmountCents === null || record.projectedNextChargeAmountCents === undefined) {
+    outcomes.push({
+      code: "price_increase_imminent",
+      status: "insufficient_data",
+      reason: "Projected next-charge pricing is not stored yet.",
+      missingFields: ["projectedNextChargeAmountCents"],
+    });
+  } else if (record.projectedNextChargeAmountCents > record.amountCents && daysUntil(nextBillingDate, now) <= ATTENTION_PROMO_WINDOW_DAYS) {
+    outcomes.push({
+      code: "price_increase_imminent",
+      status: "matched",
+      reason: `Projected renewal price exceeds the current amount within ${ATTENTION_PROMO_WINDOW_DAYS} days.`,
+      missingFields: [],
+    });
+  } else {
+    outcomes.push({
+      code: "price_increase_imminent",
+      status: "not_applicable",
+      reason: "No imminent price increase was derived from the available renewal pricing data.",
+      missingFields: [],
+    });
+  }
+
+  if (!nextBillingDate) {
+    outcomes.push({
+      code: "higher_price_renewal",
+      status: "insufficient_data",
+      reason: "A next billing date is required to describe the next renewal event.",
+      missingFields: ["nextBillingDate"],
+    });
+  } else if (record.lastChargedAmountCents === null || record.lastChargedAmountCents === undefined) {
+    outcomes.push({
+      code: "higher_price_renewal",
+      status: "insufficient_data",
+      reason: "A prior charged amount is required to compare renewal pricing.",
+      missingFields: ["lastChargedAmountCents"],
+    });
+  } else if (record.projectedNextChargeAmountCents === null || record.projectedNextChargeAmountCents === undefined) {
+    outcomes.push({
+      code: "higher_price_renewal",
+      status: "insufficient_data",
+      reason: "Projected next-charge pricing is required to compare renewal pricing.",
+      missingFields: ["projectedNextChargeAmountCents"],
+    });
+  } else if (record.projectedNextChargeAmountCents > record.lastChargedAmountCents) {
+    outcomes.push({
+      code: "higher_price_renewal",
+      status: "matched",
+      reason: "Projected renewal amount is higher than the last captured charge amount.",
+      missingFields: [],
+    });
+  } else {
+    outcomes.push({
+      code: "higher_price_renewal",
+      status: "not_applicable",
+      reason: "Projected renewal amount does not exceed the last captured charge amount.",
+      missingFields: [],
+    });
+  }
+
+  return outcomes.map((outcome) => ({
+    ...outcome,
+    reason:
+      outcome.code === "promo_ending_soon"
+        ? outcome.reason
+        : `${outcome.reason}${currency ? ` Currency context: ${currency}.` : ""}`,
+  }));
+}
+
+function buildAlertItems(
+  outcomes: SubscriptionDetailsAlertRuleOutcome[],
+  record: SubscriptionDetailsSourceRecord,
+  currency: string,
+): SubscriptionDetailsAlertItem[] {
+  const nextBillingDate = toOptionalIsoString(record.nextBillingDate);
+  const nextBillingDateValue = record.nextBillingDate ? toDate(record.nextBillingDate) : null;
+
+  return outcomes
+    .filter((outcome) => outcome.status === "matched")
+    .map((outcome) => {
+      switch (outcome.code) {
+        case "promo_ending_soon":
+          return {
+            code: outcome.code,
+            severity: "high",
+            title: "Promo ending soon",
+            message: nextBillingDateValue
+              ? `Renewal on ${formatDateForCopy(nextBillingDateValue)} may roll to the standard ${formatCurrencyForCopy(record.amountCents, currency)} rate.`
+              : "Renewal may roll to a higher standard rate soon.",
+            effectiveDate: nextBillingDate,
+            currentAmountCents: record.amountCents,
+            projectedAmountCents: record.projectedNextChargeAmountCents ?? null,
+            currency,
+          };
+        case "price_increase_imminent":
+          return {
+            code: outcome.code,
+            severity: "high",
+            title: "Price increase imminent",
+            message:
+              record.projectedNextChargeAmountCents === null || record.projectedNextChargeAmountCents === undefined
+                ? "Projected renewal pricing is unavailable."
+                : `Next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}.`,
+            effectiveDate: nextBillingDate,
+            currentAmountCents: record.amountCents,
+            projectedAmountCents: record.projectedNextChargeAmountCents ?? null,
+            currency,
+          };
+        case "higher_price_renewal":
+          return {
+            code: outcome.code,
+            severity: "medium",
+            title: "Renewal higher than last charge",
+            message:
+              record.projectedNextChargeAmountCents === null ||
+              record.projectedNextChargeAmountCents === undefined ||
+              record.lastChargedAmountCents === null ||
+              record.lastChargedAmountCents === undefined
+                ? "Renewal comparison data is unavailable."
+                : `Last charge was ${formatCurrencyForCopy(record.lastChargedAmountCents, currency)} and the next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}.`,
+            effectiveDate: nextBillingDate,
+            currentAmountCents: record.lastChargedAmountCents ?? null,
+            projectedAmountCents: record.projectedNextChargeAmountCents ?? null,
+            currency,
+          };
+      }
+    });
+}
+
+function buildActionBar(
+  record: SubscriptionDetailsSourceRecord,
+  links: SubscriptionDetailsContract["links"],
+): SubscriptionDetailsV2Contract["actionBar"] {
+  const header: SubscriptionDetailsActionCapability[] = [
+    {
+      key: "edit_subscription",
+      label: "Edit",
+      placement: "header",
+      kind: "client",
+      availability: "enabled",
+      unavailableReason: null,
+      href: null,
+      permission: "owner_write",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: [
+        "Validate authenticated ownership before updating the subscription.",
+        "Validate amount, currency, billing interval, and date fields.",
+        "Validate management URLs as http/https when provided.",
+      ],
+    },
+    {
+      key: "mark_cancelled",
+      label: "Mark Cancelled",
+      placement: "header",
+      kind: "mutate",
+      availability: record.isActive ? "enabled" : "disabled",
+      unavailableReason: record.isActive ? null : "Subscription is already inactive.",
+      href: null,
+      permission: "owner_write",
+      requiresConfirmation: true,
+      confirmationLabel: "Confirm cancellation state change",
+      serverValidation: [
+        "Validate authenticated ownership before updating lifecycle state.",
+        "Reject duplicate cancel requests for already inactive subscriptions.",
+        "Persist cancellation effective date when one is supplied.",
+      ],
+    },
+  ];
+
+  const quickActions: SubscriptionDetailsActionCapability[] = [
+    {
+      key: "open_management_page",
+      label: "Open management page",
+      placement: "quick_actions",
+      kind: "navigate",
+      availability: links.billingConsoleUrl ? "enabled" : "disabled",
+      unavailableReason: links.billingConsoleUrl ? null : "No management URL is stored for this subscription.",
+      href: links.billingConsoleUrl,
+      permission: "owner_read",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: ["Validate stored management URLs as http/https before rendering navigation affordances."],
+    },
+    {
+      key: "change_alert",
+      label: "Change alert",
+      placement: "quick_actions",
+      kind: "client",
+      availability: "disabled",
+      unavailableReason: "Alert tuning is currently account-level only and has no per-subscription persistence.",
+      href: null,
+      permission: "owner_write",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: [
+        "Validate authenticated ownership before writing reminder preferences.",
+        "Validate reminder lead time as an integer between 0 and 30.",
+      ],
+    },
+    {
+      key: "mark_for_review",
+      label: "Mark for review",
+      placement: "quick_actions",
+      kind: "mutate",
+      availability: "disabled",
+      unavailableReason: "Review-state persistence is not implemented yet.",
+      href: null,
+      permission: "owner_write",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: [
+        "Validate authenticated ownership before writing review state.",
+        "Reject review-state writes until a dedicated persistence field exists.",
+      ],
+    },
+    {
+      key: "cancel_soon",
+      label: "Cancel soon",
+      placement: "quick_actions",
+      kind: "navigate",
+      availability: record.isActive && links.cancelSubscriptionUrl ? "enabled" : "disabled",
+      unavailableReason:
+        record.isActive && links.cancelSubscriptionUrl
+          ? null
+          : record.isActive
+            ? "No cancellation URL is stored for this subscription."
+            : "Inactive subscriptions cannot start a new cancel flow.",
+      href: record.isActive ? links.cancelSubscriptionUrl : null,
+      permission: "owner_write",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: [
+        "Validate stored cancellation URLs as http/https before rendering navigation affordances.",
+        "Require an active subscription before surfacing cancel-start flows.",
+      ],
+    },
+  ];
+
+  const footer: SubscriptionDetailsActionCapability[] = [
+    {
+      key: "view_billing_history",
+      label: "View billing history",
+      placement: "footer",
+      kind: "navigate",
+      availability: links.billingHistoryUrl ? "enabled" : "disabled",
+      unavailableReason: links.billingHistoryUrl ? null : "No billing-history URL is stored for this subscription.",
+      href: links.billingHistoryUrl,
+      permission: "owner_read",
+      requiresConfirmation: false,
+      confirmationLabel: null,
+      serverValidation: ["Validate stored billing-history URLs as http/https before rendering navigation affordances."],
+    },
+  ];
+
+  return {
+    state: "ready",
+    header,
+    quickActions,
+    footer,
+  };
+}
+
+export function buildSubscriptionDetails(
+  record: SubscriptionDetailsSourceRecord,
+  options: BuildSubscriptionDetailsOptions = {},
+): SubscriptionDetailsContract {
+  const now = options.now ?? new Date();
   const normalizedMonthlyAmountCents = estimateNormalizedMonthlyAmountCents(record.amountCents, record.billingInterval);
   const normalizedYearlyAmountCents = estimateNormalizedYearlyAmountCents(record.amountCents, record.billingInterval);
   const nextBillingDateIso = toOptionalIsoString(record.nextBillingDate);
+  const trialEndDateIso = toOptionalIsoString(record.trialEndDate);
   const inferredCategory = inferSubscriptionCategory(record.name);
+  const paymentMethodMasked = maskPaymentMethod(record.paymentMethod);
+  const stage = deriveLifecycleStage(record, now);
+  const currency = normalizeCurrency(record.currency);
+  const reminderDaysBefore = normalizeReminderDaysBefore(record.reminderDaysBefore);
+  const remindersEnabled = record.remindersEnabled ?? true;
+  const reminderStatusLabel = remindersEnabled
+    ? reminderDaysBefore === 0
+      ? "On billing day"
+      : `${reminderDaysBefore} day${reminderDaysBefore === 1 ? "" : "s"} before renewal`
+    : "Disabled";
+  const metadataTags = buildMetadataTags(record, stage);
+  const timeline = buildTimeline(record);
+  const links = {
+    billingConsoleUrl: record.billingConsoleUrl,
+    cancelSubscriptionUrl: record.cancelSubscriptionUrl,
+    billingHistoryUrl: record.billingHistoryUrl,
+  };
+  const internalIdentifiers = {
+    subscriptionId: record.id,
+    providerReference: record.providerReference ?? null,
+  };
+  const alertRuleOutcomes = buildAlertRuleOutcomes(record, now, currency);
+  const alertItems = buildAlertItems(alertRuleOutcomes, record, currency);
+  const lifecycleChips: SubscriptionDetailsChip[] = [
+    {
+      key: "lifecycle",
+      label: lifecycleLabel(stage),
+      tone: lifecycleTone(stage),
+    },
+  ];
+
+  if (hasPromoHint(record.name)) {
+    lifecycleChips.push({
+      key: "promo-watch",
+      label: "Promo watch",
+      tone: "warning",
+    });
+  }
+
+  lifecycleChips.push({
+    key: "category",
+    label: inferredCategory,
+    tone: "neutral",
+  });
+
+  const attentionState =
+    alertItems.length === 0
+      ? alertRuleOutcomes.some((outcome) => outcome.status === "insufficient_data")
+        ? "partial"
+        : "empty"
+      : alertRuleOutcomes.some((outcome) => outcome.status === "insufficient_data")
+        ? "partial"
+        : "ready";
+  const managementState: SubscriptionDetailsSectionState =
+    links.billingConsoleUrl || links.cancelSubscriptionUrl || links.billingHistoryUrl || internalIdentifiers.providerReference
+      ? "ready"
+      : "partial";
+  const lifecycleState: SubscriptionDetailsSectionState =
+    record.markedForReview === undefined || record.markedForReview === null ? "partial" : "ready";
+
+  const v2: SubscriptionDetailsV2Contract = {
+    generatedAt: now.toISOString(),
+    sectionStates: {
+      header: "ready",
+      summaryStrip: nextBillingDateIso ? "ready" : "partial",
+      attentionNeeded: attentionState,
+      actionBar: "ready",
+      billingDetails: nextBillingDateIso ? "ready" : "partial",
+      notesCategory: record.notesMarkdown?.trim() ? "ready" : "partial",
+      paymentHistory: timeline.length > 0 ? "ready" : "empty",
+      management: managementState,
+      lifecycle: lifecycleState,
+    },
+    header: {
+      state: "ready",
+      title: record.name,
+      subtitle: `${formatCurrencyForCopy(record.amountCents, currency)} every ${formatBillingIntervalLabel(record.billingInterval).toLowerCase()}`,
+      categoryLabel: inferredCategory,
+      status: {
+        stage,
+        label: lifecycleLabel(stage),
+      },
+      chips: lifecycleChips,
+    },
+    summaryStrip: {
+      state: nextBillingDateIso ? "ready" : "partial",
+      currentPrice: {
+        amountCents: record.amountCents,
+        currency,
+        intervalLabel: formatBillingIntervalLabel(record.billingInterval),
+        monthlyEquivalentAmountCents: normalizedMonthlyAmountCents,
+      },
+      renewal: {
+        date: nextBillingDateIso,
+        annualizedSpendCents: normalizedYearlyAmountCents,
+        projectedAmountCents: record.projectedNextChargeAmountCents ?? null,
+        currency,
+      },
+      paymentMethod: {
+        masked: paymentMethodMasked,
+        signedUpBy: record.signedUpBy?.trim() ? record.signedUpBy.trim() : null,
+      },
+      reminders: {
+        enabled: remindersEnabled,
+        daysBefore: reminderDaysBefore,
+        statusLabel: reminderStatusLabel,
+      },
+    },
+    attentionNeeded: {
+      state: attentionState,
+      items: alertItems,
+      ruleOutcomes: alertRuleOutcomes,
+    },
+    actionBar: buildActionBar(record, links),
+    billingDetails: {
+      state: nextBillingDateIso ? "ready" : "partial",
+      amountCents: record.amountCents,
+      currency,
+      billingInterval: record.billingInterval,
+      billingIntervalLabel: formatBillingIntervalLabel(record.billingInterval),
+      nextBillingDate: nextBillingDateIso,
+      paymentMethodMasked,
+      spendSummary: {
+        label: "Projected annual spend",
+        amountCents: normalizedYearlyAmountCents,
+        currency,
+      },
+      trialEndDate: trialEndDateIso,
+    },
+    notesCategory: {
+      state: record.notesMarkdown?.trim() ? "ready" : "partial",
+      inferredCategory,
+      signedUpBy: record.signedUpBy?.trim() ? record.signedUpBy.trim() : null,
+      notesMarkdown: record.notesMarkdown,
+      metadataTags,
+    },
+    paymentHistory: {
+      state: timeline.length > 0 ? "ready" : "empty",
+      items: timeline,
+      upcomingRenewal: {
+        renewalDate: nextBillingDateIso,
+        projectedAmountCents: record.projectedNextChargeAmountCents ?? record.amountCents,
+        currency,
+      },
+      maxVisibleItems: TIMELINE_LIMIT,
+      hasMore: false,
+    },
+    management: {
+      state: managementState,
+      providerDisplayName: record.name,
+      billingConsoleUrl: links.billingConsoleUrl,
+      cancelSubscriptionUrl: links.cancelSubscriptionUrl,
+      billingHistoryUrl: links.billingHistoryUrl,
+      internalIdentifiers,
+    },
+    lifecycle: {
+      state: lifecycleState,
+      stage,
+      label: lifecycleLabel(stage),
+      autoRenew: record.isActive,
+      startDate: toIsoString(record.createdAt),
+      renewalDate: nextBillingDateIso,
+      cancellationEffectiveDate: record.isActive ? null : nextBillingDateIso,
+      cancellationReason: record.cancellationReason ?? null,
+      reviewState: {
+        isMarked: record.markedForReview ?? false,
+        canPersist: record.markedForReview !== undefined && record.markedForReview !== null,
+        unavailableReason:
+          record.markedForReview === undefined || record.markedForReview === null
+            ? "Review-state persistence is not implemented yet."
+            : null,
+      },
+      chips: lifecycleChips,
+    },
+  };
 
   return {
+    schemaVersion: "2026-03-v2",
     id: record.id,
     name: record.name,
     status: record.isActive ? "ACTIVE" : "CANCELED",
     amountCents: record.amountCents,
-    currency: record.currency,
+    currency,
     billingInterval: record.billingInterval,
     billingIntervalLabel: formatBillingIntervalLabel(record.billingInterval),
     normalizedMonthlyAmountCents,
@@ -248,32 +1057,26 @@ export function buildSubscriptionDetails(record: SubscriptionDetailsSourceRecord
     startDate: toIsoString(record.createdAt),
     renewalDate: nextBillingDateIso,
     lastChargeDate: null,
-    lastChargeAmountCents: null,
-    paymentMethodMasked: maskPaymentMethod(record.paymentMethod),
-    trialEndDate: null,
-    planName: null,
+    lastChargeAmountCents: record.lastChargedAmountCents ?? null,
+    paymentMethodMasked,
+    trialEndDate: trialEndDateIso,
+    planName: record.planName ?? null,
     autoRenew: record.isActive,
     cancellationEffectiveDate: record.isActive ? null : nextBillingDateIso,
-    cancellationReason: null,
+    cancellationReason: record.cancellationReason ?? null,
     signedUpBy: record.signedUpBy?.trim() ? record.signedUpBy.trim() : null,
     inferredCategory,
     spendSummary: {
       label: "Projected annual spend",
       amountCents: normalizedYearlyAmountCents,
-      currency: record.currency,
+      currency,
     },
-    metadataTags: buildMetadataTags(record),
+    metadataTags,
     notesMarkdown: record.notesMarkdown,
-    links: {
-      billingConsoleUrl: record.billingConsoleUrl,
-      cancelSubscriptionUrl: record.cancelSubscriptionUrl,
-      billingHistoryUrl: record.billingHistoryUrl,
-    },
-    internalIdentifiers: {
-      subscriptionId: record.id,
-      providerReference: null,
-    },
-    timeline: buildTimeline(record),
+    links,
+    internalIdentifiers,
+    timeline,
     lastUpdatedAt: toIsoString(record.updatedAt),
+    v2,
   };
 }

--- a/tests/subscription-details/build-subscription-details.test.ts
+++ b/tests/subscription-details/build-subscription-details.test.ts
@@ -44,6 +44,9 @@ describe("buildSubscriptionDetails", () => {
       amountCents: 24_000,
       currency: "USD",
     });
+    assert.equal(details.schemaVersion, "2026-03-v2");
+    assert.equal(details.v2.summaryStrip.currentPrice.monthlyEquivalentAmountCents, 2_000);
+    assert.equal(details.v2.summaryStrip.reminders.statusLabel, "3 days before renewal");
   });
 
   test("falls back cleanly when category and annualized spend cannot be inferred", () => {
@@ -65,5 +68,86 @@ describe("buildSubscriptionDetails", () => {
       currency: "USD",
     });
     assert.equal(details.notesMarkdown, "   ");
+    assert.equal(details.v2.notesCategory.state, "partial");
+    assert.equal(details.v2.sectionStates.summaryStrip, "ready");
+    assert.equal(details.v2.attentionNeeded.state, "partial");
+    assert.deepEqual(
+      details.v2.attentionNeeded.ruleOutcomes
+        .filter((outcome) => outcome.status === "insufficient_data")
+        .map((outcome) => outcome.code),
+      ["price_increase_imminent", "higher_price_renewal"],
+    );
+  });
+
+  test("derives promo alerts and action capabilities deterministically", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "promo-service",
+        name: "Streaming Trial Promo",
+        amountCents: 1299,
+        createdAt: new Date("2026-02-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+        nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+      }),
+      {
+        now: new Date("2026-03-11T00:00:00.000Z"),
+      },
+    );
+
+    assert.equal(details.v2.attentionNeeded.items.length, 1);
+    assert.equal(details.v2.attentionNeeded.items[0]?.code, "promo_ending_soon");
+    assert.equal(details.v2.attentionNeeded.items[0]?.message.includes("Mar"), true);
+    assert.equal(details.v2.attentionNeeded.ruleOutcomes[0]?.status, "matched");
+    assert.equal(details.v2.header.status.stage, "active");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "open_management_page")?.availability, "enabled");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "mark_for_review")?.availability, "disabled");
+  });
+
+  test("derives cancel-scheduled lifecycle and disables cancel actions for inactive subscriptions", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "cancelled-later",
+        name: "Cloud Suite",
+        isActive: false,
+        nextBillingDate: new Date("2026-03-20T12:00:00.000Z"),
+        notesMarkdown: null,
+        cancelSubscriptionUrl: null,
+        billingConsoleUrl: null,
+        billingHistoryUrl: null,
+      }),
+      {
+        now: new Date("2026-03-11T00:00:00.000Z"),
+      },
+    );
+
+    assert.equal(details.status, "CANCELED");
+    assert.equal(details.v2.lifecycle.stage, "cancel_scheduled");
+    assert.equal(details.v2.lifecycle.label, "Cancel scheduled");
+    assert.equal(details.v2.actionBar.header.find((action) => action.key === "mark_cancelled")?.availability, "disabled");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "cancel_soon")?.availability, "disabled");
+    assert.equal(details.v2.lifecycle.reviewState.canPersist, false);
+  });
+
+  test("matches higher-price renewal rules when comparison pricing is supplied", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "price-rise",
+        name: "AI Workspace",
+        nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+        projectedNextChargeAmountCents: 3200,
+        lastChargedAmountCents: 2400,
+      }),
+      {
+        now: new Date("2026-03-11T00:00:00.000Z"),
+      },
+    );
+
+    assert.equal(details.lastChargeAmountCents, 2400);
+    assert.deepEqual(
+      details.v2.attentionNeeded.items.map((item) => item.code),
+      ["price_increase_imminent", "higher_price_renewal"],
+    );
+    assert.equal(details.v2.paymentHistory.upcomingRenewal.projectedAmountCents, 3200);
+    assert.equal(details.v2.attentionNeeded.ruleOutcomes.find((outcome) => outcome.code === "higher_price_renewal")?.status, "matched");
   });
 });


### PR DESCRIPTION
## Summary
- extend `lib/subscription-details.ts` with a backward-compatible nested `v2` contract for the operational modal
- wire reminder settings into `/api/subscriptions/[subscriptionId]/details` so the summary strip can expose reminder status
- document the new V2 contract, lifecycle derivation rules, alert rule outcomes, and action validation policy
- add focused tests for V2 section states, lifecycle staging, alert derivation, and action capability gating

## Verification
- `npx dotenv -e .env.local -- node --import tsx --test tests/subscription-details/*.test.ts`

## Notes
- `npm run typecheck` still fails on pre-existing auth/registration verification Prisma typing errors outside this change.