### PR TITLE
Redirect expired sessions to sign in

### DIFF
--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -9,6 +9,7 @@ import {
   INITIAL_DASHBOARD_REQUEST_STATE,
   reduceDashboardRequestState,
 } from "@/lib/dashboard-view-state";
+import { isSessionExpiredRedirectError, redirectOnUnauthorized } from "@/app/components/session-expiry";
 
 type DashboardApiResponse = {
   data?: DashboardPayload;
@@ -38,6 +39,8 @@ async function loadDashboardPayload(signal?: AbortSignal): Promise<DashboardPayl
     parsedResponse = null;
   }
 
+  redirectOnUnauthorized(response);
+
   if (!response.ok) {
     const statusMessage = `Dashboard request failed with status ${response.status}.`;
     throw new Error(parsedResponse?.error || statusMessage);
@@ -66,6 +69,10 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
       );
     } catch (error) {
       if (signal?.aborted) {
+        return;
+      }
+
+      if (isSessionExpiredRedirectError(error)) {
         return;
       }
 

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 
 import { signInAction } from "@/app/auth/actions";
 import { PendingFieldset, PendingSubmitButton } from "@/app/components/PendingFormControls";
+import { getSignInErrorMessage } from "@/lib/auth-errors";
 import { getCurrentUser } from "@/lib/auth";
 
 type SignInPageProps = {
@@ -12,40 +13,6 @@ type SignInPageProps = {
     retry_after?: string;
   };
 };
-
-function getErrorMessage(errorCode?: string, retryAfter?: string): string | null {
-  if (!errorCode) {
-    return null;
-  }
-
-  if (errorCode === "missing_fields") {
-    return "Enter both email and password.";
-  }
-
-  if (errorCode === "invalid_credentials") {
-    return "Invalid email or password.";
-  }
-
-  if (errorCode === "invalid_request") {
-    return "Invalid sign-in request. Please try again.";
-  }
-
-  if (errorCode === "account_exists") {
-    return "An account already exists for that email. Sign in instead.";
-  }
-
-  if (errorCode === "rate_limited") {
-    const seconds = Number(retryAfter ?? "0");
-
-    if (!Number.isFinite(seconds) || seconds <= 0) {
-      return "Too many sign-in attempts. Please wait and try again.";
-    }
-
-    return `Too many sign-in attempts. Try again in ${seconds} seconds.`;
-  }
-
-  return "Unable to sign in.";
-}
 
 function normalizeEmail(value: string | undefined): string {
   return String(value ?? "").trim().toLowerCase();
@@ -58,7 +25,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
     redirect("/");
   }
 
-  const errorMessage = getErrorMessage(searchParams?.error, searchParams?.retry_after);
+  const errorMessage = getSignInErrorMessage(searchParams?.error, searchParams?.retry_after);
   const emailPrefill = normalizeEmail(searchParams?.email);
 
   return (

--- a/app/components/session-expiry.ts
+++ b/app/components/session-expiry.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { SESSION_EXPIRED_ERROR_CODE } from "@/lib/auth-errors";
+
+export const SESSION_EXPIRED_SIGN_IN_PATH = `/auth/sign-in?error=${SESSION_EXPIRED_ERROR_CODE}`;
+
+export class SessionExpiredRedirectError extends Error {
+  constructor() {
+    super("Session expired.");
+    this.name = "SessionExpiredRedirectError";
+  }
+}
+
+export function isSessionExpiredRedirectError(error: unknown): error is SessionExpiredRedirectError {
+  return error instanceof SessionExpiredRedirectError;
+}
+
+export function redirectToSessionExpiredSignIn(): never {
+  window.location.assign(SESSION_EXPIRED_SIGN_IN_PATH);
+  throw new SessionExpiredRedirectError();
+}
+
+export function redirectOnUnauthorized(response: Response): void {
+  if (response.status === 401) {
+    redirectToSessionExpiredSignIn();
+  }
+}

--- a/app/components/useSubscriptionDetailsModal.ts
+++ b/app/components/useSubscriptionDetailsModal.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { isSessionExpiredRedirectError, redirectOnUnauthorized } from "@/app/components/session-expiry";
 import { trackTelemetryEvent } from "@/app/components/telemetry";
 import type {
   SubscriptionDetailsActionCapability,
@@ -86,6 +87,8 @@ export function useSubscriptionDetailsModal() {
         return;
       }
 
+      redirectOnUnauthorized(response);
+
       if (!response.ok) {
         setFetchState("error");
         setErrorMessage("Could not load subscription details.");
@@ -103,6 +106,10 @@ export function useSubscriptionDetailsModal() {
       setFetchState("ready");
     } catch (error) {
       if (controller.signal.aborted) {
+        return;
+      }
+
+      if (isSessionExpiredRedirectError(error)) {
         return;
       }
 
@@ -157,6 +164,8 @@ export function useSubscriptionDetailsModal() {
 
         const payload = (await response.json().catch(() => ({}))) as DetailsResponsePayload;
 
+        redirectOnUnauthorized(response);
+
         if (payload.data) {
           setDetails(payload.data);
           setFetchState("ready");
@@ -177,6 +186,10 @@ export function useSubscriptionDetailsModal() {
         router.refresh();
         return true;
       } catch (error) {
+        if (isSessionExpiredRedirectError(error)) {
+          return false;
+        }
+
         setActionMessage({
           type: "error",
           text: error instanceof Error ? error.message : "Could not update this subscription.",

--- a/app/tools/TestEmailCard.tsx
+++ b/app/tools/TestEmailCard.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { isSessionExpiredRedirectError, redirectOnUnauthorized } from "@/app/components/session-expiry";
+
 type TestEmailCardProps = {
   emailConfigured: boolean;
 };
@@ -33,6 +35,8 @@ export default function TestEmailCard({ emailConfigured }: TestEmailCardProps): 
         ? ((await response.json().catch(() => null)) as SendTestEmailResponse | null)
         : null;
 
+      redirectOnUnauthorized(response);
+
       if (!response.ok || !data?.success) {
         setSendState({
           status: "error",
@@ -47,7 +51,11 @@ export default function TestEmailCard({ emailConfigured }: TestEmailCardProps): 
           ? `Test email queued. Message ID: ${data.messageId}. Check inbox/spam.`
           : "Test email queued. Check inbox/spam.",
       });
-    } catch {
+    } catch (error) {
+      if (isSessionExpiredRedirectError(error)) {
+        return;
+      }
+
       setSendState({
         status: "error",
         message: "Network error while sending test email.",

--- a/lib/auth-errors.ts
+++ b/lib/auth-errors.ts
@@ -1,0 +1,39 @@
+export const SESSION_EXPIRED_ERROR_CODE = "session_expired";
+
+export function getSignInErrorMessage(errorCode?: string, retryAfter?: string): string | null {
+  if (!errorCode) {
+    return null;
+  }
+
+  if (errorCode === "missing_fields") {
+    return "Enter both email and password.";
+  }
+
+  if (errorCode === "invalid_credentials") {
+    return "Invalid email or password.";
+  }
+
+  if (errorCode === "invalid_request") {
+    return "Invalid sign-in request. Please try again.";
+  }
+
+  if (errorCode === "account_exists") {
+    return "An account already exists for that email. Sign in instead.";
+  }
+
+  if (errorCode === SESSION_EXPIRED_ERROR_CODE) {
+    return "Your session has expired. Please sign in again.";
+  }
+
+  if (errorCode === "rate_limited") {
+    const seconds = Number(retryAfter ?? "0");
+
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return "Too many sign-in attempts. Please wait and try again.";
+    }
+
+    return `Too many sign-in attempts. Try again in ${seconds} seconds.`;
+  }
+
+  return "Unable to sign in.";
+}

--- a/tests/auth/session-expiry-redirect.test.ts
+++ b/tests/auth/session-expiry-redirect.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  isSessionExpiredRedirectError,
+  redirectOnUnauthorized,
+  SESSION_EXPIRED_SIGN_IN_PATH,
+  SessionExpiredRedirectError,
+} from "../../app/components/session-expiry";
+import { getSignInErrorMessage, SESSION_EXPIRED_ERROR_CODE } from "../../lib/auth-errors";
+
+describe("session expiry redirect", () => {
+  test("redirects unauthorized client responses to sign-in with session-expired error", () => {
+    const originalWindow = globalThis.window;
+    const assignedPaths: string[] = [];
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        location: {
+          assign: (path: string) => {
+            assignedPaths.push(path);
+          },
+        },
+      },
+    });
+
+    try {
+      assert.throws(
+        () => redirectOnUnauthorized(new Response(null, { status: 401 })),
+        (error: unknown) => error instanceof SessionExpiredRedirectError && isSessionExpiredRedirectError(error),
+      );
+      assert.deepEqual(assignedPaths, [SESSION_EXPIRED_SIGN_IN_PATH]);
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+
+  test("does not redirect successful client responses", () => {
+    assert.doesNotThrow(() => redirectOnUnauthorized(new Response(null, { status: 200 })));
+  });
+
+  test("maps the session-expired sign-in error to user-facing copy", () => {
+    assert.equal(
+      getSignInErrorMessage(SESSION_EXPIRED_ERROR_CODE),
+      "Your session has expired. Please sign in again.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Redirect authenticated client-side API 401s to sign-in with `error=session_expired`.
- Add shared sign-in error mapping so expired sessions show clear copy.
- Cover the redirect helper and session-expired message with focused tests.

Closes #93.

## Test plan
- `npm run lint`
- `npx dotenv -e .env.local -- node --import tsx --test tests/auth/session-expiry-redirect.test.ts`
- `npm run test:dashboard`
- `npx tsc --noEmit`

Note: `npm run typecheck` could not complete because `prisma generate` hit a Windows `EPERM` file lock on the Prisma query engine while the dev server was running; the direct TypeScript compiler check passed.