### PR TITLE
Reuse flagged currency selector

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -114,7 +114,7 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
               </span>
               <CurrencySelectControl
                 ariaDescribedBy="signup-default-currency-help"
-                className="dashboard-currency-control signup-currency-control"
+                className="signup-currency-control"
                 name="defaultCurrency"
               />
             </label>

--- a/app/components/CurrencySelectControl.tsx
+++ b/app/components/CurrencySelectControl.tsx
@@ -12,6 +12,8 @@ type CurrencySelectControlProps = {
   ariaDescribedBy?: string;
   className?: string;
   defaultValue?: string;
+  fullWidth?: boolean;
+  required?: boolean;
   value?: string;
   onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
 };
@@ -20,13 +22,15 @@ export default function CurrencySelectControl({
   name,
   ariaLabel,
   ariaDescribedBy,
-  className = "dashboard-currency-control",
+  className,
   defaultValue = "USD",
+  fullWidth = false,
+  required = false,
   value,
   onChange,
 }: CurrencySelectControlProps) {
-  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
-  const selectedCurrency = value ?? uncontrolledValue;
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue.trim().toUpperCase());
+  const selectedCurrency = (value ?? uncontrolledValue).trim().toUpperCase() || "USD";
   const currencyOptions = useMemo(
     () =>
       CURRENCY_OPTIONS.includes(selectedCurrency as (typeof CURRENCY_OPTIONS)[number])
@@ -34,18 +38,26 @@ export default function CurrencySelectControl({
         : [selectedCurrency, ...CURRENCY_OPTIONS],
     [selectedCurrency],
   );
+  const controlClassName = [
+    "currency-select-control",
+    fullWidth ? "currency-select-control-full" : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <span className={className}>
+    <span className={controlClassName}>
       <CurrencyFlag currency={selectedCurrency} width={22} />
       <select
         aria-describedby={ariaDescribedBy}
         aria-label={ariaLabel}
         name={name}
         onChange={(event) => {
-          setUncontrolledValue(event.target.value);
+          setUncontrolledValue(event.target.value.trim().toUpperCase());
           onChange?.(event);
         }}
+        required={required}
         value={selectedCurrency}
       >
         {currencyOptions.map((currency) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -382,23 +382,29 @@ a {
   justify-self: start;
 }
 
-.dashboard-currency-control {
+.currency-select-control {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
+  width: fit-content;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--input-bg);
   padding: 0.22rem 0.32rem 0.22rem 0.5rem;
 }
 
-.dashboard-currency-control > span {
+.currency-select-control-full {
+  width: 100%;
+}
+
+.currency-select-control > span {
   border-radius: 3px;
   box-shadow: 0 0 0 1px var(--border);
   flex: 0 0 auto;
 }
 
-.form-field .dashboard-currency-control select {
+.form-field .currency-select-control select {
   width: auto;
   min-width: 4.4rem;
   border: 0;
@@ -410,12 +416,17 @@ a {
   font-weight: 700;
 }
 
-.form-field .dashboard-currency-control select option {
+.form-field .currency-select-control-full select {
+  width: 100%;
+  min-width: 0;
+}
+
+.form-field .currency-select-control select option {
   background: var(--input-bg);
   color: var(--text);
 }
 
-.form-field .dashboard-currency-control select:focus {
+.form-field .currency-select-control select:focus {
   box-shadow: none;
 }
 

--- a/app/settings/SettingsClient.tsx
+++ b/app/settings/SettingsClient.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { DisplayMode } from "@prisma/client";
+import CurrencySelectControl from "@/app/components/CurrencySelectControl";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
-import { CURRENCY_OPTIONS } from "@/lib/currencies";
 
 type ResultMessage = {
   type: "error" | "success";
@@ -52,13 +52,6 @@ export default function SettingsClient({
   const [remindersEnabled, setRemindersEnabled] = useState(initialRemindersEnabled);
   const [reminderDaysBefore, setReminderDaysBefore] = useState(initialReminderDaysBefore);
   const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
-  const currencyOptions = useMemo(() => {
-    if (CURRENCY_OPTIONS.some((currency) => currency === initialDefaultCurrency)) {
-      return CURRENCY_OPTIONS;
-    }
-
-    return [initialDefaultCurrency, ...CURRENCY_OPTIONS];
-  }, [initialDefaultCurrency]);
 
   const setReminderDays = (rawValue: string | number): void => {
     const parsed = Number(rawValue);
@@ -177,20 +170,14 @@ export default function SettingsClient({
             <PendingFieldset className="form-pending-group">
               <label className="form-field setting-field">
                 Currency
-                <select
+                <CurrencySelectControl
                   name="defaultCurrency"
                   onChange={(event) => {
                     setDefaultCurrency(event.target.value);
                     event.currentTarget.form?.requestSubmit();
                   }}
                   value={defaultCurrency}
-                >
-                  {currencyOptions.map((currency) => (
-                    <option key={currency} value={currency}>
-                      {currency}
-                    </option>
-                  ))}
-                </select>
+                />
               </label>
             </PendingFieldset>
           </form>

--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
+import CurrencySelectControl from "@/app/components/CurrencySelectControl";
 import SubscriptionDetailsModal from "@/app/components/SubscriptionDetailsModal";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
 import { useSubscriptionDetailsModal } from "@/app/components/useSubscriptionDetailsModal";
@@ -566,7 +567,7 @@ export default function SubscriptionsClient({
                   </label>
                   <label className="form-field">
                     Currency
-                    <input defaultValue="USD" maxLength={3} minLength={3} name="currency" required type="text" />
+                    <CurrencySelectControl name="currency" required />
                   </label>
                 </div>
                 <div className="split-grid">
@@ -689,14 +690,7 @@ export default function SubscriptionsClient({
                   </label>
                   <label className="form-field">
                     Currency
-                    <input
-                      defaultValue={editingSubscription.currency}
-                      maxLength={3}
-                      minLength={3}
-                      name="currency"
-                      required
-                      type="text"
-                    />
+                    <CurrencySelectControl defaultValue={editingSubscription.currency} name="currency" required />
                   </label>
                 </div>
                 <div className="split-grid">


### PR DESCRIPTION
## Summary
- Reuse the flagged currency selector in subscription add/edit forms and settings default currency.
- Generalize the selector styling/API with compact-by-default sizing, optional `fullWidth`, `required`, and additive `className` support.
- Remove duplicated currency option rendering from settings.

## Test plan
- `npm run lint`
- `npx tsc --noEmit`
- User-tested currency selector UI in the app.

Closes #91