### PR TITLE
Harden subscription details modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ When the user asks for a task to be done, follow this sequence:
 3. If the user did not explicitly request execution now, confirm intent before coding:
    - ask whether they want backlog-only issue creation, or
    - immediate implementation.
-4. For implementation requests, create a dedicated branch before making code changes.
+4. For implementation requests, ensure the local codebase is up to date and create a dedicated branch before making code changes.
 5. Implement the fix.
 6. Commit the changes and push/publish the branch to remote.
 7. Check for an outstanding pull request that can reasonably include the request; if one exists, add changes there instead of creating a new PR.

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -1070,6 +1070,7 @@ export default function DashboardSectionsClient({
         isOpen={detailsModal.isOpen}
         loadState={detailsModal.fetchState}
         onClose={detailsModal.closeModal}
+        onRetry={detailsModal.retryLoad}
         onRunMutationAction={detailsModal.runMutationAction}
         onViewFullHistoryClick={detailsModal.trackViewFullHistory}
         pendingActionKey={detailsModal.pendingActionKey}

--- a/app/api/telemetry/route.ts
+++ b/app/api/telemetry/route.ts
@@ -9,13 +9,23 @@ export const revalidate = 0;
 type TelemetryEventName =
   | "subscription_details_modal_open"
   | "subscription_details_modal_close"
-  | "subscription_details_view_full_history";
+  | "subscription_details_view_full_history"
+  | "subscription_details_fetch_empty"
+  | "subscription_details_fetch_error"
+  | "subscription_details_edit_click"
+  | "subscription_details_copy_id"
+  | "subscription_details_quick_action_click"
+  | "subscription_details_cancel_flow_start"
+  | "subscription_details_cancel_flow_complete"
+  | "subscription_details_mutation_result";
 
 type TelemetryPayload = {
   eventName: TelemetryEventName;
   subscriptionId: string;
   source: SubscriptionModalOpenSource;
   closeReason?: SubscriptionModalCloseReason;
+  action?: string;
+  outcome?: "success" | "failure";
   createdAt?: string;
 };
 
@@ -23,11 +33,21 @@ const EVENT_NAMES: TelemetryEventName[] = [
   "subscription_details_modal_open",
   "subscription_details_modal_close",
   "subscription_details_view_full_history",
+  "subscription_details_fetch_empty",
+  "subscription_details_fetch_error",
+  "subscription_details_edit_click",
+  "subscription_details_copy_id",
+  "subscription_details_quick_action_click",
+  "subscription_details_cancel_flow_start",
+  "subscription_details_cancel_flow_complete",
+  "subscription_details_mutation_result",
 ];
 
 const SOURCES: SubscriptionModalOpenSource[] = ["upcoming_charges", "subscriptions_list"];
 
 const CLOSE_REASONS: SubscriptionModalCloseReason[] = ["backdrop", "escape_key", "close_button", "unknown"];
+
+const OUTCOMES = ["success", "failure"] as const;
 
 function isTelemetryEventName(value: unknown): value is TelemetryEventName {
   return typeof value === "string" && EVENT_NAMES.includes(value as TelemetryEventName);
@@ -39,6 +59,10 @@ function isSource(value: unknown): value is SubscriptionModalOpenSource {
 
 function isCloseReason(value: unknown): value is SubscriptionModalCloseReason {
   return typeof value === "string" && CLOSE_REASONS.includes(value as SubscriptionModalCloseReason);
+}
+
+function isOutcome(value: unknown): value is TelemetryPayload["outcome"] {
+  return typeof value === "string" && OUTCOMES.includes(value as (typeof OUTCOMES)[number]);
 }
 
 export async function POST(request: Request) {
@@ -64,6 +88,14 @@ export async function POST(request: Request) {
 
   if (payload.closeReason && !isCloseReason(payload.closeReason)) {
     return NextResponse.json({ error: "Unknown close reason." }, { status: 400 });
+  }
+
+  if (payload.action && typeof payload.action !== "string") {
+    return NextResponse.json({ error: "Invalid telemetry action." }, { status: 400 });
+  }
+
+  if (payload.outcome && !isOutcome(payload.outcome)) {
+    return NextResponse.json({ error: "Unknown telemetry outcome." }, { status: 400 });
   }
 
   console.info("[telemetry]", JSON.stringify({ ...payload, receivedAt: new Date().toISOString() }));

--- a/app/components/SubscriptionDetailsModal.tsx
+++ b/app/components/SubscriptionDetailsModal.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { trackTelemetryEvent } from "@/app/components/telemetry";
 import type {
   SubscriptionDetailsActionCapability,
   SubscriptionDetailsAlertItem,
@@ -34,6 +35,7 @@ type SubscriptionDetailsModalProps = {
   actionMessage?: SubscriptionDetailsModalActionMessage | null;
   pendingActionKey?: SubscriptionDetailsMutationAction | null;
   onClose: (reason: SubscriptionModalCloseReason) => void;
+  onRetry?: (() => void) | null;
   onViewFullHistoryClick: () => void;
   onEditSubscription?: ((subscriptionId: string) => void) | null;
   onRunMutationAction?: ((actionKey: SubscriptionDetailsMutationAction) => Promise<boolean>) | null;
@@ -291,6 +293,7 @@ export default function SubscriptionDetailsModal({
   actionMessage = null,
   pendingActionKey = null,
   onClose,
+  onRetry = null,
   onViewFullHistoryClick,
   onEditSubscription = null,
   onRunMutationAction = null,
@@ -418,6 +421,27 @@ export default function SubscriptionDetailsModal({
   const lifecycleActionHint = details && !onEditSubscription ? "Open this subscription from the subscriptions page to edit it." : null;
   const isMutationPending = pendingActionKey !== null;
 
+  function trackDetailsTelemetry(
+    eventName:
+      | "subscription_details_edit_click"
+      | "subscription_details_copy_id"
+      | "subscription_details_quick_action_click"
+      | "subscription_details_cancel_flow_start"
+      | "subscription_details_cancel_flow_complete",
+    action?: string,
+  ): void {
+    if (!details || !source) {
+      return;
+    }
+
+    trackTelemetryEvent({
+      action,
+      eventName,
+      source,
+      subscriptionId: details.id,
+    });
+  }
+
   async function handleCopySubscriptionId(): Promise<void> {
     if (!details) {
       return;
@@ -426,8 +450,10 @@ export default function SubscriptionDetailsModal({
     try {
       await navigator.clipboard.writeText(details.id);
       setCopyMessage("Subscription ID copied.");
+      trackDetailsTelemetry("subscription_details_copy_id", "copy_subscription_id");
     } catch {
       setCopyMessage("Could not copy subscription ID.");
+      trackDetailsTelemetry("subscription_details_copy_id", "copy_subscription_id");
     }
   }
 
@@ -437,12 +463,18 @@ export default function SubscriptionDetailsModal({
     }
 
     if (action.requiresConfirmation) {
+      if (action.key === "cancel_soon") {
+        trackDetailsTelemetry("subscription_details_cancel_flow_start", action.key);
+      }
+
       const confirmed = window.confirm(action.confirmationLabel ?? `Continue with ${action.label.toLowerCase()}?`);
 
       if (!confirmed) {
         return;
       }
     }
+
+    trackDetailsTelemetry("subscription_details_quick_action_click", action.key);
 
     if (action.kind === "mutate") {
       if (!onRunMutationAction || (action.key !== "mark_cancelled" && action.key !== "mark_for_review")) {
@@ -459,6 +491,10 @@ export default function SubscriptionDetailsModal({
       }
 
       if (isExternalHref(action.href)) {
+        if (action.key === "cancel_soon") {
+          trackDetailsTelemetry("subscription_details_cancel_flow_complete", action.key);
+        }
+
         window.open(action.href, "_blank", "noopener,noreferrer");
         return;
       }
@@ -469,6 +505,7 @@ export default function SubscriptionDetailsModal({
     }
 
     if (action.key === "edit_subscription" && onEditSubscription) {
+      trackDetailsTelemetry("subscription_details_edit_click", action.key);
       onEditSubscription(details.id);
     }
   }
@@ -479,6 +516,8 @@ export default function SubscriptionDetailsModal({
 
   return (
     <div
+      aria-describedby="subscription-details-description"
+      aria-labelledby="subscription-details-title"
       aria-modal="true"
       className="modal-backdrop"
       onMouseDown={() => onClose("backdrop")}
@@ -487,7 +526,9 @@ export default function SubscriptionDetailsModal({
       <article className="modal-panel details-modal-panel" onMouseDown={(event) => event.stopPropagation()} ref={panelRef}>
         <header className="modal-header details-modal-header">
           <div className="stack">
-            <p className="eyebrow">{sourceLabel(source)}</p>
+            <p className="eyebrow" id="subscription-details-description">
+              {sourceLabel(source)}
+            </p>
             <h2 id="subscription-details-title">Subscription Details</h2>
           </div>
           <button
@@ -501,7 +542,8 @@ export default function SubscriptionDetailsModal({
         </header>
 
         {loadState === "loading" ? (
-          <div className="details-skeleton" aria-live="polite">
+          <div className="details-skeleton" aria-busy="true" aria-live="polite" role="status">
+            <p className="sr-only">Loading subscription details.</p>
             <div className="details-skeleton-line details-skeleton-line-lg" />
             <div className="details-skeleton-line" />
             <div className="details-skeleton-line" />
@@ -510,9 +552,14 @@ export default function SubscriptionDetailsModal({
         ) : null}
 
         {loadState === "error" ? (
-          <p className="status-error" aria-live="polite">
-            {errorMessage ?? "Could not load subscription details."}
-          </p>
+          <div className="details-status-block" aria-live="polite" role="status">
+            <p className="status-error">{errorMessage ?? "Could not load subscription details."}</p>
+            {onRetry ? (
+              <button className="button button-secondary button-small" onClick={onRetry} type="button">
+                Retry
+              </button>
+            ) : null}
+          </div>
         ) : null}
 
         {loadState === "empty" ? (
@@ -547,6 +594,7 @@ export default function SubscriptionDetailsModal({
                       disabled={editActionState.disabled || !onEditSubscription}
                       onClick={() => {
                         if (onEditSubscription) {
+                          trackDetailsTelemetry("subscription_details_edit_click", "edit_subscription");
                           onEditSubscription(details.id);
                         }
                       }}
@@ -992,7 +1040,11 @@ export default function SubscriptionDetailsModal({
                 Close
               </button>
             </footer>
-            {copyMessage ? <p className="status-help">{copyMessage}</p> : null}
+            {copyMessage ? (
+              <p aria-live="polite" className="status-help" role="status">
+                {copyMessage}
+              </p>
+            ) : null}
           </div>
         ) : null}
       </article>

--- a/app/components/telemetry.ts
+++ b/app/components/telemetry.ts
@@ -8,13 +8,23 @@ import type {
 type TelemetryEventName =
   | "subscription_details_modal_open"
   | "subscription_details_modal_close"
-  | "subscription_details_view_full_history";
+  | "subscription_details_view_full_history"
+  | "subscription_details_fetch_empty"
+  | "subscription_details_fetch_error"
+  | "subscription_details_edit_click"
+  | "subscription_details_copy_id"
+  | "subscription_details_quick_action_click"
+  | "subscription_details_cancel_flow_start"
+  | "subscription_details_cancel_flow_complete"
+  | "subscription_details_mutation_result";
 
 type TelemetryPayload = {
   eventName: TelemetryEventName;
   subscriptionId: string;
   source: SubscriptionModalOpenSource;
   closeReason?: SubscriptionModalCloseReason;
+  action?: string;
+  outcome?: "success" | "failure";
 };
 
 export function trackTelemetryEvent(payload: TelemetryPayload): void {

--- a/app/components/useSubscriptionDetailsModal.ts
+++ b/app/components/useSubscriptionDetailsModal.ts
@@ -84,14 +84,27 @@ export function useSubscriptionDetailsModal() {
 
       if (response.status === 404) {
         setFetchState("empty");
+        trackTelemetryEvent({
+          eventName: "subscription_details_fetch_empty",
+          source: sourceValue,
+          subscriptionId,
+        });
         return;
       }
 
       redirectOnUnauthorized(response);
 
       if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as DetailsResponsePayload;
+
         setFetchState("error");
-        setErrorMessage("Could not load subscription details.");
+        setErrorMessage(payload.error ?? "Could not load subscription details.");
+        trackTelemetryEvent({
+          eventName: "subscription_details_fetch_error",
+          source: sourceValue,
+          subscriptionId,
+          outcome: "failure",
+        });
         return;
       }
 
@@ -99,6 +112,11 @@ export function useSubscriptionDetailsModal() {
 
       if (!payload.data) {
         setFetchState("empty");
+        trackTelemetryEvent({
+          eventName: "subscription_details_fetch_empty",
+          source: sourceValue,
+          subscriptionId,
+        });
         return;
       }
 
@@ -115,6 +133,12 @@ export function useSubscriptionDetailsModal() {
 
       setFetchState("error");
       setErrorMessage(error instanceof Error ? error.message : "Could not load subscription details.");
+      trackTelemetryEvent({
+        eventName: "subscription_details_fetch_error",
+        source: sourceValue,
+        subscriptionId,
+        outcome: "failure",
+      });
     } finally {
       if (abortRef.current === controller) {
         abortRef.current = null;
@@ -144,7 +168,7 @@ export function useSubscriptionDetailsModal() {
 
   const runMutationAction = useCallback(
     async (actionKey: SubscriptionDetailsMutationAction): Promise<boolean> => {
-      if (!selectedSubscriptionId) {
+      if (!selectedSubscriptionId || !source) {
         return false;
       }
 
@@ -176,12 +200,26 @@ export function useSubscriptionDetailsModal() {
             type: "error",
             text: payload.error ?? "Could not update this subscription.",
           });
+          trackTelemetryEvent({
+            action: actionKey,
+            eventName: "subscription_details_mutation_result",
+            outcome: "failure",
+            source,
+            subscriptionId: selectedSubscriptionId,
+          });
           return false;
         }
 
         setActionMessage({
           type: "success",
           text: actionSuccessMessage(actionKey),
+        });
+        trackTelemetryEvent({
+          action: actionKey,
+          eventName: "subscription_details_mutation_result",
+          outcome: "success",
+          source,
+          subscriptionId: selectedSubscriptionId,
         });
         router.refresh();
         return true;
@@ -194,13 +232,31 @@ export function useSubscriptionDetailsModal() {
           type: "error",
           text: error instanceof Error ? error.message : "Could not update this subscription.",
         });
+        trackTelemetryEvent({
+          action: actionKey,
+          eventName: "subscription_details_mutation_result",
+          outcome: "failure",
+          source,
+          subscriptionId: selectedSubscriptionId,
+        });
         return false;
       } finally {
         setPendingActionKey(null);
       }
     },
-    [router, selectedSubscriptionId],
+    [router, selectedSubscriptionId, source],
   );
+
+  const retryLoad = useCallback(() => {
+    if (!selectedSubscriptionId || !source) {
+      return;
+    }
+
+    void openModal({
+      subscriptionId: selectedSubscriptionId,
+      source,
+    });
+  }, [openModal, selectedSubscriptionId, source]);
 
   const trackViewFullHistory = useCallback(() => {
     if (!source || !selectedSubscriptionId) {
@@ -230,6 +286,7 @@ export function useSubscriptionDetailsModal() {
     errorMessage,
     openModal,
     closeModal,
+    retryLoad,
     runMutationAction,
     trackViewFullHistory,
   };

--- a/app/globals.css
+++ b/app/globals.css
@@ -1939,6 +1939,16 @@ button:disabled,
   align-items: center;
 }
 
+.details-status-block {
+  display: grid;
+  justify-items: start;
+  gap: 0.65rem;
+}
+
+.details-status-block p {
+  margin: 0;
+}
+
 .details-skeleton {
   display: grid;
   gap: 0.55rem;
@@ -1961,6 +1971,18 @@ button:disabled,
 ul {
   margin: 0;
   padding-left: 1.1rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @media (max-width: 940px) {
@@ -2062,5 +2084,14 @@ ul {
 
   .details-quick-actions-grid {
     grid-template-columns: 1fr;
+  }
+
+  .details-action-row {
+    align-items: stretch;
+    width: 100%;
+  }
+
+  .details-action-row > * {
+    width: 100%;
   }
 }

--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -482,6 +482,7 @@ export default function SubscriptionsClient({
           detailsModal.closeModal("close_button");
           setEditingSubscriptionId(subscriptionId);
         }}
+        onRetry={detailsModal.retryLoad}
         onRunMutationAction={detailsModal.runMutationAction}
         onViewFullHistoryClick={detailsModal.trackViewFullHistory}
         pendingActionKey={detailsModal.pendingActionKey}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:invites": "dotenv -e .env.local -- node --import tsx --test tests/invites/*.test.ts",
     "test:mail": "dotenv -e .env.local -- node --import tsx --test tests/mail/*.test.ts",
     "test:dashboard": "dotenv -e .env.local -- node --import tsx --test tests/dashboard/*.test.ts",
+    "test:subscription-details": "dotenv -e .env.local -- node --import tsx --test tests/subscription-details/*.test.ts tests/subscription-details/*.test.tsx",
     "email:dev": "email dev --dir lib/mail/templates",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/tests/subscription-details/subscription-details-modal.test.tsx
+++ b/tests/subscription-details/subscription-details-modal.test.tsx
@@ -50,6 +50,29 @@ function renderModalHtml(record: SubscriptionDetailsSourceRecord): string {
   );
 }
 
+function renderModalStateHtml({
+  errorMessage = null,
+  loadState,
+  onRetry = null,
+}: {
+  errorMessage?: string | null;
+  loadState: "loading" | "empty" | "error";
+  onRetry?: (() => void) | null;
+}): string {
+  return renderToStaticMarkup(
+    <SubscriptionDetailsModal
+      details={null}
+      errorMessage={errorMessage}
+      isOpen
+      loadState={loadState}
+      onClose={() => undefined}
+      onRetry={onRetry}
+      onViewFullHistoryClick={() => undefined}
+      source="subscriptions_list"
+    />,
+  );
+}
+
 describe("SubscriptionDetailsModal attention panel", () => {
   test("renders alert items with review-state copy", () => {
     const html = renderModalHtml(
@@ -75,6 +98,8 @@ describe("SubscriptionDetailsModal attention panel", () => {
     assert.match(html, /Lifecycle Controls/);
     assert.match(html, /Management/);
     assert.match(html, /example\.com/);
+    assert.match(html, /aria-labelledby="subscription-details-title"/);
+    assert.match(html, /aria-describedby="subscription-details-description"/);
   });
 
   test("renders an empty state when no alerts are active", () => {
@@ -108,5 +133,22 @@ describe("SubscriptionDetailsModal attention panel", () => {
     assert.doesNotMatch(html, /ftp:\/\/example\.com/);
     assert.match(html, /Not captured/);
     assert.match(html, /Management URL must start with http:\/\/ or https:\/\/\./);
+  });
+
+  test("renders accessible loading, error, and empty states", () => {
+    const loadingHtml = renderModalStateHtml({ loadState: "loading" });
+    const errorHtml = renderModalStateHtml({
+      errorMessage: "Details service is unavailable.",
+      loadState: "error",
+      onRetry: () => undefined,
+    });
+    const emptyHtml = renderModalStateHtml({ loadState: "empty" });
+
+    assert.match(loadingHtml, /role="status"/);
+    assert.match(loadingHtml, /aria-busy="true"/);
+    assert.match(loadingHtml, /Loading subscription details\./);
+    assert.match(errorHtml, /Details service is unavailable\./);
+    assert.match(errorHtml, />Retry</);
+    assert.match(emptyHtml, /Subscription details are unavailable for this record\./);
   });
 });


### PR DESCRIPTION
## Summary
- Harden the Subscription Details V2 modal with accessible dialog labeling, live loading/error/copy feedback, retry handling, and narrow-screen footer behavior.
- Add telemetry for fetch empty/error states, edit/copy/quick-action/cancel flows, and mutation outcomes.
- Add a subscription-details test script and regression coverage for loading, empty, error, and accessibility states.
- Include the AGENTS.md workflow clarification for updating before feature branches.

Closes #47.

## Test plan
- npm run test:subscription-details
- npm run lint
- npx tsc --noEmit

Note: `npm run typecheck` was attempted but Prisma client generation failed with Windows EPERM while renaming the query engine DLL, likely due to a local file lock.