### PR TITLE
Build subscription management lifecycle panel

### DIFF
--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -222,6 +222,19 @@ function isExternalHref(value: string): boolean {
   return value.startsWith("http://") || value.startsWith("https://");
 }
 
+function formatExternalHrefLabel(value: string | null): string {
+  if (!value) {
+    return "Not captured";
+  }
+
+  try {
+    const url = new URL(value);
+    return url.hostname.replace(/^www\./, "");
+  } catch {
+    return "Invalid URL";
+  }
+}
+
 function pendingActionLabel(actionKey: SubscriptionDetailsMutationAction): string {
   if (actionKey === "mark_cancelled") {
     return "Marking...";
@@ -371,17 +384,37 @@ export default function SubscriptionDetailsModal({
   const reviewState = details?.v2.lifecycle.reviewState ?? null;
   const editAction = details ? getActionByKey(details.v2.actionBar.header, "edit_subscription") : null;
   const markCancelledAction = details ? getActionByKey(details.v2.actionBar.header, "mark_cancelled") : null;
+  const markForReviewAction = details ? getActionByKey(details.v2.actionBar.quickActions, "mark_for_review") : null;
+  const openManagementAction = details ? getActionByKey(details.v2.actionBar.quickActions, "open_management_page") : null;
+  const cancelSoonAction = details ? getActionByKey(details.v2.actionBar.quickActions, "cancel_soon") : null;
   const editActionState = resolveActionState(editAction, "Edit", "Edit controls are unavailable from this view.");
   const markCancelledActionState = resolveActionState(
     markCancelledAction,
     "Mark Cancelled",
     "Cancellation controls are unavailable from this view.",
   );
+  const markForReviewActionState = resolveActionState(
+    markForReviewAction,
+    "Mark for review",
+    "Review controls are unavailable from this view.",
+  );
+  const openManagementActionState = resolveActionState(
+    openManagementAction,
+    "Open management page",
+    "Management page is unavailable for this subscription.",
+  );
+  const cancelSoonActionState = resolveActionState(
+    cancelSoonAction,
+    "Cancel soon",
+    "Provider cancellation flow is unavailable for this subscription.",
+  );
   const editUnavailableReason =
     editActionState.unavailableReason ??
     (onEditSubscription ? null : "Open this subscription from the subscriptions page to edit it.");
   const markCancelledUnavailableReason =
     markCancelledActionState.unavailableReason ?? (onRunMutationAction ? null : "Cancellation controls are unavailable.");
+  const markForReviewUnavailableReason =
+    markForReviewActionState.unavailableReason ?? (onRunMutationAction ? null : "Review controls are unavailable.");
   const lifecycleActionHint = details && !onEditSubscription ? "Open this subscription from the subscriptions page to edit it." : null;
   const isMutationPending = pendingActionKey !== null;
 
@@ -750,8 +783,18 @@ export default function SubscriptionDetailsModal({
             </div>
 
             <div className="details-card-grid">
-              <article className="surface details-section">
-                <h3>Plan and Lifecycle</h3>
+              <article className="surface details-section details-lifecycle-panel">
+                <div className="details-section-heading">
+                  <div className="stack">
+                    <h3>Lifecycle Controls</h3>
+                    <p className="text-muted details-card-caption">
+                      Review billing state, mark follow-up work, or record a completed cancellation.
+                    </p>
+                  </div>
+                  <div className="inline-actions details-tag-list" aria-label="Lifecycle state">
+                    {details.v2.lifecycle.chips.map((chip) => renderHeaderChip(chip))}
+                  </div>
+                </div>
                 <dl className="details-definition-list">
                   <div>
                     <dt>Plan / tier</dt>
@@ -770,22 +813,62 @@ export default function SubscriptionDetailsModal({
                     <dd>{details.autoRenew ? "On" : "Off"}</dd>
                   </div>
                   <div>
+                    <dt>Review state</dt>
+                    <dd>{reviewState?.isMarked ? "Marked for review" : "Not marked for review"}</dd>
+                  </div>
+                  <div>
                     <dt>Cancellation details</dt>
                     <dd>{details.cancellationReason ?? (details.status === "CANCELED" ? "Cancellation recorded" : "None")}</dd>
                   </div>
                 </dl>
+
+                {reviewState && !reviewState.canPersist && reviewState.unavailableReason ? (
+                  <p className="text-muted details-card-caption">{reviewState.unavailableReason}</p>
+                ) : null}
+
+                <div aria-busy={isMutationPending} className="details-lifecycle-actions">
+                  <button
+                    className="button button-secondary button-small"
+                    disabled={markForReviewActionState.disabled || !onRunMutationAction || isMutationPending}
+                    onClick={() => {
+                      if (markForReviewAction) {
+                        void handleActionClick(markForReviewAction);
+                      }
+                    }}
+                    title={markForReviewUnavailableReason ?? undefined}
+                    type="button"
+                  >
+                    {pendingActionKey === "mark_for_review"
+                      ? pendingActionLabel("mark_for_review")
+                      : markForReviewActionState.label}
+                  </button>
+                  <button
+                    className="button-danger button-small"
+                    disabled={markCancelledActionState.disabled || !onRunMutationAction || isMutationPending}
+                    onClick={() => {
+                      if (markCancelledAction) {
+                        void handleActionClick(markCancelledAction);
+                      }
+                    }}
+                    title={markCancelledUnavailableReason ?? undefined}
+                    type="button"
+                  >
+                    {pendingActionKey === "mark_cancelled"
+                      ? pendingActionLabel("mark_cancelled")
+                      : markCancelledActionState.label}
+                  </button>
+                </div>
               </article>
 
-              <article className="surface details-section">
+              <article className="surface details-section details-management-panel">
                 <div className="details-section-heading">
-                  <h3>Account References</h3>
-                  <div className="inline-actions details-tag-list" aria-label="Subscription metadata tags">
-                    {details.metadataTags.map((tag) => (
-                      <span className="pill" key={tag}>
-                        {tag}
-                      </span>
-                    ))}
+                  <div className="stack">
+                    <h3>Management</h3>
+                    <p className="text-muted details-card-caption">
+                      Provider links are shown only when they resolve to a valid http or https URL.
+                    </p>
                   </div>
+                  <span className="pill">{details.v2.management.providerDisplayName}</span>
                 </div>
                 <dl className="details-definition-list">
                   <div>
@@ -798,13 +881,55 @@ export default function SubscriptionDetailsModal({
                   </div>
                   <div>
                     <dt>Billing console URL</dt>
-                    <dd>{details.links.billingConsoleUrl ?? "Not captured"}</dd>
+                    <dd>{formatExternalHrefLabel(details.links.billingConsoleUrl)}</dd>
                   </div>
                   <div>
                     <dt>Cancel URL</dt>
-                    <dd>{details.links.cancelSubscriptionUrl ?? "Not captured"}</dd>
+                    <dd>{formatExternalHrefLabel(details.links.cancelSubscriptionUrl)}</dd>
                   </div>
                 </dl>
+
+                <div className="details-management-actions" role="group" aria-label="Provider management actions">
+                  <button
+                    className="button button-secondary button-small"
+                    disabled={openManagementActionState.disabled}
+                    onClick={() => {
+                      if (openManagementAction) {
+                        void handleActionClick(openManagementAction);
+                      }
+                    }}
+                    title={openManagementActionState.unavailableReason ?? undefined}
+                    type="button"
+                  >
+                    {openManagementActionState.label}
+                  </button>
+                  <button
+                    className="button button-secondary button-small"
+                    disabled={cancelSoonActionState.disabled}
+                    onClick={() => {
+                      if (cancelSoonAction) {
+                        void handleActionClick(cancelSoonAction);
+                      }
+                    }}
+                    title={cancelSoonActionState.unavailableReason ?? undefined}
+                    type="button"
+                  >
+                    {cancelSoonActionState.label}
+                  </button>
+                  <button
+                    className="button button-secondary button-small"
+                    disabled={historyAction?.availability !== "enabled"}
+                    onClick={() => {
+                      if (historyAction) {
+                        void handleActionClick(historyAction);
+                      }
+                    }}
+                    title={historyAction?.availability === "disabled" ? historyAction.unavailableReason ?? undefined : undefined}
+                    type="button"
+                  >
+                    {historyAction?.label ?? "View billing history"}
+                  </button>
+                </div>
               </article>
             </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1845,6 +1845,22 @@ button:disabled,
   margin: 0;
 }
 
+.details-lifecycle-panel,
+.details-management-panel {
+  align-content: start;
+}
+
+.details-lifecycle-actions,
+.details-management-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.details-management-actions {
+  padding-top: 0.1rem;
+}
+
 .details-definition-list {
   display: grid;
   gap: 0.45rem;

--- a/lib/subscription-details.ts
+++ b/lib/subscription-details.ts
@@ -404,6 +404,27 @@ function formatDateForCopy(value: Date): string {
   }).format(value);
 }
 
+function normalizeExternalUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function externalUrlUnavailableReason(value: string | null | undefined, label: string): string {
+  return value?.trim()
+    ? `${label} URL must start with http:// or https://.`
+    : `No ${label.toLowerCase()} URL is stored for this subscription.`;
+}
+
 function formatPositiveDeltaForCopy(currentAmountCents: number, projectedAmountCents: number, currency: string): string {
   return formatCurrencyForCopy(Math.max(0, projectedAmountCents - currentAmountCents), currency);
 }
@@ -778,7 +799,7 @@ function buildActionBar(
       placement: "quick_actions",
       kind: "navigate",
       availability: links.billingConsoleUrl ? "enabled" : "disabled",
-      unavailableReason: links.billingConsoleUrl ? null : "No management URL is stored for this subscription.",
+      unavailableReason: links.billingConsoleUrl ? null : externalUrlUnavailableReason(record.billingConsoleUrl, "Management"),
       href: links.billingConsoleUrl,
       permission: "owner_read",
       requiresConfirmation: false,
@@ -840,9 +861,9 @@ function buildActionBar(
       unavailableReason:
         record.isActive && links.cancelSubscriptionUrl
           ? null
-          : record.isActive
-            ? "No cancellation URL is stored for this subscription."
-            : "Inactive subscriptions cannot start a new cancel flow.",
+          : !record.isActive
+            ? "Inactive subscriptions cannot start a new cancel flow."
+            : externalUrlUnavailableReason(record.cancelSubscriptionUrl, "Cancellation"),
       href: record.isActive ? links.cancelSubscriptionUrl : null,
       permission: "owner_write",
       requiresConfirmation: true,
@@ -861,7 +882,7 @@ function buildActionBar(
       placement: "footer",
       kind: "navigate",
       availability: links.billingHistoryUrl ? "enabled" : "disabled",
-      unavailableReason: links.billingHistoryUrl ? null : "No billing-history URL is stored for this subscription.",
+      unavailableReason: links.billingHistoryUrl ? null : externalUrlUnavailableReason(record.billingHistoryUrl, "Billing-history"),
       href: links.billingHistoryUrl,
       permission: "owner_read",
       requiresConfirmation: false,
@@ -901,9 +922,9 @@ export function buildSubscriptionDetails(
   const metadataTags = buildMetadataTags(record, stage);
   const timeline = buildTimeline(record);
   const links = {
-    billingConsoleUrl: record.billingConsoleUrl,
-    cancelSubscriptionUrl: record.cancelSubscriptionUrl,
-    billingHistoryUrl: record.billingHistoryUrl,
+    billingConsoleUrl: normalizeExternalUrl(record.billingConsoleUrl),
+    cancelSubscriptionUrl: normalizeExternalUrl(record.cancelSubscriptionUrl),
+    billingHistoryUrl: normalizeExternalUrl(record.billingHistoryUrl),
   };
   const internalIdentifiers = {
     subscriptionId: record.id,

--- a/tests/subscription-details/build-subscription-details.test.ts
+++ b/tests/subscription-details/build-subscription-details.test.ts
@@ -106,6 +106,30 @@ describe("buildSubscriptionDetails", () => {
     assert.equal(details.v2.actionBar.quickActions.find((action) => action.key === "cancel_soon")?.requiresConfirmation, true);
   });
 
+  test("normalizes provider management links to safe external URLs", () => {
+    const details = buildSubscriptionDetails(
+      makeRecord({
+        id: "unsafe-links",
+        name: "Unsafe Provider",
+        billingConsoleUrl: "javascript:alert(1)",
+        cancelSubscriptionUrl: " https://example.com/cancel-now ",
+        billingHistoryUrl: "ftp://example.com/history",
+      }),
+    );
+
+    const openManagementAction = details.v2.actionBar.quickActions.find((action) => action.key === "open_management_page");
+    const cancelSoonAction = details.v2.actionBar.quickActions.find((action) => action.key === "cancel_soon");
+    const historyAction = details.v2.actionBar.footer.find((action) => action.key === "view_billing_history");
+
+    assert.equal(details.links.billingConsoleUrl, null);
+    assert.equal(details.links.cancelSubscriptionUrl, "https://example.com/cancel-now");
+    assert.equal(details.links.billingHistoryUrl, null);
+    assert.equal(openManagementAction?.availability, "disabled");
+    assert.match(openManagementAction?.unavailableReason ?? "", /must start with http/);
+    assert.equal(cancelSoonAction?.availability, "enabled");
+    assert.equal(historyAction?.availability, "disabled");
+  });
+
   test("derives cancel-scheduled lifecycle and disables cancel actions for inactive subscriptions", () => {
     const details = buildSubscriptionDetails(
       makeRecord({

--- a/tests/subscription-details/subscription-details-modal.test.tsx
+++ b/tests/subscription-details/subscription-details-modal.test.tsx
@@ -72,6 +72,9 @@ describe("SubscriptionDetailsModal attention panel", () => {
     assert.match(html, /Open management page/);
     assert.match(html, /Change alert/);
     assert.match(html, /Cancel soon/);
+    assert.match(html, /Lifecycle Controls/);
+    assert.match(html, /Management/);
+    assert.match(html, /example\.com/);
   });
 
   test("renders an empty state when no alerts are active", () => {
@@ -86,5 +89,24 @@ describe("SubscriptionDetailsModal attention panel", () => {
     assert.match(html, /Attention Needed/);
     assert.match(html, /Not marked for review/);
     assert.match(html, /No promo or price-change alerts are active for this subscription\./);
+  });
+
+  test("keeps invalid management URLs out of rendered provider actions", () => {
+    const html = renderModalHtml(
+      makeRecord({
+        id: "invalid-management-links",
+        name: "Unsafe Provider",
+        billingConsoleUrl: "javascript:alert(1)",
+        cancelSubscriptionUrl: null,
+        billingHistoryUrl: "ftp://example.com/history",
+        markedForReview: false,
+      }),
+    );
+
+    assert.match(html, /Management/);
+    assert.doesNotMatch(html, /javascript:alert/);
+    assert.doesNotMatch(html, /ftp:\/\/example\.com/);
+    assert.match(html, /Not captured/);
+    assert.match(html, /Management URL must start with http:\/\/ or https:\/\/\./);
   });
 });


### PR DESCRIPTION
## Summary
- Add a dedicated lifecycle controls panel to the subscription details modal for review state, cancellation state, and lifecycle mutations.
- Add a management panel for provider identity, account references, and provider navigation actions.
- Normalize provider management URLs to http/https before exposing links, with disabled-state copy for missing or invalid URLs.

## Test plan
- `node --import tsx --test tests/subscription-details/*.test.ts tests/subscription-details/*.test.tsx`
- `npx tsc --noEmit`

Closes #46