### PR TITLE
Implement issue #43 quick action bar and handlers

### DIFF
--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1233,12 +1233,15 @@ export default function DashboardSectionsClient({
       </div>
 
       <SubscriptionDetailsModal
+        actionMessage={detailsModal.actionMessage}
         details={detailsModal.details}
         errorMessage={detailsModal.errorMessage}
         isOpen={detailsModal.isOpen}
         loadState={detailsModal.fetchState}
         onClose={detailsModal.closeModal}
+        onRunMutationAction={detailsModal.runMutationAction}
         onViewFullHistoryClick={detailsModal.trackViewFullHistory}
+        pendingActionKey={detailsModal.pendingActionKey}
         source={detailsModal.source}
       />
     </>

--- a/app/api/subscriptions/[subscriptionId]/actions/route.ts
+++ b/app/api/subscriptions/[subscriptionId]/actions/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from "next/server";
 
 import { getCurrentUser } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { buildSubscriptionDetailsFromRecord, subscriptionDetailsRecordSelect } from "@/lib/subscription-details-data";
+import {
+  buildSubscriptionDetailsFromRecord,
+  findFirstSubscriptionDetailsRecord,
+  isReviewStateUnavailableError,
+  updateSubscriptionDetailsRecord,
+} from "@/lib/subscription-details-data";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -47,12 +52,9 @@ function isSameOriginRequest(request: Request): boolean {
 }
 
 async function getOwnedSubscriptionRecord(subscriptionId: string, userId: string) {
-  return db.subscription.findFirst({
-    where: {
-      id: subscriptionId,
-      userId,
-    },
-    select: subscriptionDetailsRecordSelect,
+  return findFirstSubscriptionDetailsRecord(db, {
+    id: subscriptionId,
+    userId,
   });
 }
 
@@ -113,11 +115,12 @@ export async function POST(request: Request, context: SubscriptionActionsRouteCo
     );
   }
 
-  const updatedSubscription = await db.subscription.update({
-    where: {
-      id: subscriptionId,
-    },
-    data:
+  let updatedSubscription;
+
+  try {
+    updatedSubscription = await updateSubscriptionDetailsRecord(
+      db,
+      subscriptionId,
       action === "mark_cancelled"
         ? {
             isActive: false,
@@ -125,8 +128,20 @@ export async function POST(request: Request, context: SubscriptionActionsRouteCo
         : {
             markedForReview: true,
           },
-    select: subscriptionDetailsRecordSelect,
-  });
+    );
+  } catch (error) {
+    if (action === "mark_for_review" && isReviewStateUnavailableError(error)) {
+      return NextResponse.json(
+        {
+          error: "Review-state persistence is unavailable until the latest database migration is applied.",
+          data: buildSubscriptionDetailsFromRecord(existingSubscription),
+        },
+        { status: 409 },
+      );
+    }
+
+    throw error;
+  }
 
   return NextResponse.json(
     {

--- a/app/api/subscriptions/[subscriptionId]/actions/route.ts
+++ b/app/api/subscriptions/[subscriptionId]/actions/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+
+import { getCurrentUser } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { buildSubscriptionDetailsFromRecord, subscriptionDetailsRecordSelect } from "@/lib/subscription-details-data";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type SubscriptionActionsRouteContext = {
+  params: {
+    subscriptionId: string;
+  };
+};
+
+type SubscriptionMutationAction = "mark_cancelled" | "mark_for_review";
+
+type SubscriptionActionRequestBody = {
+  action?: SubscriptionMutationAction;
+};
+
+function parseAction(value: unknown): SubscriptionMutationAction | null {
+  return value === "mark_cancelled" || value === "mark_for_review" ? value : null;
+}
+
+function isSameOriginRequest(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+
+  if (!origin) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  if (!host) {
+    return false;
+  }
+
+  const proto = request.headers.get("x-forwarded-proto") ?? (process.env.NODE_ENV === "development" ? "http" : "https");
+
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host.toLowerCase() === host.toLowerCase() && originUrl.protocol === `${proto}:`;
+  } catch {
+    return false;
+  }
+}
+
+async function getOwnedSubscriptionRecord(subscriptionId: string, userId: string) {
+  return db.subscription.findFirst({
+    where: {
+      id: subscriptionId,
+      userId,
+    },
+    select: subscriptionDetailsRecordSelect,
+  });
+}
+
+export async function POST(request: Request, context: SubscriptionActionsRouteContext) {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  if (!isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Invalid request origin." }, { status: 403 });
+  }
+
+  const subscriptionId = context.params.subscriptionId?.trim();
+
+  if (!subscriptionId) {
+    return NextResponse.json({ error: "Invalid subscription id." }, { status: 400 });
+  }
+
+  let body: SubscriptionActionRequestBody;
+
+  try {
+    body = (await request.json()) as SubscriptionActionRequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid action payload." }, { status: 400 });
+  }
+
+  const action = parseAction(body.action);
+
+  if (!action) {
+    return NextResponse.json({ error: "Unsupported subscription action." }, { status: 400 });
+  }
+
+  const existingSubscription = await getOwnedSubscriptionRecord(subscriptionId, user.id);
+
+  if (!existingSubscription) {
+    return NextResponse.json({ error: "Subscription not found." }, { status: 404 });
+  }
+
+  if (action === "mark_cancelled" && !existingSubscription.isActive) {
+    return NextResponse.json(
+      {
+        error: "Subscription is already inactive.",
+        data: buildSubscriptionDetailsFromRecord(existingSubscription),
+      },
+      { status: 409 },
+    );
+  }
+
+  if (action === "mark_for_review" && existingSubscription.markedForReview) {
+    return NextResponse.json(
+      {
+        error: "Subscription is already marked for review.",
+        data: buildSubscriptionDetailsFromRecord(existingSubscription),
+      },
+      { status: 409 },
+    );
+  }
+
+  const updatedSubscription = await db.subscription.update({
+    where: {
+      id: subscriptionId,
+    },
+    data:
+      action === "mark_cancelled"
+        ? {
+            isActive: false,
+          }
+        : {
+            markedForReview: true,
+          },
+    select: subscriptionDetailsRecordSelect,
+  });
+
+  return NextResponse.json(
+    {
+      action,
+      data: buildSubscriptionDetailsFromRecord(updatedSubscription),
+      fetchedAt: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/app/api/subscriptions/[subscriptionId]/details/route.ts
+++ b/app/api/subscriptions/[subscriptionId]/details/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { getCurrentUser } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { buildSubscriptionDetails } from "@/lib/subscription-details";
+import { buildSubscriptionDetailsFromRecord, subscriptionDetailsRecordSelect } from "@/lib/subscription-details-data";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,44 +32,14 @@ export async function GET(_request: Request, context: SubscriptionDetailsRouteCo
       id: subscriptionId,
       userId: user.id,
     },
-    select: {
-      id: true,
-      name: true,
-      paymentMethod: true,
-      signedUpBy: true,
-      billingConsoleUrl: true,
-      cancelSubscriptionUrl: true,
-      billingHistoryUrl: true,
-      notesMarkdown: true,
-      amountCents: true,
-      currency: true,
-      billingInterval: true,
-      nextBillingDate: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true,
-      user: {
-        select: {
-          settings: {
-            select: {
-              remindersEnabled: true,
-              reminderDaysBefore: true,
-            },
-          },
-        },
-      },
-    },
+    select: subscriptionDetailsRecordSelect,
   });
 
   if (!subscription) {
     return NextResponse.json({ error: "Subscription not found." }, { status: 404 });
   }
 
-  const data = buildSubscriptionDetails({
-    ...subscription,
-    remindersEnabled: subscription.user.settings?.remindersEnabled ?? true,
-    reminderDaysBefore: subscription.user.settings?.reminderDaysBefore ?? 3,
-  });
+  const data = buildSubscriptionDetailsFromRecord(subscription);
 
   return NextResponse.json(
     {

--- a/app/api/subscriptions/[subscriptionId]/details/route.ts
+++ b/app/api/subscriptions/[subscriptionId]/details/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { getCurrentUser } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { buildSubscriptionDetailsFromRecord, subscriptionDetailsRecordSelect } from "@/lib/subscription-details-data";
+import { buildSubscriptionDetailsFromRecord, findFirstSubscriptionDetailsRecord } from "@/lib/subscription-details-data";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,12 +27,9 @@ export async function GET(_request: Request, context: SubscriptionDetailsRouteCo
     return NextResponse.json({ error: "Invalid subscription id." }, { status: 400 });
   }
 
-  const subscription = await db.subscription.findFirst({
-    where: {
-      id: subscriptionId,
-      userId: user.id,
-    },
-    select: subscriptionDetailsRecordSelect,
+  const subscription = await findFirstSubscriptionDetailsRecord(db, {
+    id: subscriptionId,
+    userId: user.id,
   });
 
   if (!subscription) {

--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { PendingSubmitButton } from "@/app/components/PendingFormControls";
 import type {
   SubscriptionDetailsActionCapability,
   SubscriptionDetailsAlertItem,
@@ -16,16 +15,28 @@ import type {
   SubscriptionModalOpenSource,
 } from "@/lib/subscription-details";
 
+type SubscriptionDetailsMutationAction = Extract<
+  SubscriptionDetailsActionCapability["key"],
+  "mark_cancelled" | "mark_for_review"
+>;
+
+type SubscriptionDetailsModalActionMessage = {
+  type: "error" | "success";
+  text: string;
+};
+
 type SubscriptionDetailsModalProps = {
   isOpen: boolean;
   loadState: "idle" | "loading" | "ready" | "empty" | "error";
   details: SubscriptionDetailsContract | null;
   source: SubscriptionModalOpenSource | null;
   errorMessage: string | null;
+  actionMessage?: SubscriptionDetailsModalActionMessage | null;
+  pendingActionKey?: SubscriptionDetailsMutationAction | null;
   onClose: (reason: SubscriptionModalCloseReason) => void;
   onViewFullHistoryClick: () => void;
   onEditSubscription?: ((subscriptionId: string) => void) | null;
-  deactivateAction?: ((formData: FormData) => Promise<void>) | null;
+  onRunMutationAction?: ((actionKey: SubscriptionDetailsMutationAction) => Promise<boolean>) | null;
 };
 
 const FOCUSABLE_SELECTOR =
@@ -207,6 +218,18 @@ function formatAlertImpactCopy(item: SubscriptionDetailsAlertItem): string | nul
   return null;
 }
 
+function isExternalHref(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function pendingActionLabel(actionKey: SubscriptionDetailsMutationAction): string {
+  if (actionKey === "mark_cancelled") {
+    return "Marking...";
+  }
+
+  return "Saving...";
+}
+
 function getActionByKey(
   actions: SubscriptionDetailsActionCapability[],
   key: SubscriptionDetailsActionCapability["key"],
@@ -246,63 +269,18 @@ function resolveActionState(
   };
 }
 
-function ModalDeactivateButton({
-  subscriptionId,
-  label,
-  unavailableReason,
-  deactivateAction,
-}: {
-  subscriptionId: string;
-  label: string;
-  unavailableReason: string | null;
-  deactivateAction: ((formData: FormData) => Promise<void>) | null;
-}): JSX.Element {
-  if (!deactivateAction) {
-    return (
-      <button
-        className="button-danger button-small"
-        disabled
-        title={unavailableReason ?? "Cancellation controls are unavailable from this view."}
-        type="button"
-      >
-        {label}
-      </button>
-    );
-  }
-
-  return (
-    <form
-      action={deactivateAction}
-      className="details-action-form"
-      onSubmit={(event) => {
-        const confirmed = window.confirm("Mark this subscription as cancelled?");
-
-        if (!confirmed) {
-          event.preventDefault();
-        }
-      }}
-    >
-      <input name="subscriptionId" type="hidden" value={subscriptionId} />
-      <PendingSubmitButton
-        className="button-danger button-small"
-        disabled={Boolean(unavailableReason)}
-        idleLabel={label}
-        pendingLabel="Marking..."
-      />
-    </form>
-  );
-}
-
 export default function SubscriptionDetailsModal({
   isOpen,
   loadState,
   details,
   source,
   errorMessage,
+  actionMessage = null,
+  pendingActionKey = null,
   onClose,
   onViewFullHistoryClick,
   onEditSubscription = null,
-  deactivateAction = null,
+  onRunMutationAction = null,
 }: SubscriptionDetailsModalProps) {
   const panelRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -385,10 +363,11 @@ export default function SubscriptionDetailsModal({
     return historyAction.href;
   }, [historyAction]);
 
-  const historyIsExternal = historyHref.startsWith("http://") || historyHref.startsWith("https://");
+  const historyIsExternal = isExternalHref(historyHref);
   const notesPreview = getNotesPreview(details?.notesMarkdown ?? null);
   const headerChips = details ? details.v2.header.chips.filter((chip) => chip.key !== "category") : [];
   const attentionItems = details?.v2.attentionNeeded.items ?? [];
+  const quickActions = details?.v2.actionBar.quickActions ?? [];
   const reviewState = details?.v2.lifecycle.reviewState ?? null;
   const editAction = details ? getActionByKey(details.v2.actionBar.header, "edit_subscription") : null;
   const markCancelledAction = details ? getActionByKey(details.v2.actionBar.header, "mark_cancelled") : null;
@@ -402,12 +381,9 @@ export default function SubscriptionDetailsModal({
     editActionState.unavailableReason ??
     (onEditSubscription ? null : "Open this subscription from the subscriptions page to edit it.");
   const markCancelledUnavailableReason =
-    markCancelledActionState.unavailableReason ??
-    (deactivateAction ? null : "Open this subscription from the subscriptions page to update cancellation state.");
-  const lifecycleActionHint =
-    details && !onEditSubscription && !deactivateAction
-      ? "Manage edit and cancellation actions from the subscriptions page."
-      : null;
+    markCancelledActionState.unavailableReason ?? (onRunMutationAction ? null : "Cancellation controls are unavailable.");
+  const lifecycleActionHint = details && !onEditSubscription ? "Open this subscription from the subscriptions page to edit it." : null;
+  const isMutationPending = pendingActionKey !== null;
 
   async function handleCopySubscriptionId(): Promise<void> {
     if (!details) {
@@ -419,6 +395,48 @@ export default function SubscriptionDetailsModal({
       setCopyMessage("Subscription ID copied.");
     } catch {
       setCopyMessage("Could not copy subscription ID.");
+    }
+  }
+
+  async function handleActionClick(action: SubscriptionDetailsActionCapability): Promise<void> {
+    if (!details || action.availability === "disabled") {
+      return;
+    }
+
+    if (action.requiresConfirmation) {
+      const confirmed = window.confirm(action.confirmationLabel ?? `Continue with ${action.label.toLowerCase()}?`);
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    if (action.kind === "mutate") {
+      if (!onRunMutationAction || (action.key !== "mark_cancelled" && action.key !== "mark_for_review")) {
+        return;
+      }
+
+      await onRunMutationAction(action.key);
+      return;
+    }
+
+    if (action.kind === "navigate") {
+      if (!action.href) {
+        return;
+      }
+
+      if (isExternalHref(action.href)) {
+        window.open(action.href, "_blank", "noopener,noreferrer");
+        return;
+      }
+
+      onClose("close_button");
+      window.location.assign(action.href);
+      return;
+    }
+
+    if (action.key === "edit_subscription" && onEditSubscription) {
+      onEditSubscription(details.id);
     }
   }
 
@@ -490,7 +508,7 @@ export default function SubscriptionDetailsModal({
                 </div>
 
                 <div className="details-hero-actions">
-                  <div className="details-hero-action-row">
+                  <div aria-busy={isMutationPending} className="details-hero-action-row">
                     <button
                       className="button button-secondary button-small"
                       disabled={editActionState.disabled || !onEditSubscription}
@@ -505,12 +523,21 @@ export default function SubscriptionDetailsModal({
                       {editActionState.label}
                     </button>
 
-                    <ModalDeactivateButton
-                      deactivateAction={deactivateAction}
-                      label={markCancelledActionState.label}
-                      subscriptionId={details.id}
-                      unavailableReason={markCancelledUnavailableReason}
-                    />
+                    <button
+                      className="button-danger button-small"
+                      disabled={markCancelledActionState.disabled || !onRunMutationAction || isMutationPending}
+                      onClick={() => {
+                        if (markCancelledAction) {
+                          void handleActionClick(markCancelledAction);
+                        }
+                      }}
+                      title={markCancelledUnavailableReason ?? undefined}
+                      type="button"
+                    >
+                      {pendingActionKey === "mark_cancelled"
+                        ? pendingActionLabel("mark_cancelled")
+                        : markCancelledActionState.label}
+                    </button>
                   </div>
 
                   {lifecycleActionHint ? <p className="text-muted details-hero-actions-hint">{lifecycleActionHint}</p> : null}
@@ -616,6 +643,54 @@ export default function SubscriptionDetailsModal({
               {details.v2.attentionNeeded.state === "partial" ? (
                 <p className="text-muted details-card-caption">
                   Some pricing signals are still missing, so additional review items may appear when more billing history is captured.
+                </p>
+              ) : null}
+            </article>
+
+            <article className="surface details-section details-quick-actions-panel">
+              <div className="details-section-heading">
+                <div className="stack">
+                  <h3>Quick Actions</h3>
+                  <p className="text-muted details-card-caption">
+                    Open provider pages, tune reminder settings, or flag the subscription without leaving this modal.
+                  </p>
+                </div>
+              </div>
+
+              <div aria-busy={isMutationPending} className="details-quick-actions-grid" role="group" aria-label="Subscription quick actions">
+                {quickActions.map((action) => {
+                  const isMutationAction = action.key === "mark_cancelled" || action.key === "mark_for_review";
+                  const isPending = isMutationAction && pendingActionKey === action.key;
+                  const isDisabled =
+                    action.availability === "disabled" || (action.kind === "mutate" && (!onRunMutationAction || isMutationPending));
+                  const label =
+                    isPending && action.key === "mark_cancelled"
+                      ? pendingActionLabel("mark_cancelled")
+                      : isPending && action.key === "mark_for_review"
+                        ? pendingActionLabel("mark_for_review")
+                        : action.label;
+
+                  return (
+                    <button
+                      className="button button-secondary details-quick-action-button"
+                      disabled={isDisabled}
+                      key={action.key}
+                      onClick={() => void handleActionClick(action)}
+                      title={action.availability === "disabled" ? action.unavailableReason ?? undefined : undefined}
+                      type="button"
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {actionMessage ? (
+                <p
+                  aria-live="polite"
+                  className={actionMessage.type === "error" ? "status-error details-quick-actions-status" : "status-help details-quick-actions-status"}
+                >
+                  {actionMessage.text}
                 </p>
               ) : null}
             </article>

--- a/app/components/useSubscriptionDetailsModal.ts
+++ b/app/components/useSubscriptionDetailsModal.ts
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 
 import { trackTelemetryEvent } from "@/app/components/telemetry";
 import type {
+  SubscriptionDetailsActionCapability,
   SubscriptionDetailsContract,
   SubscriptionModalCloseReason,
   SubscriptionModalOpenSource,
@@ -11,6 +13,7 @@ import type {
 
 type DetailsResponsePayload = {
   data?: SubscriptionDetailsContract;
+  error?: string;
 };
 
 type ModalFetchState = "idle" | "loading" | "ready" | "empty" | "error";
@@ -20,13 +23,34 @@ type OpenModalArgs = {
   source: SubscriptionModalOpenSource;
 };
 
+type ModalActionMessage = {
+  type: "error" | "success";
+  text: string;
+};
+
+type SubscriptionDetailsMutationAction = Extract<
+  SubscriptionDetailsActionCapability["key"],
+  "mark_cancelled" | "mark_for_review"
+>;
+
+function actionSuccessMessage(actionKey: SubscriptionDetailsMutationAction): string {
+  if (actionKey === "mark_cancelled") {
+    return "Subscription marked as cancelled.";
+  }
+
+  return "Subscription marked for review.";
+}
+
 export function useSubscriptionDetailsModal() {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [source, setSource] = useState<SubscriptionModalOpenSource | null>(null);
   const [selectedSubscriptionId, setSelectedSubscriptionId] = useState<string | null>(null);
   const [fetchState, setFetchState] = useState<ModalFetchState>("idle");
   const [details, setDetails] = useState<SubscriptionDetailsContract | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [pendingActionKey, setPendingActionKey] = useState<SubscriptionDetailsMutationAction | null>(null);
+  const [actionMessage, setActionMessage] = useState<ModalActionMessage | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -42,6 +66,8 @@ export function useSubscriptionDetailsModal() {
     setFetchState("loading");
     setDetails(null);
     setErrorMessage(null);
+    setPendingActionKey(null);
+    setActionMessage(null);
 
     trackTelemetryEvent({
       eventName: "subscription_details_modal_open",
@@ -94,6 +120,8 @@ export function useSubscriptionDetailsModal() {
       abortRef.current?.abort();
       abortRef.current = null;
       setIsOpen(false);
+      setPendingActionKey(null);
+      setActionMessage(null);
 
       if (source && selectedSubscriptionId) {
         trackTelemetryEvent({
@@ -105,6 +133,60 @@ export function useSubscriptionDetailsModal() {
       }
     },
     [source, selectedSubscriptionId],
+  );
+
+  const runMutationAction = useCallback(
+    async (actionKey: SubscriptionDetailsMutationAction): Promise<boolean> => {
+      if (!selectedSubscriptionId) {
+        return false;
+      }
+
+      setPendingActionKey(actionKey);
+      setActionMessage(null);
+
+      try {
+        const response = await fetch(`/api/subscriptions/${encodeURIComponent(selectedSubscriptionId)}/actions`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            action: actionKey,
+          }),
+        });
+
+        const payload = (await response.json().catch(() => ({}))) as DetailsResponsePayload;
+
+        if (payload.data) {
+          setDetails(payload.data);
+          setFetchState("ready");
+        }
+
+        if (!response.ok) {
+          setActionMessage({
+            type: "error",
+            text: payload.error ?? "Could not update this subscription.",
+          });
+          return false;
+        }
+
+        setActionMessage({
+          type: "success",
+          text: actionSuccessMessage(actionKey),
+        });
+        router.refresh();
+        return true;
+      } catch (error) {
+        setActionMessage({
+          type: "error",
+          text: error instanceof Error ? error.message : "Could not update this subscription.",
+        });
+        return false;
+      } finally {
+        setPendingActionKey(null);
+      }
+    },
+    [router, selectedSubscriptionId],
   );
 
   const trackViewFullHistory = useCallback(() => {
@@ -126,6 +208,8 @@ export function useSubscriptionDetailsModal() {
   }, []);
 
   return {
+    actionMessage,
+    pendingActionKey,
     isOpen,
     source,
     fetchState,
@@ -133,6 +217,7 @@ export function useSubscriptionDetailsModal() {
     errorMessage,
     openModal,
     closeModal,
+    runMutationAction,
     trackViewFullHistory,
   };
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1685,6 +1685,10 @@ button:disabled,
   gap: 0.8rem;
 }
 
+.details-quick-actions-panel {
+  gap: 0.85rem;
+}
+
 .details-attention-review-note {
   margin: 0;
   padding: 0.75rem 0.9rem;
@@ -1724,6 +1728,20 @@ button:disabled,
 .details-attention-impact {
   font-size: 0.84rem;
   color: var(--text-muted);
+}
+
+.details-quick-actions-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.details-quick-action-button {
+  min-height: 2.75rem;
+}
+
+.details-quick-actions-status {
+  margin: 0;
 }
 
 .details-definition-list {
@@ -1864,6 +1882,10 @@ ul {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .details-quick-actions-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .dashboard-control-grid {
     grid-template-columns: 1fr;
     width: 100%;
@@ -1921,6 +1943,10 @@ ul {
   }
 
   .details-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .details-quick-actions-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/app/settings/SettingsClient.tsx
+++ b/app/settings/SettingsClient.tsx
@@ -140,7 +140,7 @@ export default function SettingsClient({
       ) : null}
 
       <section className="settings-list">
-        <article className="surface setting-item">
+        <article className="surface setting-item" id="reminders">
           <div className="setting-main">
             <h2>Display mode</h2>
             <p className="text-muted">{displayModeSummary}</p>

--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -471,7 +471,7 @@ export default function SubscriptionsClient({
       )}
 
       <SubscriptionDetailsModal
-        deactivateAction={deactivateAction}
+        actionMessage={detailsModal.actionMessage}
         details={detailsModal.details}
         errorMessage={detailsModal.errorMessage}
         isOpen={detailsModal.isOpen}
@@ -481,7 +481,9 @@ export default function SubscriptionsClient({
           detailsModal.closeModal("close_button");
           setEditingSubscriptionId(subscriptionId);
         }}
+        onRunMutationAction={detailsModal.runMutationAction}
         onViewFullHistoryClick={detailsModal.trackViewFullHistory}
+        pendingActionKey={detailsModal.pendingActionKey}
         source={detailsModal.source}
       />
 

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -1,5 +1,6 @@
 import { requireAuthenticatedUser } from "@/lib/auth";
 import { db } from "@/lib/db";
+import { subscriptionListRecordSelect } from "@/lib/subscription-details-data";
 
 import {
   createSubscriptionAction,
@@ -87,6 +88,7 @@ export default async function SubscriptionsPage({ searchParams }: SubscriptionsP
       where: {
         userId: user.id,
       },
+      select: subscriptionListRecordSelect,
       orderBy: [{ isActive: "desc" }, { nextBillingDate: "asc" }, { createdAt: "desc" }],
     }),
     db.subscription.findMany({

--- a/docs/SUBSCRIPTION_DETAILS_V2_CONTRACT.md
+++ b/docs/SUBSCRIPTION_DETAILS_V2_CONTRACT.md
@@ -85,9 +85,9 @@ Current policy:
 - `edit_subscription`: client-triggered, owner-write, no confirmation
 - `mark_cancelled`: mutating, owner-write, confirmation required
 - `open_management_page`: navigate-only, owner-read, requires a valid stored management URL
-- `change_alert`: currently disabled because alerts are only persisted at account level
-- `mark_for_review`: currently disabled because no review-state field exists yet
-- `cancel_soon`: navigate-only, owner-write, requires an active subscription plus a valid cancel URL
+- `change_alert`: navigate-only to account reminder settings because alert tuning remains account-level
+- `mark_for_review`: mutating, owner-write, enabled only for active subscriptions that are not already marked
+- `cancel_soon`: navigate-only, owner-write, requires confirmation plus an active subscription and valid cancel URL
 - `view_billing_history`: navigate-only, owner-read, requires a valid history URL
 
 ## Partial-data expectations

--- a/lib/subscription-details-data.ts
+++ b/lib/subscription-details-data.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from "@prisma/client";
+
+import { buildSubscriptionDetails, type SubscriptionDetailsContract } from "@/lib/subscription-details";
+
+export const subscriptionDetailsRecordSelect = {
+  id: true,
+  name: true,
+  paymentMethod: true,
+  signedUpBy: true,
+  billingConsoleUrl: true,
+  cancelSubscriptionUrl: true,
+  billingHistoryUrl: true,
+  notesMarkdown: true,
+  amountCents: true,
+  currency: true,
+  billingInterval: true,
+  nextBillingDate: true,
+  isActive: true,
+  markedForReview: true,
+  createdAt: true,
+  updatedAt: true,
+  user: {
+    select: {
+      settings: {
+        select: {
+          remindersEnabled: true,
+          reminderDaysBefore: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.SubscriptionSelect;
+
+export type SubscriptionDetailsDbRecord = Prisma.SubscriptionGetPayload<{
+  select: typeof subscriptionDetailsRecordSelect;
+}>;
+
+export function buildSubscriptionDetailsFromRecord(subscription: SubscriptionDetailsDbRecord): SubscriptionDetailsContract {
+  return buildSubscriptionDetails({
+    ...subscription,
+    remindersEnabled: subscription.user.settings?.remindersEnabled ?? true,
+    reminderDaysBefore: subscription.user.settings?.reminderDaysBefore ?? 3,
+  });
+}

--- a/lib/subscription-details-data.ts
+++ b/lib/subscription-details-data.ts
@@ -1,8 +1,8 @@
-import type { Prisma } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { buildSubscriptionDetails, type SubscriptionDetailsContract } from "@/lib/subscription-details";
 
-export const subscriptionDetailsRecordSelect = {
+export const subscriptionDetailsBaseRecordSelect = {
   id: true,
   name: true,
   paymentMethod: true,
@@ -16,7 +16,6 @@ export const subscriptionDetailsRecordSelect = {
   billingInterval: true,
   nextBillingDate: true,
   isActive: true,
-  markedForReview: true,
   createdAt: true,
   updatedAt: true,
   user: {
@@ -31,9 +30,128 @@ export const subscriptionDetailsRecordSelect = {
   },
 } satisfies Prisma.SubscriptionSelect;
 
+export const subscriptionDetailsRecordSelect = {
+  ...subscriptionDetailsBaseRecordSelect,
+  markedForReview: true,
+} satisfies Prisma.SubscriptionSelect;
+
 export type SubscriptionDetailsDbRecord = Prisma.SubscriptionGetPayload<{
-  select: typeof subscriptionDetailsRecordSelect;
+  select: typeof subscriptionDetailsBaseRecordSelect;
+}> & {
+  markedForReview?: boolean | null;
+};
+
+type SubscriptionDetailsRecordWhere = {
+  id?: string;
+  userId?: string;
+};
+
+function isMissingMarkedForReviewColumnError(error: unknown): boolean {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2022") {
+    return false;
+  }
+
+  return String(error.meta?.column ?? "") === "Subscription.markedForReview";
+}
+
+export function isReviewStateUnavailableError(error: unknown): boolean {
+  return error instanceof Error && error.name === "ReviewStateUnavailableError";
+}
+
+function createReviewStateUnavailableError(): Error {
+  const error = new Error("Review-state persistence is unavailable until the database migration is applied.");
+  error.name = "ReviewStateUnavailableError";
+  return error;
+}
+
+export async function findFirstSubscriptionDetailsRecord(
+  prisma: PrismaClient,
+  where: SubscriptionDetailsRecordWhere,
+): Promise<SubscriptionDetailsDbRecord | null> {
+  try {
+    return await prisma.subscription.findFirst({
+      where,
+      select: subscriptionDetailsRecordSelect,
+    });
+  } catch (error) {
+    if (!isMissingMarkedForReviewColumnError(error)) {
+      throw error;
+    }
+
+    return prisma.subscription.findFirst({
+      where,
+      select: subscriptionDetailsBaseRecordSelect,
+    });
+  }
+}
+
+export async function updateSubscriptionDetailsRecord(
+  prisma: PrismaClient,
+  subscriptionId: string,
+  data: Prisma.SubscriptionUpdateInput,
+): Promise<SubscriptionDetailsDbRecord> {
+  try {
+    return await prisma.subscription.update({
+      where: {
+        id: subscriptionId,
+      },
+      data,
+      select: subscriptionDetailsRecordSelect,
+    });
+  } catch (error) {
+    if (!isMissingMarkedForReviewColumnError(error)) {
+      throw error;
+    }
+
+    if ("markedForReview" in data) {
+      throw createReviewStateUnavailableError();
+    }
+
+    return prisma.subscription.update({
+      where: {
+        id: subscriptionId,
+      },
+      data,
+      select: subscriptionDetailsBaseRecordSelect,
+    });
+  }
+}
+
+export type SubscriptionListRecord = Prisma.SubscriptionGetPayload<{
+  select: {
+    id: true;
+    name: true;
+    paymentMethod: true;
+    signedUpBy: true;
+    billingConsoleUrl: true;
+    cancelSubscriptionUrl: true;
+    billingHistoryUrl: true;
+    notesMarkdown: true;
+    amountCents: true;
+    currency: true;
+    billingInterval: true;
+    nextBillingDate: true;
+    isActive: true;
+    createdAt: true;
+  };
 }>;
+
+export const subscriptionListRecordSelect = {
+  id: true,
+  name: true,
+  paymentMethod: true,
+  signedUpBy: true,
+  billingConsoleUrl: true,
+  cancelSubscriptionUrl: true,
+  billingHistoryUrl: true,
+  notesMarkdown: true,
+  amountCents: true,
+  currency: true,
+  billingInterval: true,
+  nextBillingDate: true,
+  isActive: true,
+  createdAt: true,
+} satisfies Prisma.SubscriptionSelect;
 
 export function buildSubscriptionDetailsFromRecord(subscription: SubscriptionDetailsDbRecord): SubscriptionDetailsContract {
   return buildSubscriptionDetails({

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -789,16 +789,16 @@ function buildActionBar(
       key: "change_alert",
       label: "Change alert",
       placement: "quick_actions",
-      kind: "client",
-      availability: "disabled",
-      unavailableReason: "Alert tuning is currently account-level only and has no per-subscription persistence.",
-      href: null,
+      kind: "navigate",
+      availability: "enabled",
+      unavailableReason: null,
+      href: "/settings#reminders",
       permission: "owner_write",
       requiresConfirmation: false,
       confirmationLabel: null,
       serverValidation: [
-        "Validate authenticated ownership before writing reminder preferences.",
-        "Validate reminder lead time as an integer between 0 and 30.",
+        "Require authenticated access to account settings before rendering reminder-management navigation.",
+        "Validate reminder lead time as an integer between 0 and 30 on the settings write path.",
       ],
     },
     {
@@ -806,15 +806,29 @@ function buildActionBar(
       label: "Mark for review",
       placement: "quick_actions",
       kind: "mutate",
-      availability: "disabled",
-      unavailableReason: "Review-state persistence is not implemented yet.",
+      availability:
+        record.markedForReview === undefined || record.markedForReview === null
+          ? "disabled"
+          : !record.isActive
+            ? "disabled"
+            : record.markedForReview
+              ? "disabled"
+              : "enabled",
+      unavailableReason:
+        record.markedForReview === undefined || record.markedForReview === null
+          ? "Review-state persistence is unavailable for this subscription."
+          : !record.isActive
+            ? "Inactive subscriptions do not need review triage."
+            : record.markedForReview
+              ? "Subscription is already marked for review."
+              : null,
       href: null,
       permission: "owner_write",
       requiresConfirmation: false,
       confirmationLabel: null,
       serverValidation: [
         "Validate authenticated ownership before writing review state.",
-        "Reject review-state writes until a dedicated persistence field exists.",
+        "Reject duplicate review-state writes when a subscription is already marked.",
       ],
     },
     {
@@ -831,8 +845,8 @@ function buildActionBar(
             : "Inactive subscriptions cannot start a new cancel flow.",
       href: record.isActive ? links.cancelSubscriptionUrl : null,
       permission: "owner_write",
-      requiresConfirmation: false,
-      confirmationLabel: null,
+      requiresConfirmation: true,
+      confirmationLabel: "Open the provider cancellation flow in a new tab?",
       serverValidation: [
         "Validate stored cancellation URLs as http/https before rendering navigation affordances.",
         "Require an active subscription before surfacing cancel-start flows.",

--- a/prisma/migrations/20260319093000_add_subscription_review_state/migration.sql
+++ b/prisma/migrations/20260319093000_add_subscription_review_state/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Subscription"
+ADD COLUMN "markedForReview" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Subscription {
   billingInterval       BillingInterval @default(MONTHLY)
   nextBillingDate       DateTime?
   isActive              Boolean         @default(true)
+  markedForReview       Boolean         @default(false)
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
   user                  User            @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/tests/subscription-details/build-subscription-details.test.ts
+++ b/tests/subscription-details/build-subscription-details.test.ts
@@ -86,6 +86,7 @@ describe("buildSubscriptionDetails", () => {
         name: "Streaming Trial Promo",
         amountCents: 1299,
         createdAt: new Date("2026-02-20T00:00:00.000Z"),
+        markedForReview: false,
         updatedAt: new Date("2026-03-01T00:00:00.000Z"),
         nextBillingDate: new Date("2026-03-14T00:00:00.000Z"),
       }),
@@ -100,7 +101,9 @@ describe("buildSubscriptionDetails", () => {
     assert.equal(details.v2.attentionNeeded.ruleOutcomes[0]?.status, "matched");
     assert.equal(details.v2.header.status.stage, "active");
     assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "open_management_page")?.availability, "enabled");
-    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "mark_for_review")?.availability, "disabled");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "change_alert")?.href, "/settings#reminders");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "mark_for_review")?.availability, "enabled");
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "cancel_soon")?.requiresConfirmation, true);
   });
 
   test("derives cancel-scheduled lifecycle and disables cancel actions for inactive subscriptions", () => {
@@ -170,5 +173,6 @@ describe("buildSubscriptionDetails", () => {
     assert.equal(details.v2.lifecycle.reviewState.isMarked, true);
     assert.equal(details.v2.lifecycle.reviewState.canPersist, true);
     assert.equal(details.v2.lifecycle.reviewState.unavailableReason, null);
+    assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "mark_for_review")?.availability, "disabled");
   });
 });

--- a/tests/subscription-details/subscription-details-modal.test.tsx
+++ b/tests/subscription-details/subscription-details-modal.test.tsx
@@ -38,7 +38,6 @@ function renderModalHtml(record: SubscriptionDetailsSourceRecord): string {
 
   return renderToStaticMarkup(
     <SubscriptionDetailsModal
-      deactivateAction={null}
       details={details}
       errorMessage={null}
       isOpen
@@ -69,6 +68,10 @@ describe("SubscriptionDetailsModal attention panel", () => {
     assert.match(html, /Price increase imminent/);
     assert.match(html, /Renewal higher than last charge/);
     assert.match(html, /Projected increase: \$12\.00 over the current price/);
+    assert.match(html, /Quick Actions/);
+    assert.match(html, /Open management page/);
+    assert.match(html, /Change alert/);
+    assert.match(html, /Cancel soon/);
   });
 
   test("renders an empty state when no alerts are active", () => {


### PR DESCRIPTION
## Summary
- add the subscription details quick action row beneath the attention panel
- wire modal-side action handling for management/settings navigation plus review/cancel mutations
- degrade safely when the `markedForReview` migration has not yet been applied so subscription pages and modal fetches do not crash

## Testing
- `npm run typecheck`
- `npx dotenv -e .env.local -- node --import tsx --test tests/subscription-details/*.test.ts tests/subscription-details/*.test.tsx`

Closes #43
Closes #82