### PR TITLE
Implement issue #42 attention-needed panel

### DIFF
--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { PendingSubmitButton } from "@/app/components/PendingFormControls";
 import type {
   SubscriptionDetailsActionCapability,
+  SubscriptionDetailsAlertItem,
+  SubscriptionDetailsAlertSeverity,
   SubscriptionDetailsChip,
   SubscriptionDetailsChipTone,
   SubscriptionDetailsContract,
@@ -152,6 +155,56 @@ function formatAnnualizedSpend(amountCents: number | null, currency: string): st
 
 function formatPaymentMethodSummary(signedUpBy: string | null): string {
   return signedUpBy ? `Signed up by ${signedUpBy}` : "Signed up by not captured";
+}
+
+function formatAttentionSeverityLabel(severity: SubscriptionDetailsAlertSeverity): string {
+  if (severity === "high") {
+    return "High";
+  }
+
+  if (severity === "medium") {
+    return "Medium";
+  }
+
+  return "Low";
+}
+
+function attentionSeverityClassName(severity: SubscriptionDetailsAlertSeverity): string {
+  return `attention-severity attention-severity-${severity}`;
+}
+
+function attentionSeverityGlyph(severity: SubscriptionDetailsAlertSeverity): string {
+  if (severity === "high") {
+    return "!";
+  }
+
+  if (severity === "medium") {
+    return "~";
+  }
+
+  return "i";
+}
+
+function formatAlertImpactCopy(item: SubscriptionDetailsAlertItem): string | null {
+  if (!item.currency) {
+    return null;
+  }
+
+  if (item.currentAmountCents !== null && item.projectedAmountCents !== null && item.projectedAmountCents > item.currentAmountCents) {
+    const baselineLabel = item.code === "higher_price_renewal" ? "last charge" : "current price";
+
+    return `Projected increase: ${formatMoney(item.projectedAmountCents - item.currentAmountCents, item.currency)} over the ${baselineLabel} (${formatMoney(item.currentAmountCents, item.currency)}).`;
+  }
+
+  if (item.projectedAmountCents !== null) {
+    return `Projected renewal amount: ${formatMoney(item.projectedAmountCents, item.currency)}.`;
+  }
+
+  if (item.currentAmountCents !== null && item.code === "promo_ending_soon") {
+    return `Standard rate shown: ${formatMoney(item.currentAmountCents, item.currency)} after the promo window.`;
+  }
+
+  return null;
 }
 
 function getActionByKey(
@@ -335,6 +388,8 @@ export default function SubscriptionDetailsModal({
   const historyIsExternal = historyHref.startsWith("http://") || historyHref.startsWith("https://");
   const notesPreview = getNotesPreview(details?.notesMarkdown ?? null);
   const headerChips = details ? details.v2.header.chips.filter((chip) => chip.key !== "category") : [];
+  const attentionItems = details?.v2.attentionNeeded.items ?? [];
+  const reviewState = details?.v2.lifecycle.reviewState ?? null;
   const editAction = details ? getActionByKey(details.v2.actionBar.header, "edit_subscription") : null;
   const markCancelledAction = details ? getActionByKey(details.v2.actionBar.header, "mark_cancelled") : null;
   const editActionState = resolveActionState(editAction, "Edit", "Edit controls are unavailable from this view.");
@@ -504,6 +559,65 @@ export default function SubscriptionDetailsModal({
                   </p>
                 </article>
               </div>
+            </article>
+
+            <article className="surface details-section details-attention-panel">
+              <div className="details-section-heading">
+                <div className="stack">
+                  <h3>Attention Needed</h3>
+                  <p className="text-muted details-card-caption">
+                    Promo and price-change risks derived from this subscription&apos;s current billing metadata.
+                  </p>
+                </div>
+                {reviewState ? (
+                  <span className={reviewState.isMarked ? "pill details-review-pill" : "pill"} role="status">
+                    {reviewState.isMarked ? "Marked for review" : "Not marked for review"}
+                  </span>
+                ) : null}
+              </div>
+
+              {reviewState?.isMarked ? (
+                <p className="details-attention-review-note">
+                  This subscription has been flagged for review before the next billing event.
+                </p>
+              ) : null}
+
+              {reviewState && !reviewState.canPersist && reviewState.unavailableReason ? (
+                <p className="text-muted details-card-caption">{reviewState.unavailableReason}</p>
+              ) : null}
+
+              {attentionItems.length === 0 ? (
+                <p className="text-muted details-card-empty">No promo or price-change alerts are active for this subscription.</p>
+              ) : (
+                <div className="details-attention-list">
+                  {attentionItems.map((item) => {
+                    const impactCopy = formatAlertImpactCopy(item);
+
+                    return (
+                      <article className="details-attention-item" key={item.code}>
+                        <div className="details-attention-item-header">
+                          <span className={attentionSeverityClassName(item.severity)}>
+                            <span aria-hidden="true" className="attention-severity-glyph">
+                              {attentionSeverityGlyph(item.severity)}
+                            </span>
+                            {formatAttentionSeverityLabel(item.severity)}
+                          </span>
+                          {item.effectiveDate ? <span className="metric-note">Effective {formatDate(item.effectiveDate)}</span> : null}
+                        </div>
+                        <h4>{item.title}</h4>
+                        <p className="text-muted">{item.message}</p>
+                        {impactCopy ? <p className="details-attention-impact">{impactCopy}</p> : null}
+                      </article>
+                    );
+                  })}
+                </div>
+              )}
+
+              {details.v2.attentionNeeded.state === "partial" ? (
+                <p className="text-muted details-card-caption">
+                  Some pricing signals are still missing, so additional review items may appear when more billing history is captured.
+                </p>
+              ) : null}
             </article>
 
             <div className="details-card-grid">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1528,6 +1528,11 @@ button:disabled,
   font-size: 1rem;
 }
 
+.details-section h4 {
+  margin: 0;
+  font-size: 0.94rem;
+}
+
 .details-hero {
   gap: 0.95rem;
   background:
@@ -1668,6 +1673,57 @@ button:disabled,
   color: #9a5b08;
   border-color: rgba(184, 119, 20, 0.28);
   background: #fff6e7;
+}
+
+.details-review-pill {
+  color: color-mix(in srgb, var(--brand), var(--text) 18%);
+  border-color: color-mix(in srgb, var(--brand) 44%, var(--border));
+  background: color-mix(in srgb, var(--brand) 12%, var(--panel));
+}
+
+.details-attention-panel {
+  gap: 0.8rem;
+}
+
+.details-attention-review-note {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--brand) 34%, var(--border));
+  background: color-mix(in srgb, var(--brand) 8%, var(--panel));
+  color: color-mix(in srgb, var(--brand), var(--text) 22%);
+}
+
+.details-attention-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.details-attention-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-soft), transparent 14%), color-mix(in srgb, var(--panel), transparent 4%));
+}
+
+.details-attention-item p {
+  margin: 0;
+}
+
+.details-attention-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.details-attention-impact {
+  font-size: 0.84rem;
+  color: var(--text-muted);
 }
 
 .details-definition-list {

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -404,6 +404,10 @@ function formatDateForCopy(value: Date): string {
   }).format(value);
 }
 
