### PR TITLE
Refactor dashboard overview currency header

### DIFF
--- a/app/DashboardCurrencyForm.tsx
+++ b/app/DashboardCurrencyForm.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { usePathname } from "next/navigation";
+import CurrencyFlag from "react-currency-flags";
+
 import { CURRENCY_OPTIONS } from "@/lib/currencies";
 
 type DashboardCurrencyFormProps = {
@@ -11,27 +14,33 @@ export default function DashboardCurrencyForm({
   defaultCurrency,
   updateCurrencyAction,
 }: DashboardCurrencyFormProps) {
+  const pathname = usePathname();
   const currencyOptions = CURRENCY_OPTIONS.includes(defaultCurrency as (typeof CURRENCY_OPTIONS)[number])
     ? CURRENCY_OPTIONS
     : [defaultCurrency, ...CURRENCY_OPTIONS];
 
   return (
     <form action={updateCurrencyAction} className="dashboard-currency-form">
+      <input name="returnTo" type="hidden" value={pathname || "/"} />
       <label className="form-field dashboard-currency-field">
-        Site currency
-        <select
-          name="defaultCurrency"
-          onChange={(event) => {
-            event.currentTarget.form?.requestSubmit();
-          }}
-          value={defaultCurrency}
-        >
-          {currencyOptions.map((currency) => (
-            <option key={currency} value={currency}>
-              {currency}
-            </option>
-          ))}
-        </select>
+        <span className="visually-hidden">Site currency</span>
+        <span className="dashboard-currency-control">
+          <CurrencyFlag currency={defaultCurrency} width={22} />
+          <select
+            aria-label="Site currency"
+            name="defaultCurrency"
+            onChange={(event) => {
+              event.currentTarget.form?.requestSubmit();
+            }}
+            value={defaultCurrency}
+          >
+            {currencyOptions.map((currency) => (
+              <option key={currency} value={currency}>
+                {currency}
+              </option>
+            ))}
+          </select>
+        </span>
       </label>
     </form>
   );

--- a/app/DashboardCurrencyForm.tsx
+++ b/app/DashboardCurrencyForm.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CURRENCY_OPTIONS } from "@/lib/currencies";
+
+type DashboardCurrencyFormProps = {
+  defaultCurrency: string;
+  updateCurrencyAction: (formData: FormData) => Promise<void>;
+};
+
+export default function DashboardCurrencyForm({
+  defaultCurrency,
+  updateCurrencyAction,
+}: DashboardCurrencyFormProps) {
+  const currencyOptions = CURRENCY_OPTIONS.includes(defaultCurrency as (typeof CURRENCY_OPTIONS)[number])
+    ? CURRENCY_OPTIONS
+    : [defaultCurrency, ...CURRENCY_OPTIONS];
+
+  return (
+    <form action={updateCurrencyAction} className="dashboard-currency-form">
+      <label className="form-field dashboard-currency-field">
+        Site currency
+        <select
+          name="defaultCurrency"
+          onChange={(event) => {
+            event.currentTarget.form?.requestSubmit();
+          }}
+          value={defaultCurrency}
+        >
+          {currencyOptions.map((currency) => (
+            <option key={currency} value={currency}>
+              {currency}
+            </option>
+          ))}
+        </select>
+      </label>
+    </form>
+  );
+}

--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -87,7 +87,7 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
     return () => {
       controller.abort();
     };
-  }, [refreshDashboard]);
+  }, [initialCurrency, refreshDashboard]);
 
   const renderState = getDashboardRenderState(requestState);
   const payload = requestState.data;

--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import DashboardSectionsClient from "@/app/DashboardSectionsClient";
 import type { DashboardPayload } from "@/lib/dashboard";
