### PR TITLE
[Subscription Details V2] Build hero section and summary metrics strip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ When the user asks for a task to be done, follow this sequence:
 6. Commit the changes and push/publish the branch to remote.
 7. Check for an outstanding pull request that can reasonably include the request; if one exists, add changes there instead of creating a new PR.
 8. Open a new pull request only when no suitable outstanding PR exists.
+9. Make sure that merging the pull request will automatically close any associated issues (when appropriate), by referencing them correctly in the PR description.
 
 ## Required setup for AI contributors
 

--- a/README.md
+++ b/README.md
@@ -272,10 +272,12 @@ Open http://localhost:3000.
 - `/tools` includes a `Send Test Email` action for operational email verification.
 - `/subscriptions` and `/settings` require authentication.
 - `/subscriptions` provides modal add/edit flows with client-side search, status filtering, and sort controls.
-- subscription details are available in a shared read-only modal opened from:
+- subscription details are available in a shared modal opened from:
   - dashboard -> `Upcoming Charges`
   - subscriptions list -> subscription card row (click, Enter, or Space)
 - the details modal fetches fresh data on open via `/api/subscriptions/[subscriptionId]/details` and includes loading, empty, and error states.
+- the details modal hero now renders V2 header/summary data with service identity, lifecycle/category badges, and summary metrics.
+- from `/subscriptions`, the details modal also exposes `Edit` and `Mark Cancelled` header actions with deterministic disabled/pending states.
 - modal telemetry events are posted to `/api/telemetry` for open/close/view-history interactions with source context.
 - `/subscriptions` learning fields:
   - required `payment method` (free-text + learned suggestions)