+function formatPositiveDeltaForCopy(currentAmountCents: number, projectedAmountCents: number, currency: string): string {
+  return formatCurrencyForCopy(Math.max(0, projectedAmountCents - currentAmountCents), currency);
+}
+
 function hasPromoHint(name: string): boolean {
   const lowered = name.trim().toLowerCase();
   return PROMO_HINT_KEYWORDS.some((keyword) => lowered.includes(keyword));
@@ -680,7 +684,7 @@ function buildAlertItems(
             severity: "high",
             title: "Promo ending soon",
             message: nextBillingDateValue
-              ? `Renewal on ${formatDateForCopy(nextBillingDateValue)} may roll to the standard ${formatCurrencyForCopy(record.amountCents, currency)} rate.`
+              ? `Renewal on ${formatDateForCopy(nextBillingDateValue)} may roll off promo pricing onto the standard ${formatCurrencyForCopy(record.amountCents, currency)} rate.`
               : "Renewal may roll to a higher standard rate soon.",
             effectiveDate: nextBillingDate,
             currentAmountCents: record.amountCents,
@@ -695,7 +699,9 @@ function buildAlertItems(
             message:
               record.projectedNextChargeAmountCents === null || record.projectedNextChargeAmountCents === undefined
                 ? "Projected renewal pricing is unavailable."
-                : `Next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}.`,
+                : nextBillingDateValue
+                  ? `Renewal on ${formatDateForCopy(nextBillingDateValue)} is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}, up ${formatPositiveDeltaForCopy(record.amountCents, record.projectedNextChargeAmountCents, currency)} from the current ${formatCurrencyForCopy(record.amountCents, currency)} price.`
+                  : `Next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}, up ${formatPositiveDeltaForCopy(record.amountCents, record.projectedNextChargeAmountCents, currency)} from the current ${formatCurrencyForCopy(record.amountCents, currency)} price.`,
             effectiveDate: nextBillingDate,
             currentAmountCents: record.amountCents,
             projectedAmountCents: record.projectedNextChargeAmountCents ?? null,
@@ -712,7 +718,9 @@ function buildAlertItems(
               record.lastChargedAmountCents === null ||
               record.lastChargedAmountCents === undefined
                 ? "Renewal comparison data is unavailable."
-                : `Last charge was ${formatCurrencyForCopy(record.lastChargedAmountCents, currency)} and the next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}.`,
+                : nextBillingDateValue
+                  ? `Renewal on ${formatDateForCopy(nextBillingDateValue)} is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}, up ${formatPositiveDeltaForCopy(record.lastChargedAmountCents, record.projectedNextChargeAmountCents, currency)} from the last ${formatCurrencyForCopy(record.lastChargedAmountCents, currency)} charge.`
+                  : `The next renewal is projected at ${formatCurrencyForCopy(record.projectedNextChargeAmountCents, currency)}, up ${formatPositiveDeltaForCopy(record.lastChargedAmountCents, record.projectedNextChargeAmountCents, currency)} from the last ${formatCurrencyForCopy(record.lastChargedAmountCents, currency)} charge.`,
             effectiveDate: nextBillingDate,
             currentAmountCents: record.lastChargedAmountCents ?? null,
             projectedAmountCents: record.projectedNextChargeAmountCents ?? null,

--- a/tests/subscription-details/build-subscription-details.test.ts
+++ b/tests/subscription-details/build-subscription-details.test.ts
@@ -147,7 +147,28 @@ describe("buildSubscriptionDetails", () => {
       details.v2.attentionNeeded.items.map((item) => item.code),
       ["price_increase_imminent", "higher_price_renewal"],
     );
+    assert.equal(details.v2.attentionNeeded.items[0]?.message.includes("Mar"), true);
+    assert.equal(details.v2.attentionNeeded.items[0]?.message.includes("$32.00"), true);
+    assert.equal(details.v2.attentionNeeded.items[0]?.message.includes("$12.00"), true);
+    assert.equal(details.v2.attentionNeeded.items[1]?.message.includes("Mar"), true);
+    assert.equal(details.v2.attentionNeeded.items[1]?.message.includes("$24.00"), true);
+    assert.equal(details.v2.attentionNeeded.items[1]?.message.includes("$8.00"), true);
     assert.equal(details.v2.paymentHistory.upcomingRenewal.projectedAmountCents, 3200);
     assert.equal(details.v2.attentionNeeded.ruleOutcomes.find((outcome) => outcome.code === "higher_price_renewal")?.status, "matched");
+  });
+
+  test("surfaces persisted review state in lifecycle metadata when supplied", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "reviewed-subscription",
+        name: "Video Suite",
+        markedForReview: true,
+      }),
+    );
+
+    assert.equal(details.v2.lifecycle.state, "ready");
+    assert.equal(details.v2.lifecycle.reviewState.isMarked, true);
+    assert.equal(details.v2.lifecycle.reviewState.canPersist, true);
+    assert.equal(details.v2.lifecycle.reviewState.unavailableReason, null);
   });
 });