@@ -19,20 +19,6 @@ type DashboardApiResponse = {
 type DashboardDataClientProps = {
   initialCurrency?: string | null;
 };
-
-function buildAvailableCurrencies(payload: DashboardPayload): string[] {
-  return [
-    ...new Set([
-      ...payload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency),
-      ...payload.spendBreakdownByCategory.flatMap((entry) => entry.totalsByCurrency.map((total) => total.currency)),
-      ...payload.attentionNeeded.map((entry) => entry.currency).filter((value): value is string => value !== null),
-      ...payload.upcomingRenewals.map((entry) => entry.currency),
-      ...payload.topCostDrivers.map((entry) => entry.currency),
-      ...payload.potentialSavings.totalsByCurrency.map((entry) => entry.currency),
-      ...payload.potentialSavings.opportunities.map((entry) => entry.currency),
-    ]),
-  ];
-}
 
 async function loadDashboardPayload(signal?: AbortSignal): Promise<DashboardPayload> {
   const response = await fetch("/api/dashboard", {
@@ -106,14 +92,6 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
   const renderState = getDashboardRenderState(requestState);
   const payload = requestState.data;
 
-  const availableCurrencies = useMemo(() => {
-    if (!payload) {
-      return [];
-    }
-
-    return buildAvailableCurrencies(payload);
-  }, [payload]);
-
   return (
     <DashboardSectionsClient
       attentionNeeded={payload?.attentionNeeded.map((item) => ({
@@ -127,7 +105,7 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
         estimatedMonthlyImpactCents: item.estimatedMonthlyImpactCents,
         currency: item.currency,
       })) ?? []}
-      availableCurrencies={availableCurrencies}
+      currencyConversion={payload?.currencyConversion ?? null}
       initialCurrency={initialCurrency}
       kpis={payload?.kpis ?? null}
       loadErrorMessage={requestState.errorMessage}

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import Image from "next/image";
 import { useEffect, useId, useMemo, useState } from "react";
 
@@ -9,22 +8,14 @@ import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDet
 import type {
   DashboardAttentionSeverity,
   DashboardAttentionType,
+  DashboardCurrencyConversion,
   DashboardCurrencyTotal,
   DashboardKpis,
   DashboardMetricAmount,
   DashboardSavingsOpportunity,
   DashboardUpcomingRenewalTag,
 } from "@/lib/dashboard";
-import {
-  buildDashboardCurrencyOptions,
-  DASHBOARD_ALL_CURRENCIES,
-  DASHBOARD_DATE_RANGE_OPTIONS,
-  DEFAULT_DASHBOARD_DATE_RANGE,
-  mapDashboardSpendBreakdownByCurrency,
-  filterDashboardUpcomingRenewals,
-  resolveInitialDashboardCurrency,
-  type DashboardDateRangeValue,
-} from "@/lib/dashboard-controls";
+import { mapDashboardSpendBreakdownByCurrency } from "@/lib/dashboard-controls";
 import type { DashboardRenderState } from "@/lib/dashboard-view-state";
 
 type DashboardUpcomingChargeListItem = {
@@ -84,7 +75,6 @@ type DashboardPotentialSavingsData = {
 };
 
 type DashboardSectionsClientProps = {
-  availableCurrencies: string[];
   kpis?: DashboardKpis | null;
   attentionNeeded: DashboardAttentionListItem[];
   topCostDrivers: DashboardTopCostDriverListItem[];
@@ -103,6 +93,7 @@ type DashboardSectionsClientProps = {
     }>;
   }>;
   initialCurrency?: string | null;
+  currencyConversion?: DashboardCurrencyConversion | null;
   renderState?: DashboardRenderState;
   loadErrorMessage?: string | null;
   onRetryLoad?: () => void;
@@ -376,29 +367,11 @@ function attentionSeverityGlyph(severity: DashboardAttentionSeverity): string {
   return "i";
 }
 
-function isInDateRange(value: string | null, now: Date, rangeDays: number): boolean {
-  if (!value) {
-    return true;
-  }
-
-  const parsedDate = new Date(value);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return false;
-  }
-
-  const deltaMs = parsedDate.getTime() - now.getTime();
-  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
-
-  return deltaMs >= 0 && deltaMs <= maxMs;
-}
-
 function DashboardSkeletonLine({ className = "" }: { className?: string }) {
   return <span aria-hidden="true" className={`dashboard-skeleton-line ${className}`.trim()} />;
 }
 
 export default function DashboardSectionsClient({
-  availableCurrencies,
   kpis,
   attentionNeeded,
   topCostDrivers,
@@ -407,6 +380,7 @@ export default function DashboardSectionsClient({
   monthlySpendTotalsByCurrency,
   spendBreakdownByCategory,
   initialCurrency,
+  currencyConversion,
   renderState,
   loadErrorMessage,
   onRetryLoad,
@@ -417,32 +391,12 @@ export default function DashboardSectionsClient({
   const resolvedRenderState = renderState ?? (kpis ? "populated" : "loading");
   const isLoading = resolvedRenderState === "loading";
   const isError = resolvedRenderState === "error";
-  const controlsDisabled = isLoading;
-  const [currency, setCurrency] = useState<string>(() => resolveInitialDashboardCurrency(initialCurrency));
-  const [dateRange, setDateRange] = useState<DashboardDateRangeValue>(DEFAULT_DASHBOARD_DATE_RANGE);
-  const [searchQuery, setSearchQuery] = useState("");
   const [showAllUpcomingRenewals, setShowAllUpcomingRenewals] = useState(false);
-  const now = useMemo(() => new Date(), []);
-  const dateRangeDays = useMemo(() => {
-    return DASHBOARD_DATE_RANGE_OPTIONS.find((option) => option.value === dateRange)?.days ?? 30;
-  }, [dateRange]);
-
-  const filteredUpcomingCharges = useMemo(
-    () =>
-      filterDashboardUpcomingRenewals(
-        upcomingCharges,
-        {
-          currency,
-          dateRange,
-          searchQuery,
-        },
-        now,
-      ),
-    [currency, dateRange, now, searchQuery, upcomingCharges],
-  );
+  const reportingCurrency = currencyConversion?.targetCurrency ?? kpis?.monthlyEquivalentSpend.currency ?? initialCurrency ?? "USD";
+  const filteredUpcomingCharges = upcomingCharges;
   useEffect(() => {
     setShowAllUpcomingRenewals(false);
-  }, [currency, dateRange, searchQuery]);
+  }, [upcomingCharges]);
   const visibleUpcomingCharges = useMemo(() => {
     if (showAllUpcomingRenewals) {
       return filteredUpcomingCharges;
@@ -452,72 +406,9 @@ export default function DashboardSectionsClient({
   }, [filteredUpcomingCharges, showAllUpcomingRenewals]);
   const hasClippedUpcomingRenewals = filteredUpcomingCharges.length > UPCOMING_RENEWALS_VISIBLE_ROWS;
   const hiddenUpcomingRenewalsCount = Math.max(filteredUpcomingCharges.length - visibleUpcomingCharges.length, 0);
-  const filteredAttentionNeeded = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    const selectedCurrency = currency.toUpperCase();
-
-    return attentionNeeded.filter((alert) => {
-      if (
-        currency !== DASHBOARD_ALL_CURRENCIES &&
-        alert.currency !== null &&
-        alert.currency.toUpperCase() !== selectedCurrency
-      ) {
-        return false;
-      }
-
-      if (!isInDateRange(alert.dueDate, now, dateRangeDays)) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      return [alert.title, alert.message, alert.currency ?? "", alert.type].some((value) =>
-        value.toLowerCase().includes(normalizedQuery),
-      );
-    });
-  }, [attentionNeeded, currency, dateRangeDays, now, searchQuery]);
-  const filteredTopCostDrivers = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    const selectedCurrency = currency.toUpperCase();
-
-    return topCostDrivers.filter((driver) => {
-      if (currency !== DASHBOARD_ALL_CURRENCIES && driver.currency.toUpperCase() !== selectedCurrency) {
-        return false;
-      }
-
-      if (!isInDateRange(driver.nextBillingDate, now, dateRangeDays)) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      return [driver.name, driver.currency, driver.billingInterval].some((value) =>
-        value.toLowerCase().includes(normalizedQuery),
-      );
-    });
-  }, [currency, dateRangeDays, now, searchQuery, topCostDrivers]);
-  const filteredSavingsOpportunities = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    const selectedCurrency = currency.toUpperCase();
-
-    return potentialSavings.opportunities.filter((opportunity) => {
-      if (currency !== DASHBOARD_ALL_CURRENCIES && opportunity.currency.toUpperCase() !== selectedCurrency) {
-        return false;
-      }
-
-      if (!normalizedQuery) {
-        return true;
-      }
-
-      return [opportunity.title, opportunity.description, opportunity.currency, opportunity.type].some((value) =>
-        value.toLowerCase().includes(normalizedQuery),
-      );
-    });
-  }, [currency, potentialSavings.opportunities, searchQuery]);
+  const filteredAttentionNeeded = attentionNeeded;
+  const filteredTopCostDrivers = topCostDrivers;
+  const filteredSavingsOpportunities = potentialSavings.opportunities;
   const filteredSavingsTotalsByCurrency = useMemo(() => {
     const totalsMap = new Map<string, number>();
 
@@ -544,7 +435,7 @@ export default function DashboardSectionsClient({
     if (filteredSavingsTotalsByCurrency.length === 0) {
       return {
         value: "No opportunities",
-        note: "No savings candidates match the current control filters.",
+        note: "No savings candidates currently qualify.",
       };
     }
 
@@ -562,10 +453,6 @@ export default function DashboardSectionsClient({
       note: formatSavingsCurrencyTotalsSummary(filteredSavingsTotalsByCurrency),
     };
   }, [filteredSavingsOpportunities.length, filteredSavingsTotalsByCurrency]);
-  const topCostDriverCurrencyCount = useMemo(() => {
-    return new Set(filteredTopCostDrivers.map((driver) => driver.currency.toUpperCase())).size;
-  }, [filteredTopCostDrivers]);
-  const currencyOptions = useMemo(() => buildDashboardCurrencyOptions(availableCurrencies, currency), [availableCurrencies, currency]);
   const monthlyEquivalentSpend = buildSpendMetricContent(kpis?.monthlyEquivalentSpend, "monthly");
   const annualProjection = buildSpendMetricContent(kpis?.annualProjection, "annual");
   const renewalsInNextSevenDays: KpiCardContent = !kpis
@@ -596,20 +483,14 @@ export default function DashboardSectionsClient({
           value: `${formatCountLabel(kpis.subscriptions.active, "active", "active")}`,
           note: `${formatCountLabel(kpis.subscriptions.canceled, "canceled", "canceled")} · ${kpis.subscriptions.total} total`,
         };
-  const spendBreakdownCurrency = useMemo(() => {
-    if (currency !== DASHBOARD_ALL_CURRENCIES) {
-      return currency.toUpperCase();
-    }
-
-    return monthlySpendTotalsByCurrency.length === 1 ? monthlySpendTotalsByCurrency[0].currency : null;
-  }, [currency, monthlySpendTotalsByCurrency]);
+  const spendBreakdownCurrency = monthlySpendTotalsByCurrency.length > 0 ? reportingCurrency : null;
   const spendBreakdownRows = useMemo(() => {
     if (!spendBreakdownCurrency) {
       return [];
     }
 
-    return mapDashboardSpendBreakdownByCurrency(spendBreakdownByCategory, spendBreakdownCurrency, searchQuery);
-  }, [searchQuery, spendBreakdownByCategory, spendBreakdownCurrency]);
+    return mapDashboardSpendBreakdownByCurrency(spendBreakdownByCategory, spendBreakdownCurrency, "");
+  }, [spendBreakdownByCategory, spendBreakdownCurrency]);
   const spendBreakdownTotalCents = useMemo(() => {
     return spendBreakdownRows.reduce((total, row) => total + row.monthlyEquivalentSpendCents, 0);
   }, [spendBreakdownRows]);
@@ -671,58 +552,6 @@ export default function DashboardSectionsClient({
               : "Dashboard content loaded."}
         </span>
 
-        <article aria-label="Dashboard filters and actions" className="dashboard-card dashboard-controls-shell">
-          <div className="dashboard-control-grid">
-            <label className="form-field" htmlFor="dashboard-currency-select">
-              Currency
-              <select
-                disabled={controlsDisabled}
-                id="dashboard-currency-select"
-                onChange={(event) => setCurrency(event.target.value)}
-                value={currency}
-              >
-                <option value={DASHBOARD_ALL_CURRENCIES}>All currencies</option>
-                {currencyOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="form-field" htmlFor="dashboard-date-range-select">
-              Date range
-              <select
-                disabled={controlsDisabled}
-                id="dashboard-date-range-select"
-                onChange={(event) => setDateRange(event.target.value as DashboardDateRangeValue)}
-                value={dateRange}
-              >
-                {DASHBOARD_DATE_RANGE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="form-field dashboard-search-control" htmlFor="dashboard-search-input">
-              Search
-              <input
-                disabled={controlsDisabled}
-                id="dashboard-search-input"
-                onChange={(event) => setSearchQuery(event.target.value)}
-                placeholder="Search name, payment method, or currency..."
-                type="search"
-                value={searchQuery}
-              />
-            </label>
-          </div>
-          <div className="dashboard-control-actions">
-            <Link aria-disabled={controlsDisabled} className="button" href="/subscriptions" tabIndex={controlsDisabled ? -1 : undefined}>
-              Add Subscription
-            </Link>
-          </div>
-        </article>
-
         {isError ? (
           <div className="notice-error dashboard-error-banner" role="alert">
             <span>{loadErrorMessage ?? "Unable to load dashboard data. Please try again."}</span>
@@ -732,6 +561,12 @@ export default function DashboardSectionsClient({
               </button>
             ) : null}
           </div>
+        ) : null}
+        {!isLoading && currencyConversion && currencyConversion.missingRates.length > 0 ? (
+          <p className="status-help" role="status">
+            Some source currencies could not be converted to {currencyConversion.targetCurrency}:{" "}
+            {currencyConversion.missingRates.join(", ")}.
+          </p>
         ) : null}
 
         <section className="dashboard-grid">
@@ -783,7 +618,7 @@ export default function DashboardSectionsClient({
                   ? "Loading categories..."
                   : spendBreakdownCurrency
                     ? `${spendBreakdownRows.length} categories`
-                    : "Select a currency"}
+                    : `No ${reportingCurrency} data`}
               </span>
             </div>
             {isLoading ? (
@@ -808,11 +643,9 @@ export default function DashboardSectionsClient({
                 </ul>
               </div>
             ) : !spendBreakdownCurrency ? (
-              <p className="text-muted">
-                Choose a specific currency to compare category spend when your dashboard contains multiple currencies.
-              </p>
+              <p className="text-muted">No categorized spend is available in {reportingCurrency}.</p>
             ) : spendBreakdownRows.length === 0 || spendBreakdownTotalCents <= 0 ? (
-              <p className="text-muted">No categorized spend exists for the current filters.</p>
+              <p className="text-muted">No categorized spend exists yet.</p>
             ) : (
               <div className="spend-breakdown-layout">
                 <figure className="spend-donut-figure">
@@ -872,7 +705,7 @@ export default function DashboardSectionsClient({
               </div>
             )}
             {!isLoading && spendBreakdownCurrency && spendBreakdownRows.length === 1 ? (
-              <p className="text-muted">Only one category currently contributes spend for these filters.</p>
+              <p className="text-muted">Only one category currently contributes spend.</p>
             ) : null}
             {!isLoading && spendBreakdownCurrency && !spendBreakdownReconciled ? (
               <p className="text-muted" role="status">
@@ -885,7 +718,7 @@ export default function DashboardSectionsClient({
             <div className="dashboard-card-header">
               <h2>Attention Needed</h2>
               <span className="metric-note">
-                {isLoading ? "Loading alerts..." : `${filteredAttentionNeeded.length} matching alerts`}
+                {isLoading ? "Loading alerts..." : `${filteredAttentionNeeded.length} alerts`}
               </span>
             </div>
             {isLoading ? (
@@ -903,7 +736,7 @@ export default function DashboardSectionsClient({
                 ))}
               </div>
             ) : filteredAttentionNeeded.length === 0 ? (
-              <p className="text-muted">No attention alerts match the current control filters.</p>
+              <p className="text-muted">No attention alerts right now.</p>
             ) : (
               <div className="attention-list">
                 {filteredAttentionNeeded.map((alert) => {
@@ -956,7 +789,7 @@ export default function DashboardSectionsClient({
               <span className="metric-note">
                 {isLoading
                   ? "Loading renewals..."
-                  : `${filteredUpcomingCharges.length} matching rows, sorted by soonest date`}
+                  : `${filteredUpcomingCharges.length} renewals, sorted by soonest date`}
               </span>
             </div>
             {isLoading ? (
@@ -989,7 +822,7 @@ export default function DashboardSectionsClient({
                 </div>
               </div>
             ) : filteredUpcomingCharges.length === 0 ? (
-              <p className="text-muted">No upcoming renewals match the current control filters.</p>
+              <p className="text-muted">No upcoming renewals in the current summary window.</p>
             ) : (
               <div className="upcoming-renewals-table-shell">
                 <p className="text-muted" role="status">
@@ -1094,7 +927,7 @@ export default function DashboardSectionsClient({
             <div className="dashboard-card-header">
               <h2>Potential Savings</h2>
               <span className="metric-note">
-                {isLoading ? "Loading opportunities..." : `${filteredSavingsOpportunities.length} matching opportunities`}
+                {isLoading ? "Loading opportunities..." : `${filteredSavingsOpportunities.length} opportunities`}
               </span>
             </div>
             {isLoading ? (
@@ -1122,7 +955,7 @@ export default function DashboardSectionsClient({
                   <span className="metric-note">{potentialSavingsSummary.note}</span>
                 </article>
                 {filteredSavingsOpportunities.length === 0 ? (
-                  <p className="text-muted mt-sm">No savings opportunities match the current control filters.</p>
+                  <p className="text-muted mt-sm">No savings opportunities currently qualify.</p>
                 ) : (
                   <ul className="savings-opportunity-list">
                     {filteredSavingsOpportunities.map((opportunity) => {
@@ -1173,7 +1006,7 @@ export default function DashboardSectionsClient({
             <div className="dashboard-card-header">
               <h2>Top Cost Drivers</h2>
               <span className="metric-note">
-                {isLoading ? "Loading drivers..." : `${filteredTopCostDrivers.length} matching rows`}
+                {isLoading ? "Loading drivers..." : `${filteredTopCostDrivers.length} drivers`}
               </span>
             </div>
             {isLoading ? (
@@ -1189,7 +1022,7 @@ export default function DashboardSectionsClient({
                 ))}
               </ol>
             ) : filteredTopCostDrivers.length === 0 ? (
-              <p className="text-muted">No cost drivers match the current control filters.</p>
+              <p className="text-muted">No cost drivers are available yet.</p>
             ) : (
               <ol className="cost-driver-list">
                 {filteredTopCostDrivers.map((driver, index) => (
@@ -1224,9 +1057,7 @@ export default function DashboardSectionsClient({
                 ))}
               </ol>
             )}
-            {!isLoading && topCostDriverCurrencyCount > 1 ? (
-              <p className="text-muted mt-sm">Ranking is normalized to monthly amounts without FX conversion.</p>
-            ) : null}
+            {!isLoading ? <p className="text-muted mt-sm">Ranking is normalized to monthly amounts in {reportingCurrency}.</p> : null}
           </article>
         </section>
 

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -7,6 +7,16 @@ import { requireAuthenticatedUser } from "@/lib/auth";
 import { normalizeCurrencyCode } from "@/lib/currencies";
 import { db } from "@/lib/db";
 
+function resolveReturnPath(value: FormDataEntryValue | null): string {
+  const path = String(value ?? "").trim();
+
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    return "/";
+  }
+
+  return path;
+}
+
 async function isSameOriginRequest(): Promise<boolean> {
   const headerStore = await headers();
   const origin = headerStore.get("origin");
@@ -34,15 +44,16 @@ async function isSameOriginRequest(): Promise<boolean> {
 
 export async function updateDashboardCurrencyAction(formData: FormData): Promise<void> {
   const user = await requireAuthenticatedUser();
+  const returnTo = resolveReturnPath(formData.get("returnTo"));
 
   if (!(await isSameOriginRequest())) {
-    redirect("/?error=invalid_request");
+    redirect(`${returnTo}?error=invalid_request`);
   }
 
   const defaultCurrency = normalizeCurrencyCode(String(formData.get("defaultCurrency") ?? ""));
 
   if (!defaultCurrency) {
-    redirect("/?error=invalid_currency");
+    redirect(`${returnTo}?error=invalid_currency`);
   }
 
   await db.userSettings.upsert({
@@ -58,5 +69,5 @@ export async function updateDashboardCurrencyAction(formData: FormData): Promise
     },
   });
 
-  redirect("/");
+  redirect(returnTo);
 }

--- a/app/dashboard/actions.ts
+++ b/app/dashboard/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { requireAuthenticatedUser } from "@/lib/auth";
+import { normalizeCurrencyCode } from "@/lib/currencies";
+import { db } from "@/lib/db";
+
+async function isSameOriginRequest(): Promise<boolean> {
+  const headerStore = await headers();
+  const origin = headerStore.get("origin");
+  const host = headerStore.get("x-forwarded-host") ?? headerStore.get("host");
+
+  if (!origin) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  if (!host) {
+    return false;
+  }
+
+  const proto =
+    headerStore.get("x-forwarded-proto") ??
+    (process.env.NODE_ENV === "development" ? "http" : "https");
+
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host.toLowerCase() === host.toLowerCase() && originUrl.protocol === `${proto}:`;
+  } catch {
+    return false;
+  }
+}
+
+export async function updateDashboardCurrencyAction(formData: FormData): Promise<void> {
+  const user = await requireAuthenticatedUser();
+
+  if (!(await isSameOriginRequest())) {
+    redirect("/?error=invalid_request");
+  }
+
+  const defaultCurrency = normalizeCurrencyCode(String(formData.get("defaultCurrency") ?? ""));
+
+  if (!defaultCurrency) {
+    redirect("/?error=invalid_currency");
+  }
+
+  await db.userSettings.upsert({
+    where: {
+      userId: user.id,
+    },
+    create: {
+      userId: user.id,
+      defaultCurrency,
+    },
+    update: {
+      defaultCurrency,
+    },
+  });
+
+  redirect("/");
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -373,11 +373,43 @@ a {
 }
 
 .dashboard-currency-form {
-  min-width: 8rem;
+  min-width: 7.25rem;
 }
 
 .dashboard-currency-field {
-  gap: 0.25rem;
+  display: block;
+}
+
+.dashboard-currency-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--input-bg);
+  padding: 0.22rem 0.32rem 0.22rem 0.5rem;
+}
+
+.dashboard-currency-control > span {
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px var(--border);
+  flex: 0 0 auto;
+}
+
+.form-field .dashboard-currency-control select {
+  width: auto;
+  min-width: 4.4rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  padding: 0.28rem 1.4rem 0.28rem 0.1rem;
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.form-field .dashboard-currency-control select:focus {
+  box-shadow: none;
 }
 
 .dashboard-card-header {
@@ -1881,8 +1913,7 @@ ul {
     width: 100%;
   }
 
-  .dashboard-header-actions .button,
-  .dashboard-currency-form {
+  .dashboard-header-actions .button {
     width: 100%;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -365,28 +365,19 @@ a {
   min-height: 8.5rem;
 }
 
-.dashboard-controls-shell {
+.dashboard-header-actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   gap: 0.9rem;
 }
 
-.dashboard-control-grid {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  flex: 1;
-  min-width: 0;
+.dashboard-currency-form {
+  min-width: 8rem;
 }
 
-.dashboard-search-control {
-  min-width: min(320px, 100%);
-}
-
-.dashboard-control-actions {
-  display: inline-flex;
-  align-items: center;
+.dashboard-currency-field {
+  gap: 0.25rem;
 }
 
 .dashboard-card-header {
@@ -1886,16 +1877,12 @@ ul {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .dashboard-control-grid {
-    grid-template-columns: 1fr;
+  .dashboard-header-actions {
     width: 100%;
   }
 
-  .dashboard-control-actions {
-    width: 100%;
-  }
-
-  .dashboard-control-actions .button {
+  .dashboard-header-actions .button,
+  .dashboard-currency-form {
     width: 100%;
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,10 @@ import "easymde/dist/easymde.min.css";
 
 import { signOutAction } from "@/app/auth/actions";
 import { PendingSubmitButton } from "@/app/components/PendingFormControls";
+import DashboardCurrencyForm from "@/app/DashboardCurrencyForm";
+import { updateDashboardCurrencyAction } from "@/app/dashboard/actions";
 import { getCurrentUser } from "@/lib/auth";
+import { resolvePreferredCurrency } from "@/lib/currencies";
 import { db } from "@/lib/db";
 
 import "./globals.css";
@@ -40,6 +43,7 @@ export default async function RootLayout({
 }>) {
   const user = await getCurrentUser();
   let displayMode: DisplayMode = "DEVICE";
+  let defaultCurrency = "USD";
 
   if (user) {
     const settings = await db.userSettings.findUnique({
@@ -48,10 +52,12 @@ export default async function RootLayout({
       },
       select: {
         displayMode: true,
+        defaultCurrency: true,
       },
     });
 
     displayMode = settings?.displayMode ?? "DEVICE";
+    defaultCurrency = resolvePreferredCurrency(settings?.defaultCurrency);
   }
 
   const htmlTheme = displayMode === "DEVICE" ? undefined : displayMode.toLowerCase();
@@ -100,6 +106,10 @@ export default async function RootLayout({
               </nav>
               {user ? (
                 <div className="nav-auth">
+                  <DashboardCurrencyForm
+                    defaultCurrency={defaultCurrency}
+                    updateCurrencyAction={updateDashboardCurrencyAction}
+                  />
                   <span className="nav-user">{user.email}</span>
                   <form action={signOutAction}>
                     <PendingSubmitButton

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
 
-import DashboardCurrencyForm from "@/app/DashboardCurrencyForm";
 import DashboardDataClient from "@/app/DashboardDataClient";
-import { updateDashboardCurrencyAction } from "@/app/dashboard/actions";
 import { getCurrentUser } from "@/lib/auth";
 import { resolvePreferredCurrency } from "@/lib/currencies";
 import { db } from "@/lib/db";
@@ -73,10 +71,6 @@ export default async function DashboardPage() {
           </p>
         </div>
         <div className="inline-actions dashboard-header-actions">
-          <DashboardCurrencyForm
-            defaultCurrency={defaultCurrency}
-            updateCurrencyAction={updateDashboardCurrencyAction}
-          />
           <Link className="button" href="/subscriptions">
             Add Subscription
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 
+import DashboardCurrencyForm from "@/app/DashboardCurrencyForm";
 import DashboardDataClient from "@/app/DashboardDataClient";
+import { updateDashboardCurrencyAction } from "@/app/dashboard/actions";
 import { getCurrentUser } from "@/lib/auth";
+import { resolvePreferredCurrency } from "@/lib/currencies";
 import { db } from "@/lib/db";
 
 export default async function DashboardPage() {
@@ -57,6 +60,8 @@ export default async function DashboardPage() {
     },
   });
 
+  const defaultCurrency = resolvePreferredCurrency(settings?.defaultCurrency);
+
   return (
     <section className="page-stack">
       <header className="page-header">
@@ -64,12 +69,21 @@ export default async function DashboardPage() {
           <p className="eyebrow">Dashboard</p>
           <h1>Subscription overview</h1>
           <p className="page-lead">
-            Signed in as {user.email}. Use the control bar to scope dashboard sections by currency, date range, and search.
+            Signed in as {user.email}. Overview totals and comparisons use your site currency.
           </p>
+        </div>
+        <div className="inline-actions dashboard-header-actions">
+          <DashboardCurrencyForm
+            defaultCurrency={defaultCurrency}
+            updateCurrencyAction={updateDashboardCurrencyAction}
+          />
+          <Link className="button" href="/subscriptions">
+            Add Subscription
+          </Link>
         </div>
       </header>
 
-      <DashboardDataClient initialCurrency={settings?.defaultCurrency ?? null} />
+      <DashboardDataClient initialCurrency={defaultCurrency} />
     </section>
   );
 }

--- a/app/settings/SettingsClient.tsx
+++ b/app/settings/SettingsClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { DisplayMode } from "@prisma/client";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
+import { CURRENCY_OPTIONS } from "@/lib/currencies";
 
 type ResultMessage = {
   type: "error" | "success";
@@ -24,7 +25,6 @@ type SettingsClientProps = {
   updateAccountDetailsAction: (formData: FormData) => Promise<void>;
 };
 
-const CURRENCY_OPTIONS = ["USD", "EUR", "GBP", "JPY", "CAD", "AUD"];
 const DISPLAY_MODE_OPTIONS: Array<{ value: DisplayMode; label: string }> = [
   { value: "DEVICE", label: "Device" },
   { value: "LIGHT", label: "Light" },
@@ -53,7 +53,7 @@ export default function SettingsClient({
   const [reminderDaysBefore, setReminderDaysBefore] = useState(initialReminderDaysBefore);
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
   const currencyOptions = useMemo(() => {
-    if (CURRENCY_OPTIONS.includes(initialDefaultCurrency)) {
+    if (CURRENCY_OPTIONS.some((currency) => currency === initialDefaultCurrency)) {
       return CURRENCY_OPTIONS;
     }
 

--- a/app/settings/actions.ts
+++ b/app/settings/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import type { DisplayMode } from "@prisma/client";
 
 import { requireAuthenticatedUser } from "@/lib/auth";
+import { normalizeCurrencyCode } from "@/lib/currencies";
 import { db } from "@/lib/db";
 
 function normalizeText(value: FormDataEntryValue | null): string {
@@ -12,13 +13,7 @@ function normalizeText(value: FormDataEntryValue | null): string {
 }
 
 function parseDefaultCurrency(value: FormDataEntryValue | null): string | null {
-  const normalized = normalizeText(value).toUpperCase();
-
-  if (!/^[A-Z]{3}$/.test(normalized)) {
-    return null;
-  }
-
-  return normalized;
+  return normalizeCurrencyCode(normalizeText(value));
 }
 
 function parseReminderDaysBefore(value: FormDataEntryValue | null): number | null {

--- a/docs/DASHBOARD_AGGREGATION.md
+++ b/docs/DASHBOARD_AGGREGATION.md
@@ -20,22 +20,23 @@ The dashboard aggregation contract is built in `lib/dashboard.ts` and exposed th
 
 ## Currency handling
 
-- No FX conversion is applied.
-- Normalized KPI totals return a single `amountCents` only when all contributing subscriptions share one currency.
-- When multiple currencies are present, KPI totals are returned in `totalsByCurrency` and single-currency fields are `null`.
+- Dashboard summary totals use the user's `UserSettings.defaultCurrency` as the reporting currency.
+- Source subscription currencies remain unchanged for individual subscription records and upcoming renewal rows.
+- Cross-currency summaries use exchange rates when available. Missing rates are reported in `currencyConversion.missingRates` and excluded from converted totals instead of being silently mixed.
+- `normalizationPolicy` is `preferred_currency_with_fx_conversion`.
 
 ## Potential savings rules
 
 - Rule 1 (`duplicate_overlap`): for active subscriptions sharing canonical service name and currency, keep the lowest monthly-equivalent entry and treat the remaining entries as overlap savings.
 - Rule 2 (`potentially_unused_subscription`): active subscriptions are flagged when they have an upcoming renewal in 30 days, account age is at least 120 days, and last update is at least 90 days old.
 - To avoid double counting, subscriptions that are part of duplicate groups are excluded from the potentially-unused rule.
-- Savings totals are grouped by currency with no FX conversion.
+- Savings totals are converted to the reporting currency when exchange rates are available.
 - `CUSTOM` cadence subscriptions are excluded from savings opportunities because monthly normalization is undefined.
 
 ## Deterministic ordering
 
 - `upcomingRenewals`: renewal date ascending, then name ascending.
 - `attentionNeeded`: severity descending, then due date ascending, then title ascending.
-- `topCostDrivers`: monthly equivalent descending, then currency ascending, then name ascending.
+- `topCostDrivers`: converted monthly equivalent descending, then source currency ascending, then name ascending.
 - `spendBreakdownByCategory`: max category monthly total descending, then subscription count descending, then category ascending.
 - `potentialSavings.opportunities`: estimated monthly savings descending, then title ascending.

--- a/lib/currencies.ts
+++ b/lib/currencies.ts
@@ -1,0 +1,15 @@
+export const CURRENCY_OPTIONS = ["USD", "EUR", "GBP", "JPY", "CAD", "AUD"] as const;
+
+export function normalizeCurrencyCode(value: string | null | undefined): string | null {
+  const normalized = String(value ?? "").trim().toUpperCase();
+
+  if (!/^[A-Z]{3}$/.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function resolvePreferredCurrency(value: string | null | undefined): string {
+  return normalizeCurrencyCode(value) ?? "USD";
+}

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -1,20 +1,5 @@
-export const DASHBOARD_ALL_CURRENCIES = "all";
+import { normalizeCurrencyCode } from "@/lib/currencies";
 
-export const DASHBOARD_DATE_RANGE_OPTIONS = [
-  { value: "7d", label: "Last 7 days", days: 7 },
-  { value: "30d", label: "Last 30 days", days: 30 },
-  { value: "90d", label: "Last 90 days", days: 90 },
-] as const;
-
-export const DEFAULT_DASHBOARD_DATE_RANGE = "30d";
-
-export type DashboardDateRangeValue = (typeof DASHBOARD_DATE_RANGE_OPTIONS)[number]["value"];
-
-export type DashboardControlState = {
-  currency: string;
-  dateRange: DashboardDateRangeValue;
-  searchQuery: string;
-};
 
 const DASHBOARD_CATEGORY_COLOR_PALETTE = [
   "#0EA5E9",
@@ -28,13 +13,6 @@ const DASHBOARD_CATEGORY_COLOR_PALETTE = [
   "#EC4899",
   "#84CC16",
 ] as const;
-
-type DashboardUpcomingRenewalRecord = {
-  name: string;
-  currency: string;
-  paymentMethod: string;
-  renewalDate: string;
-};
 
 type DashboardSpendBreakdownCategoryRecord = {
   category: string;
@@ -52,52 +30,8 @@ export type DashboardSpendBreakdownRow = {
   color: string;
 };
 
-function normalizeCurrencyCode(value: string | null | undefined): string | null {
-  const normalized = String(value ?? "").trim().toUpperCase();
-
-  if (!/^[A-Z]{3}$/.test(normalized)) {
-    return null;
-  }
-
-  return normalized;
-}
-
-export function resolveInitialDashboardCurrency(defaultCurrency: string | null | undefined): string {
-  if (String(defaultCurrency ?? "").trim().toLowerCase() === DASHBOARD_ALL_CURRENCIES) {
-    return DASHBOARD_ALL_CURRENCIES;
-  }
-
-  return normalizeCurrencyCode(defaultCurrency) ?? DASHBOARD_ALL_CURRENCIES;
-}
-
-export function buildDashboardCurrencyOptions(availableCurrencies: string[], selectedCurrency: string): string[] {
-  const normalizedCurrencies = [
-    ...new Set(availableCurrencies.map((value) => normalizeCurrencyCode(value)).filter((value): value is string => value !== null)),
-  ].sort((first, second) => first.localeCompare(second));
-  const normalizedSelectedCurrency = normalizeCurrencyCode(selectedCurrency);
-
-  if (normalizedSelectedCurrency && !normalizedCurrencies.includes(normalizedSelectedCurrency)) {
-    normalizedCurrencies.push(normalizedSelectedCurrency);
-    normalizedCurrencies.sort((first, second) => first.localeCompare(second));
-  }
-
-  if (!normalizedCurrencies.includes("USD")) {
-    return normalizedCurrencies;
-  }
-
-  return ["USD", ...normalizedCurrencies.filter((value) => value !== "USD")];
-}
-
 function toNormalizedSearchQuery(value: string): string {
   return value.trim().toLowerCase();
-}
-
-function matchesCurrencyFilter(recordCurrency: string, selectedCurrency: string): boolean {
-  if (selectedCurrency === DASHBOARD_ALL_CURRENCIES) {
-    return true;
-  }
-
-  return recordCurrency.toUpperCase() === selectedCurrency.toUpperCase();
 }
 
 function matchesSearchFilter(parts: string[], normalizedQuery: string): boolean {
@@ -127,45 +61,6 @@ export function getDashboardCategoryColor(category: string): string {
 
   const index = hashString(normalized) % DASHBOARD_CATEGORY_COLOR_PALETTE.length;
   return DASHBOARD_CATEGORY_COLOR_PALETTE[index];
-}
-
-function toDateRangeDays(value: DashboardDateRangeValue): number {
-  const option = DASHBOARD_DATE_RANGE_OPTIONS.find((entry) => entry.value === value);
-  return option?.days ?? DASHBOARD_DATE_RANGE_OPTIONS[1].days;
-}
-
-function isWithinUpcomingWindow(dateValue: string, now: Date, rangeDays: number): boolean {
-  const parsedDate = new Date(dateValue);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return false;
-  }
-
-  const deltaMs = parsedDate.getTime() - now.getTime();
-  const maxMs = rangeDays * 24 * 60 * 60 * 1000;
-
-  return deltaMs >= 0 && deltaMs <= maxMs;
-}
-
-export function filterDashboardUpcomingRenewals<T extends DashboardUpcomingRenewalRecord>(
-  records: T[],
-  controls: DashboardControlState,
-  now: Date,
-): T[] {
-  const rangeDays = toDateRangeDays(controls.dateRange);
-  const normalizedQuery = toNormalizedSearchQuery(controls.searchQuery);
-
-  return records.filter((record) => {
-    if (!matchesCurrencyFilter(record.currency, controls.currency)) {
-      return false;
-    }
-
-    if (!isWithinUpcomingWindow(record.renewalDate, now, rangeDays)) {
-      return false;
-    }
-
-    return matchesSearchFilter([record.name, record.paymentMethod, record.currency], normalizedQuery);
-  });
 }
 
 export function mapDashboardSpendBreakdownByCurrency<T extends DashboardSpendBreakdownCategoryRecord>(

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,5 +1,6 @@
 import { BillingInterval } from "@prisma/client";
 
+import { normalizeCurrencyCode, resolvePreferredCurrency } from "@/lib/currencies";
 import { db } from "@/lib/db";
 import { inferSubscriptionCategory } from "@/lib/subscription-classification";
 
@@ -59,6 +60,13 @@ export type DashboardCurrencyTotal = {
   currency: string;
   monthlyEquivalentSpendCents: number;
   annualProjectionCents: number;
+};
+
+export type DashboardCurrencyConversion = {
+  targetCurrency: string;
+  generatedAt: string | null;
+  source: "not_required" | "frankfurter" | "provided_rates";
+  missingRates: string[];
 };
 
 export type DashboardMetricAmount = {
@@ -167,7 +175,8 @@ export type DashboardPayload = {
     renewalsNextDays: typeof DASHBOARD_RENEWALS_WINDOW_DAYS;
     upcomingRenewalsDays: typeof DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS;
   };
-  normalizationPolicy: "single_currency_totals_without_fx_conversion";
+  normalizationPolicy: "preferred_currency_with_fx_conversion";
+  currencyConversion: DashboardCurrencyConversion;
   kpis: DashboardKpis;
   spendBreakdownByCategory: DashboardSpendCategory[];
   attentionNeeded: DashboardAttentionItem[];
@@ -184,6 +193,8 @@ type NormalizedSubscription = DashboardSubscriptionSourceRecord & {
   nextBillingDateDate: Date | null;
   monthlyEquivalentAmountCents: number | null;
   annualProjectionCents: number | null;
+  preferredMonthlyEquivalentAmountCents: number | null;
+  preferredAnnualProjectionCents: number | null;
   canonicalServiceKey: string;
   inferredCategory: string;
 };
@@ -193,6 +204,20 @@ type DuplicateGroup = {
   currency: string;
   displayName: string;
   subscriptions: NormalizedSubscription[];
+};
+
+export type DashboardExchangeRateMap = Record<string, number>;
+
+export type DashboardPayloadOptions = {
+  preferredCurrency?: string | null;
+  exchangeRates?: DashboardExchangeRateMap;
+  exchangeRateSource?: DashboardCurrencyConversion["source"];
+  exchangeRateGeneratedAt?: string | null;
+};
+
+type FrankfurterLatestResponse = {
+  date?: string;
+  rates?: Record<string, number>;
 };
 
 function toDate(value: Date | string): Date {
@@ -242,6 +267,118 @@ export function normalizeToAnnualAmountCents(amountCents: number, billingInterva
     default:
       return null;
   }
+}
+
+function normalizeExchangeRates(exchangeRates: DashboardExchangeRateMap | undefined): Map<string, number> {
+  const normalizedRates = new Map<string, number>();
+
+  for (const [currency, rate] of Object.entries(exchangeRates ?? {})) {
+    const normalizedCurrency = normalizeCurrencyCode(currency);
+
+    if (!normalizedCurrency || !Number.isFinite(rate) || rate <= 0) {
+      continue;
+    }
+
+    normalizedRates.set(normalizedCurrency, rate);
+  }
+
+  return normalizedRates;
+}
+
+function convertCurrencyAmountCents(
+  amountCents: number | null,
+  sourceCurrency: string,
+  targetCurrency: string,
+  exchangeRates: Map<string, number>,
+  missingRates: Set<string>,
+): number | null {
+  if (amountCents === null) {
+    return null;
+  }
+
+  if (sourceCurrency === targetCurrency) {
+    return amountCents;
+  }
+
+  const rate = exchangeRates.get(sourceCurrency);
+
+  if (rate === undefined) {
+    missingRates.add(sourceCurrency);
+    return null;
+  }
+
+  return Math.round(amountCents * rate);
+}
+
+async function fetchExchangeRatesToCurrency(
+  sourceCurrencies: string[],
+  targetCurrency: string,
+): Promise<{ rates: DashboardExchangeRateMap; generatedAt: string | null }> {
+  const currenciesNeedingRates = [...new Set(sourceCurrencies)]
+    .map((currency) => normalizeCurrencyCode(currency))
+    .filter((currency): currency is string => currency !== null && currency !== targetCurrency);
+
+  if (currenciesNeedingRates.length === 0) {
+    return {
+      rates: {},
+      generatedAt: null,
+    };
+  }
+
+  const results = await Promise.all(
+    currenciesNeedingRates.map(async (sourceCurrency) => {
+      const url = new URL("https://api.frankfurter.app/latest");
+      url.searchParams.set("from", sourceCurrency);
+      url.searchParams.set("to", targetCurrency);
+
+      try {
+        const response = await fetch(url, {
+          next: {
+            revalidate: 60 * 60 * 6,
+          },
+        });
+
+        if (!response.ok) {
+          return null;
+        }
+
+        const payload = (await response.json()) as FrankfurterLatestResponse;
+        const rate = payload.rates?.[targetCurrency];
+
+        if (!Number.isFinite(rate) || !rate || rate <= 0) {
+          return null;
+        }
+
+        return {
+          sourceCurrency,
+          rate,
+          date: payload.date ?? null,
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const rates: DashboardExchangeRateMap = {};
+  const generatedDates = new Set<string>();
+
+  for (const result of results) {
+    if (!result) {
+      continue;
+    }
+
+    rates[result.sourceCurrency] = result.rate;
+
+    if (result.date) {
+      generatedDates.add(result.date);
+    }
+  }
+
+  return {
+    rates,
+    generatedAt: generatedDates.size === 1 ? [...generatedDates][0] : null,
+  };
 }
 
 function isWithinNextDays(value: Date, now: Date, days: number): boolean {
@@ -294,26 +431,26 @@ function canonicalizeServiceName(name: string): string {
   return normalized || "unknown";
 }
 
-function makeCurrencyTotals(records: Iterable<NormalizedSubscription>): DashboardCurrencyTotal[] {
+function makeCurrencyTotals(records: Iterable<NormalizedSubscription>, preferredCurrency: string): DashboardCurrencyTotal[] {
   const totals = new Map<string, DashboardCurrencyTotal>();
 
   for (const record of records) {
-    if (record.monthlyEquivalentAmountCents === null || record.annualProjectionCents === null) {
+    if (record.preferredMonthlyEquivalentAmountCents === null || record.preferredAnnualProjectionCents === null) {
       continue;
     }
 
-    const existing = totals.get(record.currency);
+    const existing = totals.get(preferredCurrency);
 
     if (existing) {
-      existing.monthlyEquivalentSpendCents += record.monthlyEquivalentAmountCents;
-      existing.annualProjectionCents += record.annualProjectionCents;
+      existing.monthlyEquivalentSpendCents += record.preferredMonthlyEquivalentAmountCents;
+      existing.annualProjectionCents += record.preferredAnnualProjectionCents;
       continue;
     }
 
-    totals.set(record.currency, {
-      currency: record.currency,
-      monthlyEquivalentSpendCents: record.monthlyEquivalentAmountCents,
-      annualProjectionCents: record.annualProjectionCents,
+    totals.set(preferredCurrency, {
+      currency: preferredCurrency,
+      monthlyEquivalentSpendCents: record.preferredMonthlyEquivalentAmountCents,
+      annualProjectionCents: record.preferredAnnualProjectionCents,
     });
   }
 
@@ -445,12 +582,18 @@ function findDuplicateGroups(records: NormalizedSubscription[]): DuplicateGroup[
 export function buildDashboardPayload(
   subscriptions: DashboardSubscriptionSourceRecord[],
   now: Date = new Date(),
+  options: DashboardPayloadOptions = {},
 ): DashboardPayload {
+  const preferredCurrency = resolvePreferredCurrency(options.preferredCurrency);
+  const exchangeRates = normalizeExchangeRates(options.exchangeRates);
+  const missingRates = new Set<string>();
   const normalizedSubscriptions: NormalizedSubscription[] = subscriptions.map((subscription) => {
     const createdAtDate = toDate(subscription.createdAt);
     const updatedAtDate = toDate(subscription.updatedAt);
     const nextBillingDateDate = toOptionalDate(subscription.nextBillingDate);
     const currency = normalizeCurrency(subscription.currency);
+    const monthlyEquivalentAmountCents = normalizeToMonthlyAmountCents(subscription.amountCents, subscription.billingInterval);
+    const annualProjectionCents = normalizeToAnnualAmountCents(subscription.amountCents, subscription.billingInterval);
 
     return {
       ...subscription,
@@ -458,8 +601,22 @@ export function buildDashboardPayload(
       createdAtDate,
       updatedAtDate,
       nextBillingDateDate,
-      monthlyEquivalentAmountCents: normalizeToMonthlyAmountCents(subscription.amountCents, subscription.billingInterval),
-      annualProjectionCents: normalizeToAnnualAmountCents(subscription.amountCents, subscription.billingInterval),
+      monthlyEquivalentAmountCents,
+      annualProjectionCents,
+      preferredMonthlyEquivalentAmountCents: convertCurrencyAmountCents(
+        monthlyEquivalentAmountCents,
+        currency,
+        preferredCurrency,
+        exchangeRates,
+        missingRates,
+      ),
+      preferredAnnualProjectionCents: convertCurrencyAmountCents(
+        annualProjectionCents,
+        currency,
+        preferredCurrency,
+        exchangeRates,
+        missingRates,
+      ),
       canonicalServiceKey: canonicalizeServiceName(subscription.name),
       inferredCategory: inferSubscriptionCategory(subscription.name),
     };
@@ -471,7 +628,7 @@ export function buildDashboardPayload(
     (subscription) => subscription.monthlyEquivalentAmountCents === null || subscription.annualProjectionCents === null,
   ).length;
 
-  const totalsByCurrency = makeCurrencyTotals(activeSubscriptions);
+  const totalsByCurrency = makeCurrencyTotals(activeSubscriptions, preferredCurrency);
 
   const kpis: DashboardKpis = {
     monthlyEquivalentSpend: metricAmountFromCurrencyTotals(totalsByCurrency, excludedCustomCadenceCount, "monthly"),
@@ -519,7 +676,7 @@ export function buildDashboardPayload(
 
   const spendBreakdownByCategory: DashboardSpendCategory[] = [...categoryGroups.values()]
     .map((group) => {
-      const categoryTotals = makeCurrencyTotals(group.records);
+      const categoryTotals = makeCurrencyTotals(group.records, preferredCurrency);
 
       return {
         category: group.category,
@@ -592,8 +749,8 @@ export function buildDashboardPayload(
           message: `Potential charge of ${formatCurrencyCents(subscription.amountCents, subscription.currency)} on ${formatAttentionDate(dueDate)} (${daysUntilDue} day(s)).`,
           dueDate: dueDate.toISOString(),
           subscriptionIds: [subscription.id],
-          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
-          currency: subscription.currency,
+          estimatedMonthlyImpactCents: subscription.preferredMonthlyEquivalentAmountCents,
+          currency: subscription.preferredMonthlyEquivalentAmountCents === null ? null : preferredCurrency,
         };
       }),
     ...activeSubscriptions
@@ -610,8 +767,8 @@ export function buildDashboardPayload(
           message: `No subscription updates in ${staleDays} day(s). Next charge ${formatCurrencyCents(subscription.amountCents, subscription.currency)} on ${formatAttentionDate(dueDate)}.`,
           dueDate: dueDate.toISOString(),
           subscriptionIds: [subscription.id],
-          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
-          currency: subscription.currency,
+          estimatedMonthlyImpactCents: subscription.preferredMonthlyEquivalentAmountCents,
+          currency: subscription.preferredMonthlyEquivalentAmountCents === null ? null : preferredCurrency,
         };
       }),
     ...activeSubscriptions
@@ -634,14 +791,14 @@ export function buildDashboardPayload(
           message: `Annual charge of ${formatCurrencyCents(subscription.amountCents, subscription.currency)} is due on ${formatAttentionDate(dueDate)} (${daysUntilDue} day(s)).`,
           dueDate: dueDate.toISOString(),
           subscriptionIds: [subscription.id],
-          estimatedMonthlyImpactCents: subscription.monthlyEquivalentAmountCents,
-          currency: subscription.currency,
+          estimatedMonthlyImpactCents: subscription.preferredMonthlyEquivalentAmountCents,
+          currency: subscription.preferredMonthlyEquivalentAmountCents === null ? null : preferredCurrency,
         };
       }),
     ...duplicateGroups.map((group) => {
       const duplicates = group.subscriptions.slice(1);
       const estimatedMonthlyImpactCents = duplicates.reduce(
-        (total, subscription) => total + (subscription.monthlyEquivalentAmountCents ?? 0),
+        (total, subscription) => total + (subscription.preferredMonthlyEquivalentAmountCents ?? 0),
         0,
       );
       const soonestRenewal = group.subscriptions
@@ -657,23 +814,29 @@ export function buildDashboardPayload(
         type: "potential_duplicate_services" as const,
         severity: "high" as const,
         title: `Potential duplicate services: ${group.displayName}`,
-        message: `${group.subscriptions.length} active subscriptions may overlap. Estimated extra spend is ${formatCurrencyCents(estimatedMonthlyImpactCents, group.currency)} per month.${soonestRenewalText}`,
+        message: `${group.subscriptions.length} active subscriptions may overlap. Estimated extra spend is ${formatCurrencyCents(estimatedMonthlyImpactCents, preferredCurrency)} per month.${soonestRenewalText}`,
         dueDate: soonestRenewal ? soonestRenewal.toISOString() : null,
         subscriptionIds: group.subscriptions.map((subscription) => subscription.id),
         estimatedMonthlyImpactCents,
-        currency: group.currency,
+        currency: preferredCurrency,
       };
     }),
   ].sort(compareAttentionItems);
 
   const topCostDrivers: DashboardTopCostDriver[] = activeSubscriptions
     .filter(
-      (subscription): subscription is NormalizedSubscription & { monthlyEquivalentAmountCents: number; annualProjectionCents: number } =>
-        subscription.monthlyEquivalentAmountCents !== null && subscription.annualProjectionCents !== null,
+      (
+        subscription,
+      ): subscription is NormalizedSubscription & {
+        preferredMonthlyEquivalentAmountCents: number;
+        preferredAnnualProjectionCents: number;
+      } =>
+        subscription.preferredMonthlyEquivalentAmountCents !== null &&
+        subscription.preferredAnnualProjectionCents !== null,
     )
     .sort((first, second) => {
       return (
-        second.monthlyEquivalentAmountCents - first.monthlyEquivalentAmountCents ||
+        second.preferredMonthlyEquivalentAmountCents - first.preferredMonthlyEquivalentAmountCents ||
         first.currency.localeCompare(second.currency) ||
         first.name.localeCompare(second.name) ||
         first.id.localeCompare(second.id)
@@ -683,10 +846,10 @@ export function buildDashboardPayload(
     .map((subscription) => ({
       id: subscription.id,
       name: subscription.name,
-      currency: subscription.currency,
+      currency: preferredCurrency,
       billingInterval: subscription.billingInterval,
-      monthlyEquivalentAmountCents: subscription.monthlyEquivalentAmountCents,
-      annualProjectionCents: subscription.annualProjectionCents,
+      monthlyEquivalentAmountCents: subscription.preferredMonthlyEquivalentAmountCents,
+      annualProjectionCents: subscription.preferredAnnualProjectionCents,
       nextBillingDate: subscription.nextBillingDateDate ? subscription.nextBillingDateDate.toISOString() : null,
     }));
 
@@ -694,7 +857,7 @@ export function buildDashboardPayload(
     .map((group) => {
       const duplicateSubscriptions = group.subscriptions.slice(1);
       const estimatedMonthlySavingsCents = duplicateSubscriptions.reduce(
-        (total, subscription) => total + (subscription.monthlyEquivalentAmountCents ?? 0),
+        (total, subscription) => total + (subscription.preferredMonthlyEquivalentAmountCents ?? 0),
         0,
       );
 
@@ -703,7 +866,7 @@ export function buildDashboardPayload(
         type: "duplicate_overlap" as const,
         title: `Consolidate duplicate ${group.displayName} subscriptions`,
         description: `Cancelling ${duplicateSubscriptions.length} overlapping subscription(s) could reduce recurring spend.`,
-        currency: group.currency,
+        currency: preferredCurrency,
         estimatedMonthlySavingsCents,
         subscriptionIds: duplicateSubscriptions.map((subscription) => subscription.id),
       };
@@ -716,8 +879,8 @@ export function buildDashboardPayload(
 
   const potentiallyUnusedOpportunities: DashboardSavingsOpportunity[] = activeSubscriptions
     .filter(
-      (subscription): subscription is NormalizedSubscription & { monthlyEquivalentAmountCents: number } =>
-        subscription.monthlyEquivalentAmountCents !== null &&
+      (subscription): subscription is NormalizedSubscription & { preferredMonthlyEquivalentAmountCents: number } =>
+        subscription.preferredMonthlyEquivalentAmountCents !== null &&
         isPotentiallyUnusedCandidate(subscription, now) &&
         !subscriptionsInDuplicateGroups.has(subscription.id),
     )
@@ -726,8 +889,8 @@ export function buildDashboardPayload(
       type: "potentially_unused_subscription" as const,
       title: `Review usage for ${subscription.name}`,
       description: "No recent updates detected. Confirm this subscription is still needed before the next renewal.",
-      currency: subscription.currency,
-      estimatedMonthlySavingsCents: subscription.monthlyEquivalentAmountCents,
+      currency: preferredCurrency,
+      estimatedMonthlySavingsCents: subscription.preferredMonthlyEquivalentAmountCents,
       subscriptionIds: [subscription.id],
     }))
     .filter((opportunity) => opportunity.estimatedMonthlySavingsCents > 0);
@@ -773,7 +936,7 @@ export function buildDashboardPayload(
       "Savings estimate includes duplicate-overlap candidates (same canonical service name + currency) and potentially-unused subscriptions.",
       "Potentially-unused candidates require an upcoming renewal within 30 days, account age of at least 120 days, and no updates for 90+ days.",
       "Subscriptions in duplicate groups are excluded from the potentially-unused rule to avoid double counting.",
-      "No FX conversion is applied when currencies differ.",
+      `Combined estimates are converted into ${preferredCurrency} when exchange rates are available.`,
       "Custom billing intervals are excluded from normalized monthly/annual estimates.",
     ],
   };
@@ -808,6 +971,7 @@ export function buildDashboardPayload(
         nextBillingDate: (fallbackNextChargeSource.nextBillingDateDate as Date).toISOString(),
       }
     : null;
+  const hasCrossCurrencyData = activeSubscriptions.some((subscription) => subscription.currency !== preferredCurrency);
 
   return {
     generatedAt: now.toISOString(),
@@ -815,7 +979,13 @@ export function buildDashboardPayload(
       renewalsNextDays: DASHBOARD_RENEWALS_WINDOW_DAYS,
       upcomingRenewalsDays: DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS,
     },
-    normalizationPolicy: "single_currency_totals_without_fx_conversion",
+    normalizationPolicy: "preferred_currency_with_fx_conversion",
+    currencyConversion: {
+      targetCurrency: preferredCurrency,
+      generatedAt: options.exchangeRateGeneratedAt ?? null,
+      source: hasCrossCurrencyData ? (options.exchangeRateSource ?? "provided_rates") : "not_required",
+      missingRates: [...missingRates].sort((first, second) => first.localeCompare(second)),
+    },
     kpis,
     spendBreakdownByCategory,
     attentionNeeded,
@@ -827,25 +997,45 @@ export function buildDashboardPayload(
 }
 
 export async function getDashboardPayloadForUser(userId: string, now: Date = new Date()): Promise<DashboardPayload> {
-  const subscriptions = await db.subscription.findMany({
-    where: {
-      userId,
-    },
-    select: {
-      id: true,
-      name: true,
-      amountCents: true,
-      currency: true,
-      billingInterval: true,
-      nextBillingDate: true,
-      isActive: true,
-      paymentMethod: true,
-      signedUpBy: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-    orderBy: [{ isActive: "desc" }, { nextBillingDate: "asc" }, { createdAt: "desc" }],
-  });
+  const [subscriptions, settings] = await Promise.all([
+    db.subscription.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        id: true,
+        name: true,
+        amountCents: true,
+        currency: true,
+        billingInterval: true,
+        nextBillingDate: true,
+        isActive: true,
+        paymentMethod: true,
+        signedUpBy: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      orderBy: [{ isActive: "desc" }, { nextBillingDate: "asc" }, { createdAt: "desc" }],
+    }),
+    db.userSettings.findUnique({
+      where: {
+        userId,
+      },
+      select: {
+        defaultCurrency: true,
+      },
+    }),
+  ]);
+  const preferredCurrency = resolvePreferredCurrency(settings?.defaultCurrency);
+  const activeSourceCurrencies = subscriptions
+    .filter((subscription) => subscription.isActive)
+    .map((subscription) => normalizeCurrency(subscription.currency));
+  const exchangeRates = await fetchExchangeRatesToCurrency(activeSourceCurrencies, preferredCurrency);
 
-  return buildDashboardPayload(subscriptions, now);
+  return buildDashboardPayload(subscriptions, now, {
+    preferredCurrency,
+    exchangeRates: exchangeRates.rates,
+    exchangeRateGeneratedAt: exchangeRates.generatedAt,
+    exchangeRateSource: "frankfurter",
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "easymde": "^2.20.0",
         "next": "14.2.5",
         "react": "18.3.1",
+        "react-currency-flags": "^0.1.2",
         "react-dom": "18.3.1",
         "react-simplemde-editor": "^5.2.0",
-        "resend": "^6.3.0"
+        "resend": "^6.3.0",
+        "styled-components": "^4.4.1"
       },
       "devDependencies": {
         "@types/node": "20.14.9",
@@ -35,7 +37,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -46,11 +47,70 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -63,11 +123,95 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -77,7 +221,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -87,8 +230,29 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -97,7 +261,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -109,11 +272,25 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -128,7 +305,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -147,7 +323,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -190,6 +365,27 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -785,10 +981,19 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -796,7 +1001,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -806,14 +1010,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2400,6 +2602,18 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2422,6 +2636,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/busboy": {
@@ -2524,10 +2772,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2733,6 +2990,12 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -2774,6 +3037,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "node_modules/csstype": {
@@ -2877,7 +3160,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3202,6 +3484,12 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -3492,6 +3780,15 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4245,6 +4542,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -5139,6 +5445,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5223,7 +5535,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5358,6 +5669,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5421,6 +5738,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
+    "node_modules/merge-anything": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
+      "integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^3.3.1"
       }
     },
     "node_modules/merge2": {
@@ -5524,7 +5856,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5665,6 +5996,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5704,7 +6041,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6175,7 +6511,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6239,6 +6574,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6329,7 +6670,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6407,6 +6747,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-currency-flags": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/react-currency-flags/-/react-currency-flags-0.1.2.tgz",
+      "integrity": "sha512-p51uPd3hPe6gTigLNZusTjiurXiau1wxnGZyQkwZFTptWhuai+KG//kAwZaCWp0zzNI7sfjKUPXw4fVbi8ep8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "styled-components": "^4.2.0"
       }
     },
     "node_modules/react-dom": {
@@ -7117,7 +7466,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-promise-suspense": {
@@ -7992,6 +8340,70 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/styled-components": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
+      "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^5.0.0",
+        "merge-anything": "^2.2.4",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.6.0",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^5.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/babel-plugin-styled-components": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
+      }
+    },
+    "node_modules/styled-components/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/styled-components/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -8013,6 +8425,22 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/stylis": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "stylis": "^3.5.0"
       }
     },
     "node_modules/supports-color": {
@@ -8394,6 +8822,36 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8678,6 +9136,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "easymde": "^2.20.0",
     "next": "14.2.5",
     "react": "18.3.1",
+    "react-currency-flags": "^0.1.2",
     "react-dom": "18.3.1",
     "react-simplemde-editor": "^5.2.0",
-    "resend": "^6.3.0"
+    "resend": "^6.3.0",
+    "styled-components": "^4.4.1"
   },
   "devDependencies": {
     "@types/node": "20.14.9",

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -107,7 +107,7 @@ describe("buildDashboardPayload", () => {
     assert.equal(payload.attentionNeeded.some((item) => item.type === "annual_renewal_approaching"), true);
   });
 
-  test("does not merge mixed currencies into a single normalized KPI total", () => {
+  test("converts mixed currencies into preferred-currency KPI totals", () => {
     const now = new Date("2026-03-11T00:00:00.000Z");
 
     const payload = buildDashboardPayload(
@@ -116,12 +116,22 @@ describe("buildDashboardPayload", () => {
         makeSubscription({ id: "aud", name: "Canva", amountCents: 2000, currency: "aud" }),
       ],
       now,
+      {
+        preferredCurrency: "USD",
+        exchangeRates: {
+          AUD: 0.65,
+        },
+        exchangeRateGeneratedAt: "2026-03-10",
+        exchangeRateSource: "provided_rates",
+      },
     );
 
-    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, null);
-    assert.equal(payload.kpis.monthlyEquivalentSpend.currency, null);
-    assert.equal(payload.kpis.monthlyEquivalentSpend.totalsByCurrency.length, 2);
-    assert.deepEqual(payload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency), ["AUD", "USD"]);
+    assert.equal(payload.normalizationPolicy, "preferred_currency_with_fx_conversion");
+    assert.equal(payload.currencyConversion.targetCurrency, "USD");
+    assert.deepEqual(payload.currencyConversion.missingRates, []);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, 2300);
+    assert.equal(payload.kpis.monthlyEquivalentSpend.currency, "USD");
+    assert.deepEqual(payload.kpis.monthlyEquivalentSpend.totalsByCurrency.map((entry) => entry.currency), ["USD"]);
   });
 
   test("keeps canceled subscriptions in counts while excluding them from active spend and cost drivers", () => {
@@ -155,6 +165,29 @@ describe("buildDashboardPayload", () => {
     );
 
     assert.deepEqual(payload.topCostDrivers.map((driver) => driver.id), ["weekly", "monthly", "yearly"]);
+  });
+
+  test("ranks top cost drivers after preferred-currency conversion", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "usd", name: "USD Tool", amountCents: 1500, currency: "usd" }),
+        makeSubscription({ id: "aud", name: "AUD Tool", amountCents: 3000, currency: "aud" }),
+      ],
+      now,
+      {
+        preferredCurrency: "USD",
+        exchangeRates: {
+          AUD: 0.5,
+        },
+      },
+    );
+
+    assert.deepEqual(payload.topCostDrivers.map((driver) => [driver.id, driver.monthlyEquivalentAmountCents, driver.currency]), [
+      ["aud", 1500, "USD"],
+      ["usd", 1500, "USD"],
+    ]);
   });
 
   test("builds duplicate-service alerts and savings opportunities deterministically", () => {

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -2,88 +2,17 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
 import {
-  buildDashboardCurrencyOptions,
-  DASHBOARD_ALL_CURRENCIES,
-  DEFAULT_DASHBOARD_DATE_RANGE,
-  filterDashboardUpcomingRenewals,
   getDashboardCategoryColor,
   mapDashboardSpendBreakdownByCurrency,
-  resolveInitialDashboardCurrency,
 } from "../../lib/dashboard-controls";
+import { normalizeCurrencyCode, resolvePreferredCurrency } from "../../lib/currencies";
 
-describe("dashboard controls filtering", () => {
-  test("uses last 30 days as the default date range", () => {
-    assert.equal(DEFAULT_DASHBOARD_DATE_RANGE, "30d");
-  });
-
-  test("resolves dashboard initial currency from user default", () => {
-    assert.equal(resolveInitialDashboardCurrency("aud"), "AUD");
-    assert.equal(resolveInitialDashboardCurrency(""), DASHBOARD_ALL_CURRENCIES);
-    assert.equal(resolveInitialDashboardCurrency("all"), DASHBOARD_ALL_CURRENCIES);
-  });
-
-  test("builds currency options with selected currency and USD priority", () => {
-    const options = buildDashboardCurrencyOptions(["aud", " eur ", "usd", "AUD"], "cad");
-
-    assert.deepEqual(options, ["USD", "AUD", "CAD", "EUR"]);
-  });
-
-  test("filters upcoming renewals by currency, search, and upcoming date window", () => {
-    const now = new Date("2026-03-11T00:00:00.000Z");
-    const records = [
-      {
-        name: "GitHub Team",
-        currency: "USD",
-        paymentMethod: "Visa 1234",
-        renewalDate: "2026-03-20T00:00:00.000Z",
-      },
-      {
-        name: "Canva Pro",
-        currency: "AUD",
-        paymentMethod: "Mastercard 9876",
-        renewalDate: "2026-03-18T00:00:00.000Z",
-      },
-      {
-        name: "Legacy Service",
-        currency: "USD",
-        paymentMethod: "Visa 1234",
-        renewalDate: "2026-04-20T00:00:00.000Z",
-      },
-      {
-        name: "Past Renewal",
-        currency: "USD",
-        paymentMethod: "Visa 1234",
-        renewalDate: "2026-03-01T00:00:00.000Z",
-      },
-    ];
-
-    const allResults = filterDashboardUpcomingRenewals(
-      records,
-      {
-        currency: DASHBOARD_ALL_CURRENCIES,
-        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
-        searchQuery: "",
-      },
-      now,
-    );
-    const filteredUsdVisa = filterDashboardUpcomingRenewals(
-      records,
-      {
-        currency: "usd",
-        dateRange: DEFAULT_DASHBOARD_DATE_RANGE,
-        searchQuery: "visa",
-      },
-      now,
-    );
-
-    assert.deepEqual(
-      allResults.map((record) => record.name),
-      ["GitHub Team", "Canva Pro"],
-    );
-    assert.deepEqual(
-      filteredUsdVisa.map((record) => record.name),
-      ["GitHub Team"],
-    );
+describe("dashboard controls", () => {
+  test("resolves preferred currency from user default", () => {
+    assert.equal(normalizeCurrencyCode("aud"), "AUD");
+    assert.equal(resolvePreferredCurrency("gbp"), "GBP");
+    assert.equal(resolvePreferredCurrency(""), "USD");
+    assert.equal(resolvePreferredCurrency("invalid"), "USD");
   });
 
   test("maps spend breakdown rows by currency and search query", () => {


### PR DESCRIPTION
## Summary
- Replace the dashboard filter panel with header-level actions for site currency and adding subscriptions.
- Persist dashboard currency changes to `UserSettings.defaultCurrency` and use that preference as the dashboard reporting currency.
- Convert dashboard summary/comparison values into the preferred currency with FX metadata and missing-rate warnings.

## Test plan
- [x] `npm run test:dashboard`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [ ] `npm run typecheck` is blocked locally by Windows Prisma client DLL file lock: `EPERM` renaming `query_engine-windows.dll.node`.

Closes #83