--- a/app/components/PendingFormControls.tsx
+++ b/app/components/PendingFormControls.tsx
@@ -6,6 +6,7 @@ type PendingSubmitButtonProps = {
   idleLabel: string;
   pendingLabel: string;
   className?: string;
+  disabled?: boolean;
 };
 
 type PendingFieldsetProps = {
@@ -17,11 +18,12 @@ export function PendingSubmitButton({
   idleLabel,
   pendingLabel,
   className,
+  disabled = false,
 }: PendingSubmitButtonProps): JSX.Element {
   const { pending } = useFormStatus();
 
   return (
-    <button className={className} disabled={pending} type="submit">
+    <button className={className} disabled={pending || disabled} type="submit">
       {pending ? pendingLabel : idleLabel}
     </button>
   );

--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -3,7 +3,11 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { PendingSubmitButton } from "@/app/components/PendingFormControls";
 import type {
+  SubscriptionDetailsActionCapability,
+  SubscriptionDetailsChip,
+  SubscriptionDetailsChipTone,
   SubscriptionDetailsContract,
   SubscriptionModalCloseReason,
   SubscriptionModalOpenSource,
@@ -17,6 +21,8 @@ type SubscriptionDetailsModalProps = {
   errorMessage: string | null;
   onClose: (reason: SubscriptionModalCloseReason) => void;
   onViewFullHistoryClick: () => void;
+  onEditSubscription?: ((subscriptionId: string) => void) | null;
+  deactivateAction?: ((formData: FormData) => Promise<void>) | null;
 };
 
 const FOCUSABLE_SELECTOR =
@@ -107,6 +113,133 @@ function getNotesPreview(notesMarkdown: string | null): { preview: string | null
   };
 }
 
+function chipClassName(tone: SubscriptionDetailsChipTone): string {
+  switch (tone) {
+    case "success":
+      return "pill pill-ok";
+    case "warning":
+      return "pill details-chip-warning";
+    case "danger":
+      return "pill pill-fail";
+    default:
+      return "pill";
+  }
+}
+
+function renderHeaderChip(chip: SubscriptionDetailsChip): JSX.Element {
+  return (
+    <span className={chipClassName(chip.tone)} key={chip.key}>
+      {chip.label}
+    </span>
+  );
+}
+
+function formatMonthlyEquivalent(amountCents: number | null, currency: string): string {
+  if (amountCents === null) {
+    return "Monthly equivalent unavailable";
+  }
+
+  return `${formatMoney(amountCents, currency)}/mo equivalent`;
+}
+
+function formatAnnualizedSpend(amountCents: number | null, currency: string): string {
+  if (amountCents === null) {
+    return "Annualized spend unavailable";
+  }
+
+  return `Annualized spend ${formatMoney(amountCents, currency)}/yr`;
+}
+
+function formatPaymentMethodSummary(signedUpBy: string | null): string {
+  return signedUpBy ? `Signed up by ${signedUpBy}` : "Signed up by not captured";
+}
+
+function getActionByKey(
+  actions: SubscriptionDetailsActionCapability[],
+  key: SubscriptionDetailsActionCapability["key"],
+): SubscriptionDetailsActionCapability | null {
+  return actions.find((action) => action.key === key) ?? null;
+}
+
+function resolveActionState(
+  action: SubscriptionDetailsActionCapability | null,
+  fallbackLabel: string,
+  fallbackUnavailableReason: string,
+): {
+  label: string;
+  disabled: boolean;
+  unavailableReason: string | null;
+} {
+  if (!action) {
+    return {
+      label: fallbackLabel,
+      disabled: true,
+      unavailableReason: fallbackUnavailableReason,
+    };
+  }
+
+  if (action.availability === "disabled") {
+    return {
+      label: action.label,
+      disabled: true,
+      unavailableReason: action.unavailableReason,
+    };
+  }
+
+  return {
+    label: action.label,
+    disabled: false,
+    unavailableReason: null,
+  };
+}
+
+function ModalDeactivateButton({
+  subscriptionId,
+  label,
+  unavailableReason,
+  deactivateAction,
+}: {
+  subscriptionId: string;
+  label: string;
+  unavailableReason: string | null;
+  deactivateAction: ((formData: FormData) => Promise<void>) | null;
+}): JSX.Element {
+  if (!deactivateAction) {
+    return (
+      <button
+        className="button-danger button-small"
+        disabled
+        title={unavailableReason ?? "Cancellation controls are unavailable from this view."}
+        type="button"
+      >
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <form
+      action={deactivateAction}
+      className="details-action-form"
+      onSubmit={(event) => {
+        const confirmed = window.confirm("Mark this subscription as cancelled?");
+
+        if (!confirmed) {
+          event.preventDefault();
+        }
+      }}
+    >
+      <input name="subscriptionId" type="hidden" value={subscriptionId} />
+      <PendingSubmitButton
+        className="button-danger button-small"
+        disabled={Boolean(unavailableReason)}
+        idleLabel={label}
+        pendingLabel="Marking..."
+      />
+    </form>
+  );
+}
+
 export default function SubscriptionDetailsModal({
   isOpen,
   loadState,
@@ -115,6 +248,8 @@ export default function SubscriptionDetailsModal({
   errorMessage,
   onClose,
   onViewFullHistoryClick,
+  onEditSubscription = null,
+  deactivateAction = null,
 }: SubscriptionDetailsModalProps) {
   const panelRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -188,16 +323,36 @@ export default function SubscriptionDetailsModal({
     setCopyMessage(null);
   }, [details?.id, isOpen]);
 
+  const historyAction = details ? getActionByKey(details.v2.actionBar.footer, "view_billing_history") : null;
   const historyHref = useMemo(() => {
-    if (!details) {
+    if (!historyAction?.href) {
       return "/subscriptions";
     }
 
-    return details.links.billingHistoryUrl ?? "/subscriptions";
-  }, [details]);
+    return historyAction.href;
+  }, [historyAction]);
 
   const historyIsExternal = historyHref.startsWith("http://") || historyHref.startsWith("https://");
   const notesPreview = getNotesPreview(details?.notesMarkdown ?? null);
+  const headerChips = details ? details.v2.header.chips.filter((chip) => chip.key !== "category") : [];
+  const editAction = details ? getActionByKey(details.v2.actionBar.header, "edit_subscription") : null;
+  const markCancelledAction = details ? getActionByKey(details.v2.actionBar.header, "mark_cancelled") : null;
+  const editActionState = resolveActionState(editAction, "Edit", "Edit controls are unavailable from this view.");
+  const markCancelledActionState = resolveActionState(
+    markCancelledAction,
+    "Mark Cancelled",
+    "Cancellation controls are unavailable from this view.",
+  );
+  const editUnavailableReason =
+    editActionState.unavailableReason ??
+    (onEditSubscription ? null : "Open this subscription from the subscriptions page to edit it.");
+  const markCancelledUnavailableReason =
+    markCancelledActionState.unavailableReason ??
+    (deactivateAction ? null : "Open this subscription from the subscriptions page to update cancellation state.");
+  const lifecycleActionHint =
+    details && !onEditSubscription && !deactivateAction
+      ? "Manage edit and cancellation actions from the subscriptions page."
+      : null;
 
   async function handleCopySubscriptionId(): Promise<void> {
     if (!details) {
@@ -228,7 +383,6 @@ export default function SubscriptionDetailsModal({
           <div className="stack">
             <p className="eyebrow">{sourceLabel(source)}</p>
             <h2 id="subscription-details-title">Subscription Details</h2>
-            {details ? <p className="text-muted">Last updated: {formatDateTime(details.lastUpdatedAt)}</p> : null}
           </div>
           <button
             className="button button-secondary button-small details-modal-close"
@@ -263,21 +417,92 @@ export default function SubscriptionDetailsModal({
 
         {loadState === "ready" && details ? (
           <div className="details-grid">
-            <article className="surface surface-soft details-section">
-              <div className="details-title-row">
-                <div className="details-logo">{getInitials(details.name)}</div>
-                <div>
-                  <h3>{details.name}</h3>
-                  <p className="text-muted">
-                    {formatMoney(details.amountCents, details.currency)} every {details.billingIntervalLabel.toLowerCase()}
-                  </p>
+            <article className="surface surface-soft details-section details-hero">
+              <div className="details-hero-row">
+                <div className="details-hero-main">
+                  <div className="details-title-row details-hero-identity">
+                    <div className="details-logo details-hero-logo">{getInitials(details.v2.header.title)}</div>
+                    <div className="details-title-copy">
+                      <h3>{details.v2.header.title}</h3>
+                      <p className="text-muted details-hero-subtitle">{details.v2.header.subtitle}</p>
+                      <p className="text-muted details-hero-updated">Last updated: {formatDateTime(details.lastUpdatedAt)}</p>
+                    </div>
+                  </div>
+                  <div className="inline-actions details-hero-badges" aria-label="Subscription status and category">
+                    <span className="pill">{details.v2.header.categoryLabel}</span>
+                    {headerChips.map((chip) => renderHeaderChip(chip))}
+                  </div>
+                </div>
+
+                <div className="details-hero-actions">
+                  <div className="details-hero-action-row">
+                    <button
+                      className="button button-secondary button-small"
+                      disabled={editActionState.disabled || !onEditSubscription}
+                      onClick={() => {
+                        if (onEditSubscription) {
+                          onEditSubscription(details.id);
+                        }
+                      }}
+                      title={editUnavailableReason ?? undefined}
+                      type="button"
+                    >
+                      {editActionState.label}
+                    </button>
+
+                    <ModalDeactivateButton
+                      deactivateAction={deactivateAction}
+                      label={markCancelledActionState.label}
+                      subscriptionId={details.id}
+                      unavailableReason={markCancelledUnavailableReason}
+                    />
+                  </div>
+
+                  {lifecycleActionHint ? <p className="text-muted details-hero-actions-hint">{lifecycleActionHint}</p> : null}
                 </div>
               </div>
-              <div className="inline-actions">
-                <span className={details.status === "ACTIVE" ? "pill pill-ok" : "pill pill-fail"}>{details.status}</span>
-                <span className="pill">
-                  Monthly estimate: {formatMoney(details.normalizedMonthlyAmountCents, details.currency)}
-                </span>
+
+              <div className="details-summary-grid" aria-label="Subscription summary">
+                <article className="details-summary-card">
+                  <span className="details-summary-label">Current price</span>
+                  <strong className="details-summary-value">
+                    {formatMoney(details.v2.summaryStrip.currentPrice.amountCents, details.v2.summaryStrip.currentPrice.currency)}
+                  </strong>
+                  <p className="text-muted details-summary-meta">
+                    {details.v2.summaryStrip.currentPrice.intervalLabel} billing ·{" "}
+                    {formatMonthlyEquivalent(
+                      details.v2.summaryStrip.currentPrice.monthlyEquivalentAmountCents,
+                      details.v2.summaryStrip.currentPrice.currency,
+                    )}
+                  </p>
+                </article>
+
+                <article className="details-summary-card">
+                  <span className="details-summary-label">Renewal</span>
+                  <strong className="details-summary-value">{formatDate(details.v2.summaryStrip.renewal.date)}</strong>
+                  <p className="text-muted details-summary-meta">
+                    {formatAnnualizedSpend(
+                      details.v2.summaryStrip.renewal.annualizedSpendCents,
+                      details.v2.summaryStrip.renewal.currency,
+                    )}
+                  </p>
+                </article>
+
+                <article className="details-summary-card">
+                  <span className="details-summary-label">Payment method</span>
+                  <strong className="details-summary-value">{details.v2.summaryStrip.paymentMethod.masked}</strong>
+                  <p className="text-muted details-summary-meta">
+                    {formatPaymentMethodSummary(details.v2.summaryStrip.paymentMethod.signedUpBy)}
+                  </p>
+                </article>
+
+                <article className="details-summary-card">
+                  <span className="details-summary-label">Reminder</span>
+                  <strong className="details-summary-value">{details.v2.summaryStrip.reminders.statusLabel}</strong>
+                  <p className="text-muted details-summary-meta">
+                    {details.v2.summaryStrip.reminders.enabled ? "Reminder emails enabled" : "Reminder emails disabled"}
+                  </p>
+                </article>
               </div>
             </article>
 
@@ -419,21 +644,33 @@ export default function SubscriptionDetailsModal({
             </article>
 
             <footer className="inline-actions details-action-row">
-              {historyIsExternal ? (
-                <a
-                  className="button button-secondary"
-                  href={historyHref}
-                  onClick={onViewFullHistoryClick}
-                  rel="noreferrer noopener"
-                  target="_blank"
-                >
-                  View Full History
-                </a>
+              {historyAction?.availability === "enabled" ? (
+                historyIsExternal ? (
+                  <a
+                    className="button button-secondary"
+                    href={historyHref}
+                    onClick={onViewFullHistoryClick}
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    {historyAction.label}
+                  </a>
+                ) : (
+                  <Link className="button button-secondary" href={historyHref} onClick={onViewFullHistoryClick}>
+                    {historyAction.label}
+                  </Link>
+                )
               ) : (
-                <Link className="button button-secondary" href={historyHref} onClick={onViewFullHistoryClick}>
-                  View Full History
-                </Link>
+                <button
+                  className="button button-secondary"
+                  disabled
+                  title={historyAction?.unavailableReason ?? "Billing history is unavailable for this subscription."}
+                  type="button"
+                >
+                  {historyAction?.label ?? "View billing history"}
+                </button>
               )}
+
               <button className="button button-secondary" onClick={() => void handleCopySubscriptionId()} type="button">
                 Copy Subscription ID
               </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1509,7 +1509,7 @@ button:disabled,
 
 .details-grid {
   display: grid;
-  gap: 0.85rem;
+  gap: 1rem;
 }
 
 .details-card-grid {
@@ -1528,6 +1528,28 @@ button:disabled,
   font-size: 1rem;
 }
 
+.details-hero {
+  gap: 0.95rem;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--brand), transparent 84%), transparent 42%),
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-soft), white 20%), var(--panel-soft));
+}
+
+.details-hero-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.details-hero-main {
+  display: grid;
+  gap: 0.8rem;
+  min-width: 0;
+  flex: 1 1 440px;
+}
+
 .details-section-heading {
   display: flex;
   align-items: flex-start;
@@ -1542,6 +1564,33 @@ button:disabled,
   gap: 0.75rem;
 }
 
+.details-hero-identity {
+  align-items: flex-start;
+}
+
+.details-title-copy {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.details-hero-subtitle,
+.details-hero-updated,
+.details-hero-actions-hint,
+.details-summary-meta {
+  margin: 0;
+}
+
+.details-hero-subtitle {
+  font-size: 0.92rem;
+}
+
+.details-hero-updated,
+.details-hero-actions-hint,
+.details-summary-meta {
+  font-size: 0.82rem;
+}
+
 .details-logo {
   width: 2.4rem;
   height: 2.4rem;
@@ -1554,6 +1603,71 @@ button:disabled,
   font-weight: 700;
   border: 1px solid var(--border);
   background: var(--panel);
+}
+
+.details-hero-logo {
+  width: 3rem;
+  height: 3rem;
+  font-size: 0.92rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.details-hero-badges {
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.details-hero-actions {
+  display: grid;
+  gap: 0.45rem;
+  justify-items: end;
+  flex: 0 0 auto;
+}
+
+.details-hero-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.details-action-form {
+  margin: 0;
+}
+
+.details-summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.details-summary-card {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel), transparent 8%);
+  padding: 0.8rem 0.9rem;
+}
+
+.details-summary-label {
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.details-summary-value {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.details-chip-warning {
+  color: #9a5b08;
+  border-color: rgba(184, 119, 20, 0.28);
+  background: #fff6e7;
 }
 
 .details-definition-list {
@@ -1690,6 +1804,10 @@ ul {
     grid-template-columns: 1fr;
   }
 
+  .details-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .dashboard-control-grid {
     grid-template-columns: 1fr;
     width: 100%;
@@ -1729,5 +1847,24 @@ ul {
 
   .setting-field {
     min-width: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  .details-hero-actions {
+    justify-items: stretch;
+    width: 100%;
+  }
+
+  .details-hero-action-row {
+    justify-content: stretch;
+  }
+
+  .details-hero-action-row > * {
+    flex: 1 1 100%;
+  }
+
+  .details-summary-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -471,11 +471,16 @@ export default function SubscriptionsClient({
       )}
 
       <SubscriptionDetailsModal
+        deactivateAction={deactivateAction}
         details={detailsModal.details}
         errorMessage={detailsModal.errorMessage}
         isOpen={detailsModal.isOpen}
         loadState={detailsModal.fetchState}
         onClose={detailsModal.closeModal}
+        onEditSubscription={(subscriptionId) => {
+          detailsModal.closeModal("close_button");
+          setEditingSubscriptionId(subscriptionId);
+        }}
         onViewFullHistoryClick={detailsModal.trackViewFullHistory}
         source={detailsModal.source}
       />

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -35,11 +35,12 @@ Implemented:
 - Subscription CRUD:
   - authenticated users can create, list, update, and deactivate subscriptions from `/subscriptions`.
   - subscriptions page now supports modal add/edit flows plus client-side search, status filtering, and sorting.
-  - shared read-only `Subscription Details` modal now opens from:
+  - shared `Subscription Details` modal now opens from:
     - dashboard `Upcoming Charges`
     - `/subscriptions` card rows (click + keyboard Enter/Space)
   - details modal data is served by `/api/subscriptions/[subscriptionId]/details` using a shared contract in `lib/subscription-details.ts`.
-  - details modal includes loading/empty/error states, focus trap, `Esc` close, and non-edit actions (`View Full History`, `Copy Subscription ID`, `Close`).
+  - details modal includes loading/empty/error states, focus trap, `Esc` close, V2 hero/summary rendering, and action buttons with deterministic disabled/pending states.
+  - from `/subscriptions`, modal header actions can launch `Edit` and submit `Mark Cancelled`; dashboard entry points keep those lifecycle actions disabled.
   - modal interaction telemetry posts to `/api/telemetry` with source context (`upcoming_charges`, `subscriptions_list`).
   - `paymentMethod` is now required and acts as a learning field (suggests prior values entered by the same user).
   - `signedUpBy` is optional and also acts as a learning field (suggests prior user-entered values).

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -56,9 +56,12 @@ Subscriptions UX:
 15. Use global search with text that appears only in notes or URL fields and confirm matching subscriptions are returned.
 16. Click a subscription card body (not Edit/Deactivate buttons) and confirm `Subscription Details` modal opens.
 17. Focus a subscription card and press `Enter`, then `Space`; confirm modal opens from keyboard.
-18. Inside the modal, confirm focus remains trapped, `Esc` closes it, and there are no editing controls.
+18. Inside the modal, confirm focus remains trapped and `Esc` closes it.
 19. In the modal, click `Copy Subscription ID` and confirm clipboard copy succeeds.
 20. In browser devtools network tab, confirm modal interaction telemetry posts to `POST /api/telemetry` with source `subscriptions_list`.
+21. In the `/subscriptions` details modal, confirm the hero shows category/lifecycle badges plus four summary cards for price, renewal, payment method, and reminder status.
+22. In the `/subscriptions` details modal, click `Edit` and confirm the edit modal opens for the same record.
+23. In the `/subscriptions` details modal for an active record, click `Mark Cancelled`, confirm the confirmation prompt appears, then verify pending state and success message after submit.
 
 Dashboard details modal UX:
 
@@ -66,6 +69,7 @@ Dashboard details modal UX:
 2. While opening modal, confirm loading state is visible and details render after request.
 3. Temporarily break the details request (for example, by forcing `401/404`) and confirm error/empty state copy is shown.
 4. In browser devtools network tab, confirm telemetry source value is `upcoming_charges`.
+5. Confirm dashboard-opened modal still shows the hero/summary strip, and that `Edit` / `Mark Cancelled` are disabled from that context.
 
 Settings UX:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:vercel": "node scripts/vercel-build.mjs",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "npm run prisma:generate && tsc --noEmit",
     "test:auth": "npx dotenv -e .env.local -- node --import tsx --test tests/auth/*.test.ts",
     "test:invites": "dotenv -e .env.local -- node --import tsx --test tests/invites/*.test.ts",
     "test:mail": "dotenv -e .env.local -- node --import tsx --test tests/mail/*.test.ts",


### PR DESCRIPTION
## Summary
- render the subscription-details hero and summary strip from the V2 payload
- wire `Edit` and `Mark Cancelled` header actions for `/subscriptions` with deterministic disabled and pending states
- refresh modal docs/test notes, include the AGENTS issue-closing workflow tweak, and fix repo-wide Prisma client drift during typecheck

## Validation
- `node --import tsx --test tests/subscription-details/*.test.ts`
- `npx eslint app/components/SubscriptionDetailsModal.tsx app/subscriptions/SubscriptionsClient.tsx app/components/PendingFormControls.tsx`
- `npm run typecheck`
- `node --import tsx --test tests/auth/*.test.ts` *(still blocked locally because the auth test database is unavailable in this environment)*

Closes #41
Closes #76
Related to #48