--- a/tests/subscription-details/subscription-details-modal.test.tsx
+++ b/tests/subscription-details/subscription-details-modal.test.tsx
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import SubscriptionDetailsModal from "../../app/components/SubscriptionDetailsModal";
+import { buildSubscriptionDetails, type SubscriptionDetailsSourceRecord } from "../../lib/subscription-details";
+
+function makeRecord(
+  overrides: Partial<SubscriptionDetailsSourceRecord> & Pick<SubscriptionDetailsSourceRecord, "id" | "name">,
+): SubscriptionDetailsSourceRecord {
+  const { id, name, ...rest } = overrides;
+
+  return {
+    id,
+    name,
+    paymentMethod: "Visa 4242",
+    signedUpBy: "Alex",
+    billingConsoleUrl: "https://example.com/manage",
+    cancelSubscriptionUrl: "https://example.com/cancel",
+    billingHistoryUrl: "https://example.com/history",
+    notesMarkdown: "Primary workspace subscription.",
+    amountCents: 2000,
+    currency: "USD",
+    billingInterval: "MONTHLY",
+    nextBillingDate: new Date("2026-03-20T12:00:00.000Z"),
+    isActive: true,
+    createdAt: new Date("2026-01-10T08:00:00.000Z"),
+    updatedAt: new Date("2026-03-10T09:30:00.000Z"),
+    ...rest,
+  };
+}
+
+function renderModalHtml(record: SubscriptionDetailsSourceRecord): string {
+  const details = buildSubscriptionDetails(record, {
+    now: new Date("2026-03-11T00:00:00.000Z"),
+  });
+
+  return renderToStaticMarkup(
+    <SubscriptionDetailsModal
+      deactivateAction={null}
+      details={details}
+      errorMessage={null}
+      isOpen
+      loadState="ready"
+      onClose={() => undefined}
+      onEditSubscription={null}
+      onViewFullHistoryClick={() => undefined}
+      source="subscriptions_list"
+    />,
+  );
+}
+
+describe("SubscriptionDetailsModal attention panel", () => {
+  test("renders alert items with review-state copy", () => {
+    const html = renderModalHtml(
+      makeRecord({
+        id: "reviewed-price-rise",
+        name: "AI Workspace",
+        nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
+        projectedNextChargeAmountCents: 3200,
+        lastChargedAmountCents: 2400,
+        markedForReview: true,
+      }),
+    );
+
+    assert.match(html, /Attention Needed/);
+    assert.match(html, /Marked for review/);
+    assert.match(html, /Price increase imminent/);
+    assert.match(html, /Renewal higher than last charge/);
+    assert.match(html, /Projected increase: \$12\.00 over the current price/);
+  });
+
+  test("renders an empty state when no alerts are active", () => {
+    const html = renderModalHtml(
+      makeRecord({
+        id: "steady-plan",
+        name: "Back Office Suite",
+        createdAt: new Date("2025-10-10T08:00:00.000Z"),
+      }),
+    );
+
+    assert.match(html, /Attention Needed/);
+    assert.match(html, /Not marked for review/);
+    assert.match(html, /No promo or price-change alerts are active for this subscription\./);
+  });
+});


### PR DESCRIPTION
Fixes #42

## Summary
- add an in-modal `Attention Needed` panel to the subscription details modal
- surface marked-for-review lifecycle state, empty-state handling, and partial-data guidance in the panel UI
- enrich deterministic alert copy with timing and price-impact context and cover the new behavior with tests

## Verification
- `npx tsx --test tests/subscription-details/*.test.ts tests/subscription-details/*.test.tsx`
- `npm run typecheck`