### PR TITLE
Add signup currency selection

### DIFF
--- a/app/DashboardCurrencyForm.tsx
+++ b/app/DashboardCurrencyForm.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import CurrencyFlag from "react-currency-flags";
 
-import { CURRENCY_OPTIONS } from "@/lib/currencies";
+import CurrencySelectControl from "@/app/components/CurrencySelectControl";
 
 type DashboardCurrencyFormProps = {
   defaultCurrency: string;
@@ -15,32 +14,20 @@ export default function DashboardCurrencyForm({
   updateCurrencyAction,
 }: DashboardCurrencyFormProps) {
   const pathname = usePathname();
-  const currencyOptions = CURRENCY_OPTIONS.includes(defaultCurrency as (typeof CURRENCY_OPTIONS)[number])
-    ? CURRENCY_OPTIONS
-    : [defaultCurrency, ...CURRENCY_OPTIONS];
 
   return (
     <form action={updateCurrencyAction} className="dashboard-currency-form">
       <input name="returnTo" type="hidden" value={pathname || "/"} />
       <label className="form-field dashboard-currency-field">
         <span className="visually-hidden">Site currency</span>
-        <span className="dashboard-currency-control">
-          <CurrencyFlag currency={defaultCurrency} width={22} />
-          <select
-            aria-label="Site currency"
-            name="defaultCurrency"
-            onChange={(event) => {
-              event.currentTarget.form?.requestSubmit();
-            }}
-            value={defaultCurrency}
-          >
-            {currencyOptions.map((currency) => (
-              <option key={currency} value={currency}>
-                {currency}
-              </option>
-            ))}
-          </select>
-        </span>
+        <CurrencySelectControl
+          ariaLabel="Site currency"
+          name="defaultCurrency"
+          onChange={(event) => {
+            event.currentTarget.form?.requestSubmit();
+          }}
+          value={defaultCurrency}
+        />
       </label>
     </form>
   );

--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { db } from "@/lib/db";
+import { normalizeCurrencyCode } from "@/lib/currencies";
 import { isInvitesRequired } from "@/lib/env";
 import { createUserWithInvite } from "@/lib/invites";
 import {
@@ -24,6 +25,10 @@ function normalizeEmail(value: FormDataEntryValue | null): string {
 
 function normalizeText(value: FormDataEntryValue | null): string {
   return String(value ?? "").trim();
+}
+
+function parseDefaultCurrency(value: FormDataEntryValue | null): string | null {
+  return normalizeCurrencyCode(normalizeText(value));
 }
 
 function getClientIp(headerStore: Awaited<ReturnType<typeof headers>>): string | null {
@@ -100,6 +105,36 @@ function buildVerificationRequestedRedirect(params: {
   return `/auth/verify/requested?${searchParams.toString()}`;
 }
 
+async function redirectExistingSignupUser(user: {
+  id: string;
+  email: string;
+  emailVerifiedAt: Date | null;
+}): Promise<never> {
+  if (user.emailVerifiedAt) {
+    const searchParams = new URLSearchParams({
+      email: user.email,
+      error: "account_exists",
+    });
+
+    redirect(`/auth/sign-in?${searchParams.toString()}`);
+  }
+
+  const verification = await issueRegistrationVerificationForUser({
+    userId: user.id,
+    email: user.email,
+    baseUrl: await getRequestBaseUrl(),
+  });
+
+  redirect(
+    buildVerificationRequestedRedirect({
+      email: user.email,
+      source: "signup",
+      delivery: verification.outcome,
+      retryAfterSeconds: verification.retryAfterSeconds,
+    }),
+  );
+}
+
 export async function signUpAction(formData: FormData): Promise<void> {
   if (!(await isSameOriginRequest())) {
     redirect("/auth/sign-up?error=invalid_request");
@@ -107,8 +142,8 @@ export async function signUpAction(formData: FormData): Promise<void> {
 
   const email = normalizeEmail(formData.get("email"));
   const password = normalizeText(formData.get("password"));
-  const name = normalizeText(formData.get("name"));
   const inviteToken = normalizeText(formData.get("inviteToken"));
+  const defaultCurrency = parseDefaultCurrency(formData.get("defaultCurrency"));
 
   if (!email || !password) {
     redirect("/auth/sign-up?error=missing_fields");
@@ -118,15 +153,31 @@ export async function signUpAction(formData: FormData): Promise<void> {
     redirect("/auth/sign-up?error=password_too_short");
   }
 
+  if (!defaultCurrency) {
+    redirect("/auth/sign-up?error=invalid_currency");
+  }
+
   const passwordHash = hashPassword(password);
   const invitesRequired = isInvitesRequired();
+  const existingUser = await db.user.findUnique({
+    where: { email },
+    select: {
+      id: true,
+      email: true,
+      emailVerifiedAt: true,
+    },
+  });
+
+  if (existingUser) {
+    await redirectExistingSignupUser(existingUser);
+  }
 
   if (invitesRequired) {
     const registration = await createUserWithInvite({
       email,
-      name: name || null,
       passwordHash,
       inviteToken,
+      defaultCurrency,
     });
 
     if (!registration.ok) {
@@ -153,22 +204,14 @@ export async function signUpAction(formData: FormData): Promise<void> {
     );
   }
 
-  const existingUser = await db.user.findUnique({
-    where: { email },
-    select: { id: true },
-  });
-
-  if (existingUser) {
-    redirect("/auth/sign-up?error=unable_to_create");
-  }
-
   const user = await db.user.create({
     data: {
       email,
-      name: name || null,
       passwordHash,
       settings: {
-        create: {},
+        create: {
+          defaultCurrency,
+        },
       },
     },
     select: {

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -7,6 +7,7 @@ import { getCurrentUser } from "@/lib/auth";
 
 type SignInPageProps = {
   searchParams?: {
+    email?: string;
     error?: string;
     retry_after?: string;
   };
@@ -29,6 +30,10 @@ function getErrorMessage(errorCode?: string, retryAfter?: string): string | null
     return "Invalid sign-in request. Please try again.";
   }
 
+  if (errorCode === "account_exists") {
+    return "An account already exists for that email. Sign in instead.";
+  }
+
   if (errorCode === "rate_limited") {
     const seconds = Number(retryAfter ?? "0");
 
@@ -42,6 +47,10 @@ function getErrorMessage(errorCode?: string, retryAfter?: string): string | null
   return "Unable to sign in.";
 }
 
+function normalizeEmail(value: string | undefined): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
 export default async function SignInPage({ searchParams }: SignInPageProps) {
   const user = await getCurrentUser();
 
@@ -50,6 +59,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
   }
 
   const errorMessage = getErrorMessage(searchParams?.error, searchParams?.retry_after);
+  const emailPrefill = normalizeEmail(searchParams?.email);
 
   return (
     <section className="auth-wrap">
@@ -62,7 +72,14 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
           <PendingFieldset className="form-grid form-pending-group">
             <label className="form-field">
               Email
-              <input name="email" type="email" autoComplete="email" placeholder="name@example.com" required />
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                defaultValue={emailPrefill}
+                placeholder="name@example.com"
+                required
+              />
             </label>
             <label className="form-field">
               Password

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { signUpAction } from "@/app/auth/actions";
+import CurrencySelectControl from "@/app/components/CurrencySelectControl";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
 import { getCurrentUser } from "@/lib/auth";
 import { isInvitesRequired } from "@/lib/env";
@@ -30,6 +31,10 @@ function getErrorMessage(errorCode: string | undefined, invitesRequired: boolean
 
   if (errorCode === "invalid_request") {
     return "Invalid sign-up request. Please try again.";
+  }
+
+  if (errorCode === "invalid_currency") {
+    return "Choose a valid default currency.";
   }
 
   if (errorCode === "unable_to_create") {
@@ -68,10 +73,6 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
         <form className="mt-md" action={signUpAction}>
           <PendingFieldset className="form-grid form-pending-group">
             <label className="form-field">
-              Name (optional)
-              <input name="name" type="text" autoComplete="name" placeholder="Your name" />
-            </label>
-            <label className="form-field">
               Email
               <input
                 name="email"
@@ -91,6 +92,30 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
                 minLength={8}
                 placeholder="At least 8 characters"
                 required
+              />
+            </label>
+            <label className="form-field signup-currency-field">
+              <span className="field-label-with-help">
+                Default currency
+                <span className="help-tooltip">
+                  <span
+                    aria-label="About default currency"
+                    aria-describedby="signup-default-currency-help"
+                    className="help-tooltip-trigger"
+                    role="img"
+                    tabIndex={0}
+                  >
+                    i
+                  </span>
+                  <span className="help-tooltip-content" id="signup-default-currency-help" role="tooltip">
+                    Used for subscriptions and dashboard totals. You can change it later.
+                  </span>
+                </span>
+              </span>
+              <CurrencySelectControl
+                ariaDescribedBy="signup-default-currency-help"
+                className="dashboard-currency-control signup-currency-control"
+                name="defaultCurrency"
               />
             </label>
             {invitesRequired ? (

--- a/app/auth/verify/requested/page.tsx
+++ b/app/auth/verify/requested/page.tsx
@@ -80,10 +80,23 @@ function getStatusMessage(delivery: string | undefined, retryAfter: string | und
   return null;
 }
 
+function buildSignInHref(email: string): string {
+  if (!email) {
+    return "/auth/sign-in";
+  }
+
+  const searchParams = new URLSearchParams({
+    email,
+  });
+
+  return `/auth/sign-in?${searchParams.toString()}`;
+}
+
 export default function VerificationRequestedPage({ searchParams }: VerificationRequestedPageProps) {
   const email = normalizeEmail(searchParams?.email);
   const heading = getHeading(searchParams?.source);
   const statusMessage = getStatusMessage(searchParams?.delivery, searchParams?.retry_after, email);
+  const signInHref = buildSignInHref(email);
 
   return (
     <section className="auth-wrap">
@@ -109,7 +122,7 @@ export default function VerificationRequestedPage({ searchParams }: Verification
           </PendingFieldset>
         </form>
         <p className="auth-switch">
-          <Link href="/auth/sign-in">Back to sign in</Link>
+          <Link href={signInHref}>Back to sign in</Link>
         </p>
       </article>
     </section>

--- a/app/components/CurrencySelectControl.tsx
+++ b/app/components/CurrencySelectControl.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
+import CurrencyFlag from "react-currency-flags";
+
+import { CURRENCY_OPTIONS } from "@/lib/currencies";
+
+type CurrencySelectControlProps = {
+  name: string;
+  ariaLabel?: string;
+  ariaDescribedBy?: string;
+  className?: string;
+  defaultValue?: string;
+  value?: string;
+  onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
+};
+
+export default function CurrencySelectControl({
+  name,
+  ariaLabel,
+  ariaDescribedBy,
+  className = "dashboard-currency-control",
+  defaultValue = "USD",
+  value,
+  onChange,
+}: CurrencySelectControlProps) {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const selectedCurrency = value ?? uncontrolledValue;
+  const currencyOptions = useMemo(
+    () =>
+      CURRENCY_OPTIONS.includes(selectedCurrency as (typeof CURRENCY_OPTIONS)[number])
+        ? CURRENCY_OPTIONS
+        : [selectedCurrency, ...CURRENCY_OPTIONS],
+    [selectedCurrency],
+  );
+
+  return (
+    <span className={className}>
+      <CurrencyFlag currency={selectedCurrency} width={22} />
+      <select
+        aria-describedby={ariaDescribedBy}
+        aria-label={ariaLabel}
+        name={name}
+        onChange={(event) => {
+          setUncontrolledValue(event.target.value);
+          onChange?.(event);
+        }}
+        value={selectedCurrency}
+      >
+        {currencyOptions.map((currency) => (
+          <option key={currency} value={currency}>
+            {currency}
+          </option>
+        ))}
+      </select>
+    </span>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -376,6 +376,12 @@ a {
   display: block;
 }
 
+.signup-currency-field {
+  width: fit-content;
+  max-width: 100%;
+  justify-self: start;
+}
+
 .dashboard-currency-control {
   display: inline-flex;
   align-items: center;
@@ -912,6 +918,66 @@ button:disabled,
   color: var(--text-muted);
   font-size: 0.9rem;
   font-weight: 600;
+}
+
+.field-label-with-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.help-tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.help-tooltip-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid color-mix(in srgb, var(--text-muted), transparent 28%);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  cursor: help;
+}
+
+.help-tooltip-trigger:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--brand) 72%, #ffffff 28%);
+  outline-offset: 2px;
+}
+
+.help-tooltip-content {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  z-index: 20;
+  width: min(18rem, calc(100vw - 2rem));
+  padding: 0.5rem 0.62rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.18);
+  font-size: 0.82rem;
+  font-weight: 500;
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 0.2rem);
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.help-tooltip:hover .help-tooltip-content,
+.help-tooltip:focus-within .help-tooltip-content {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .form-field input,

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -2,6 +2,7 @@ import { createHmac, randomBytes } from "node:crypto";
 
 import { InviteStatus } from "@prisma/client";
 
+import { normalizeCurrencyCode } from "./currencies";
 import { db } from "./db";
 import { normalizeEnvValue } from "./env";
 import { isValidInviteEmail, normalizeInviteEmail } from "./invite-email";
@@ -220,16 +221,17 @@ export async function issueInvite(params: {
 
 export async function createUserWithInvite(params: {
   email: string;
-  name: string | null;
   passwordHash: string;
   inviteToken: string;
+  defaultCurrency: string;
 }): Promise<InviteRegistrationResult> {
   const email = normalizeInviteEmail(params.email);
   const inviteToken = params.inviteToken.trim();
+  const defaultCurrency = normalizeCurrencyCode(params.defaultCurrency);
 
-  if (!inviteToken) {
+  if (!inviteToken || !defaultCurrency) {
     logInviteEvent("invite_rejected", {
-      reason: "missing_token",
+      reason: inviteToken ? "invalid_default_currency" : "missing_token",
       email,
     });
 
@@ -360,10 +362,11 @@ export async function createUserWithInvite(params: {
     const user = await tx.user.create({
       data: {
         email,
-        name: params.name,
         passwordHash: params.passwordHash,
         settings: {
-          create: {},
+          create: {
+            defaultCurrency,
+          },
         },
       },
       select: {

--- a/tests/invites/invite-flow.test.ts
+++ b/tests/invites/invite-flow.test.ts
@@ -143,9 +143,9 @@ describe("invite flow", () => {
 
       const result = await createUserWithInvite({
         email: mismatchEmail,
-        name: "Mismatch User",
         passwordHash: hashPassword("test-password"),
         inviteToken: issued.inviteToken,
+        defaultCurrency: "USD",
       });
 
       assert.deepEqual(result, {
@@ -198,9 +198,9 @@ describe("invite flow", () => {
 
       const result = await createUserWithInvite({
         email: invitedEmail,
-        name: "Expired Invite",
         passwordHash: hashPassword("test-password"),
         inviteToken: issued.inviteToken,
+        defaultCurrency: "USD",
       });
 
       assert.deepEqual(result, {
@@ -244,16 +244,16 @@ describe("invite flow", () => {
 
       const firstAttempt = createUserWithInvite({
         email: invitedEmail,
-        name: "Parallel One",
         passwordHash: hashPassword("parallel-password"),
         inviteToken: issued.inviteToken,
+        defaultCurrency: "AUD",
       });
 
       const secondAttempt = createUserWithInvite({
         email: invitedEmail,
-        name: "Parallel Two",
         passwordHash: hashPassword("parallel-password"),
         inviteToken: issued.inviteToken,
+        defaultCurrency: "AUD",
       });
 
       const [firstResult, secondResult] = await Promise.all([firstAttempt, secondAttempt]);
@@ -281,10 +281,23 @@ describe("invite flow", () => {
           },
         }),
       ]);
+      const registeredUser = await db.user.findUnique({
+        where: {
+          email: invitedEmail.toLowerCase(),
+        },
+        select: {
+          settings: {
+            select: {
+              defaultCurrency: true,
+            },
+          },
+        },
+      });
 
       assert.equal(usersWithEmail, 1);
       assert.equal(inviteStatus?.status, "CONSUMED");
       assert.ok(inviteStatus?.consumedByUserId);
+      assert.equal(registeredUser?.settings?.defaultCurrency, "AUD");
     });
 
   test("rate limits invite issuance per operator", async () => {


### PR DESCRIPTION
## Summary
- Adds default currency selection to signup and persists it for direct and invite-based account creation.
- Removes the optional name field from signup so the flow stays focused on email, password, and currency.
- Reuses the flag-backed currency selector and preserves email context when routing users to verification or sign-in.

Closes #89

## Test plan
- `npx tsc --noEmit`
- `npm run test:invites`

Note: `npm run typecheck` previously could not complete locally because `prisma generate` hit a Windows file-lock on the Prisma query engine DLL; `tsc --noEmit` passed after that.