### PR TITLE
Show spend breakdown by signed-up owner

### DIFF
--- a/app/DashboardDataClient.tsx
+++ b/app/DashboardDataClient.tsx
@@ -146,11 +146,11 @@ export default function DashboardDataClient({ initialCurrency }: DashboardDataCl
         assumptions: payload?.potentialSavings.assumptions ?? [],
       }}
       renderState={renderState}
-      spendBreakdownByCategory={
-        payload?.spendBreakdownByCategory.map((category) => ({
-          category: category.category,
-          subscriptionCount: category.subscriptionCount,
-          totalsByCurrency: category.totalsByCurrency.map((total) => ({
+      spendBreakdown={
+        payload?.spendBreakdown.map((group) => ({
+          label: group.label,
+          subscriptionCount: group.subscriptionCount,
+          totalsByCurrency: group.totalsByCurrency.map((total) => ({
             currency: total.currency,
             monthlyEquivalentSpendCents: total.monthlyEquivalentSpendCents,
           })),

--- a/app/DashboardSectionsClient.tsx
+++ b/app/DashboardSectionsClient.tsx
@@ -84,8 +84,8 @@ type DashboardSectionsClientProps = {
     currency: string;
     monthlyEquivalentSpendCents: number;
   }>;
-  spendBreakdownByCategory: Array<{
-    category: string;
+  spendBreakdown: Array<{
+    label: string;
     subscriptionCount: number;
     totalsByCurrency: Array<{
       currency: string;
@@ -378,7 +378,7 @@ export default function DashboardSectionsClient({
   potentialSavings,
   upcomingCharges,
   monthlySpendTotalsByCurrency,
-  spendBreakdownByCategory,
+  spendBreakdown,
   initialCurrency,
   currencyConversion,
   renderState,
@@ -489,8 +489,8 @@ export default function DashboardSectionsClient({
       return [];
     }
 
-    return mapDashboardSpendBreakdownByCurrency(spendBreakdownByCategory, spendBreakdownCurrency, "");
-  }, [spendBreakdownByCategory, spendBreakdownCurrency]);
+    return mapDashboardSpendBreakdownByCurrency(spendBreakdown, spendBreakdownCurrency, "");
+  }, [spendBreakdown, spendBreakdownCurrency]);
   const spendBreakdownTotalCents = useMemo(() => {
     return spendBreakdownRows.reduce((total, row) => total + row.monthlyEquivalentSpendCents, 0);
   }, [spendBreakdownRows]);
@@ -518,7 +518,7 @@ export default function DashboardSectionsClient({
     return spendBreakdownRows.map((row) => {
       const segmentLength = (row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * circumference;
       const segment = {
-        category: row.category,
+        label: row.label,
         color: row.color,
         segmentLength,
         dashOffset,
@@ -529,13 +529,13 @@ export default function DashboardSectionsClient({
   }, [spendBreakdownCurrency, spendBreakdownRows, spendBreakdownTotalCents]);
   const spendBreakdownDescription = useMemo(() => {
     if (!spendBreakdownCurrency || spendBreakdownRows.length === 0 || spendBreakdownTotalCents <= 0) {
-      return "No categorized spend data is available for the current controls.";
+      return "No spend by Signed up by data is available for the current controls.";
     }
 
     return spendBreakdownRows
       .map((row) => {
         const percent = Math.round((row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * 100);
-        return `${row.category}: ${formatMoney(row.monthlyEquivalentSpendCents, spendBreakdownCurrency)} (${percent}%).`;
+        return `${row.label}: ${formatMoney(row.monthlyEquivalentSpendCents, spendBreakdownCurrency)} (${percent}%).`;
       })
       .join(" ");
   }, [spendBreakdownCurrency, spendBreakdownRows, spendBreakdownTotalCents]);
@@ -615,9 +615,9 @@ export default function DashboardSectionsClient({
               <h2>Spend Breakdown</h2>
               <span className="metric-note">
                 {isLoading
-                  ? "Loading categories..."
+                  ? "Loading owners..."
                   : spendBreakdownCurrency
-                    ? `${spendBreakdownRows.length} categories`
+                    ? `${spendBreakdownRows.length} Signed up by ${spendBreakdownRows.length === 1 ? "group" : "groups"}`
                     : `No ${reportingCurrency} data`}
               </span>
             </div>
@@ -643,9 +643,9 @@ export default function DashboardSectionsClient({
                 </ul>
               </div>
             ) : !spendBreakdownCurrency ? (
-              <p className="text-muted">No categorized spend is available in {reportingCurrency}.</p>
+              <p className="text-muted">No spend by Signed up by is available in {reportingCurrency}.</p>
             ) : spendBreakdownRows.length === 0 || spendBreakdownTotalCents <= 0 ? (
-              <p className="text-muted">No categorized spend exists yet.</p>
+              <p className="text-muted">No spend by Signed up by exists yet.</p>
             ) : (
               <div className="spend-breakdown-layout">
                 <figure className="spend-donut-figure">
@@ -657,7 +657,7 @@ export default function DashboardSectionsClient({
                     viewBox="0 0 112 112"
                   >
                     <title id={spendBreakdownTitleId}>
-                      Spend by category in {spendBreakdownCurrency}
+                      Spend by Signed up by in {spendBreakdownCurrency}
                     </title>
                     <desc id={spendBreakdownDescriptionId}>{spendBreakdownDescription}</desc>
                     <circle className="spend-donut-track" cx="56" cy="56" r="44" />
@@ -666,7 +666,7 @@ export default function DashboardSectionsClient({
                         className="spend-donut-segment"
                         cx="56"
                         cy="56"
-                        key={segment.category}
+                        key={segment.label}
                         r="44"
                         stroke={segment.color}
                         strokeDasharray={`${segment.segmentLength} ${spendBreakdownChartCircumference}`}
@@ -679,20 +679,20 @@ export default function DashboardSectionsClient({
                     <strong>{formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}</strong>
                   </figcaption>
                 </figure>
-                <ul aria-label={`Spend category legend in ${spendBreakdownCurrency}`} className="spend-legend">
+                <ul aria-label={`Spend by Signed up by legend in ${spendBreakdownCurrency}`} className="spend-legend">
                   {spendBreakdownRows.map((row) => {
                     const percent = Math.round((row.monthlyEquivalentSpendCents / spendBreakdownTotalCents) * 100);
                     const subscriptionLabel = row.subscriptionCount === 1 ? "1 subscription" : `${row.subscriptionCount} subscriptions`;
 
                     return (
-                      <li className="spend-legend-item" key={row.category}>
+                      <li className="spend-legend-item" key={row.label}>
                         <span
                           aria-hidden="true"
                           className="spend-legend-swatch"
                           style={{ backgroundColor: row.color }}
                         />
                         <div className="spend-legend-copy">
-                          <span className="spend-legend-label">{row.category}</span>
+                          <span className="spend-legend-label">{row.label}</span>
                           <span className="spend-legend-value">
                             {formatMoney(row.monthlyEquivalentSpendCents, spendBreakdownCurrency)} - {percent}% -{" "}
                             {subscriptionLabel}
@@ -705,11 +705,11 @@ export default function DashboardSectionsClient({
               </div>
             )}
             {!isLoading && spendBreakdownCurrency && spendBreakdownRows.length === 1 ? (
-              <p className="text-muted">Only one category currently contributes spend.</p>
+              <p className="text-muted">Only one Signed up by group currently contributes spend.</p>
             ) : null}
             {!isLoading && spendBreakdownCurrency && !spendBreakdownReconciled ? (
               <p className="text-muted" role="status">
-                Category totals ({formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}) differ from KPI total (
+                Signed up by totals ({formatMoney(spendBreakdownTotalCents, spendBreakdownCurrency)}) differ from KPI total (
                 {formatMoney(spendBreakdownKpiTotalCents ?? 0, spendBreakdownCurrency)}).
               </p>
             ) : null}

--- a/lib/dashboard-controls.ts
+++ b/lib/dashboard-controls.ts
@@ -1,7 +1,4 @@
-import { normalizeCurrencyCode } from "@/lib/currencies";
-
-
-const DASHBOARD_CATEGORY_COLOR_PALETTE = [
+const DASHBOARD_SPEND_BREAKDOWN_COLOR_PALETTE = [
   "#0EA5E9",
   "#F97316",
   "#22C55E",
@@ -14,8 +11,8 @@ const DASHBOARD_CATEGORY_COLOR_PALETTE = [
   "#84CC16",
 ] as const;
 
-type DashboardSpendBreakdownCategoryRecord = {
-  category: string;
+type DashboardSpendBreakdownRecord = {
+  label: string;
   subscriptionCount: number;
   totalsByCurrency: Array<{
     currency: string;
@@ -24,7 +21,7 @@ type DashboardSpendBreakdownCategoryRecord = {
 };
 
 export type DashboardSpendBreakdownRow = {
-  category: string;
+  label: string;
   monthlyEquivalentSpendCents: number;
   subscriptionCount: number;
   color: string;
@@ -52,18 +49,18 @@ function hashString(value: string): number {
   return hash;
 }
 
-export function getDashboardCategoryColor(category: string): string {
-  const normalized = category.trim().toLowerCase();
+export function getDashboardSpendBreakdownColor(label: string): string {
+  const normalized = label.trim().toLowerCase();
 
   if (!normalized) {
-    return DASHBOARD_CATEGORY_COLOR_PALETTE[0];
+    return DASHBOARD_SPEND_BREAKDOWN_COLOR_PALETTE[0];
   }
 
-  const index = hashString(normalized) % DASHBOARD_CATEGORY_COLOR_PALETTE.length;
-  return DASHBOARD_CATEGORY_COLOR_PALETTE[index];
+  const index = hashString(normalized) % DASHBOARD_SPEND_BREAKDOWN_COLOR_PALETTE.length;
+  return DASHBOARD_SPEND_BREAKDOWN_COLOR_PALETTE[index];
 }
 
-export function mapDashboardSpendBreakdownByCurrency<T extends DashboardSpendBreakdownCategoryRecord>(
+export function mapDashboardSpendBreakdownByCurrency<T extends DashboardSpendBreakdownRecord>(
   records: T[],
   currency: string,
   searchQuery: string,
@@ -81,19 +78,19 @@ export function mapDashboardSpendBreakdownByCurrency<T extends DashboardSpendBre
       }
 
       return {
-        category: record.category,
+        label: record.label,
         monthlyEquivalentSpendCents: amount,
         subscriptionCount: record.subscriptionCount,
-        color: getDashboardCategoryColor(record.category),
+        color: getDashboardSpendBreakdownColor(record.label),
       };
     })
     .filter((record): record is DashboardSpendBreakdownRow => record !== null)
-    .filter((record) => matchesSearchFilter([record.category], normalizedQuery))
+    .filter((record) => matchesSearchFilter([record.label], normalizedQuery))
     .sort((first, second) => {
       return (
         second.monthlyEquivalentSpendCents - first.monthlyEquivalentSpendCents ||
         second.subscriptionCount - first.subscriptionCount ||
-        first.category.localeCompare(second.category)
+        first.label.localeCompare(second.label)
       );
     });
 }

--- a/lib/dashboard-view-state.ts
+++ b/lib/dashboard-view-state.ts
@@ -50,7 +50,7 @@ export function hasDashboardContent(data: DashboardPayload): boolean {
     return true;
   }
 
-  if (data.spendBreakdownByCategory.some((category) => category.totalsByCurrency.length > 0)) {
+  if (data.spendBreakdown.some((group) => group.totalsByCurrency.length > 0)) {
     return true;
   }
 

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -16,6 +16,7 @@ const ATTENTION_UNUSED_MIN_ACCOUNT_AGE_DAYS = 120;
 const ATTENTION_UNUSED_STALE_UPDATED_DAYS = 90;
 const UPCOMING_RENEW_URGENCY_WINDOW_DAYS = 3;
 const UPCOMING_RENEW_TAG_WINDOW_DAYS = 10;
+export const DASHBOARD_UNSPECIFIED_SIGNED_UP_BY_LABEL = "Not specified";
 
 const PROMO_HINT_KEYWORDS = ["trial", "promo", "intro", "discount", "offer", "starter"] as const;
 const WORK_TAG_HINT_KEYWORDS = [
@@ -87,8 +88,8 @@ export type DashboardKpis = {
   };
 };
 
-export type DashboardSpendCategory = {
-  category: string;
+export type DashboardSpendBreakdownGroup = {
+  label: string;
   amountCents: number | null;
   annualProjectionCents: number | null;
   currency: string | null;
@@ -178,7 +179,7 @@ export type DashboardPayload = {
   normalizationPolicy: "preferred_currency_with_fx_conversion";
   currencyConversion: DashboardCurrencyConversion;
   kpis: DashboardKpis;
-  spendBreakdownByCategory: DashboardSpendCategory[];
+  spendBreakdown: DashboardSpendBreakdownGroup[];
   attentionNeeded: DashboardAttentionItem[];
   upcomingRenewals: DashboardUpcomingRenewal[];
   topCostDrivers: DashboardTopCostDriver[];
@@ -645,10 +646,10 @@ export function buildDashboardPayload(
     },
   };
 
-  const categoryGroups = new Map<
+  const spendBreakdownGroups = new Map<
     string,
     {
-      category: string;
+      label: string;
       subscriptionCount: number;
       records: NormalizedSubscription[];
     }
@@ -659,7 +660,9 @@ export function buildDashboardPayload(
       continue;
     }
 
-    const existing = categoryGroups.get(subscription.inferredCategory);
+    const ownerLabel = subscription.signedUpBy?.trim() || DASHBOARD_UNSPECIFIED_SIGNED_UP_BY_LABEL;
+    const ownerKey = ownerLabel.toLowerCase();
+    const existing = spendBreakdownGroups.get(ownerKey);
 
     if (existing) {
       existing.subscriptionCount += 1;
@@ -667,23 +670,23 @@ export function buildDashboardPayload(
       continue;
     }
 
-    categoryGroups.set(subscription.inferredCategory, {
-      category: subscription.inferredCategory,
+    spendBreakdownGroups.set(ownerKey, {
+      label: ownerLabel,
       subscriptionCount: 1,
       records: [subscription],
     });
   }
 
-  const spendBreakdownByCategory: DashboardSpendCategory[] = [...categoryGroups.values()]
+  const spendBreakdown: DashboardSpendBreakdownGroup[] = [...spendBreakdownGroups.values()]
     .map((group) => {
-      const categoryTotals = makeCurrencyTotals(group.records, preferredCurrency);
+      const groupTotals = makeCurrencyTotals(group.records, preferredCurrency);
 
       return {
-        category: group.category,
-        amountCents: categoryTotals.length === 1 ? categoryTotals[0].monthlyEquivalentSpendCents : null,
-        annualProjectionCents: categoryTotals.length === 1 ? categoryTotals[0].annualProjectionCents : null,
-        currency: categoryTotals.length === 1 ? categoryTotals[0].currency : null,
-        totalsByCurrency: categoryTotals,
+        label: group.label,
+        amountCents: groupTotals.length === 1 ? groupTotals[0].monthlyEquivalentSpendCents : null,
+        annualProjectionCents: groupTotals.length === 1 ? groupTotals[0].annualProjectionCents : null,
+        currency: groupTotals.length === 1 ? groupTotals[0].currency : null,
+        totalsByCurrency: groupTotals,
         subscriptionCount: group.subscriptionCount,
       };
     })
@@ -691,7 +694,7 @@ export function buildDashboardPayload(
       const firstSortAmount = Math.max(0, ...first.totalsByCurrency.map((entry) => entry.monthlyEquivalentSpendCents));
       const secondSortAmount = Math.max(0, ...second.totalsByCurrency.map((entry) => entry.monthlyEquivalentSpendCents));
 
-      return secondSortAmount - firstSortAmount || second.subscriptionCount - first.subscriptionCount || first.category.localeCompare(second.category);
+      return secondSortAmount - firstSortAmount || second.subscriptionCount - first.subscriptionCount || first.label.localeCompare(second.label);
     });
 
   const upcomingRenewals: DashboardUpcomingRenewal[] = activeSubscriptions
@@ -987,7 +990,7 @@ export function buildDashboardPayload(
       missingRates: [...missingRates].sort((first, second) => first.localeCompare(second)),
     },
     kpis,
-    spendBreakdownByCategory,
+    spendBreakdown,
     attentionNeeded,
     upcomingRenewals,
     topCostDrivers,

--- a/tests/dashboard/dashboard-aggregation.test.ts
+++ b/tests/dashboard/dashboard-aggregation.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 
 import {
   DASHBOARD_RENEWALS_WINDOW_DAYS,
+  DASHBOARD_UNSPECIFIED_SIGNED_UP_BY_LABEL,
   DASHBOARD_UPCOMING_RENEWALS_WINDOW_DAYS,
   type DashboardSubscriptionSourceRecord,
   buildDashboardPayload,
@@ -41,12 +42,40 @@ describe("buildDashboardPayload", () => {
     assert.equal(payload.kpis.renewalsInNext7Days, 0);
     assert.equal(payload.kpis.monthlyEquivalentSpend.amountCents, null);
     assert.equal(payload.kpis.annualProjection.amountCents, null);
-    assert.deepEqual(payload.spendBreakdownByCategory, []);
+    assert.deepEqual(payload.spendBreakdown, []);
     assert.deepEqual(payload.attentionNeeded, []);
     assert.deepEqual(payload.upcomingRenewals, []);
     assert.deepEqual(payload.topCostDrivers, []);
     assert.deepEqual(payload.potentialSavings.opportunities, []);
     assert.equal(payload.nextCharge, null);
+  });
+
+  test("groups spend breakdown by signed-up owner with a fallback label", () => {
+    const now = new Date("2026-03-11T00:00:00.000Z");
+
+    const payload = buildDashboardPayload(
+      [
+        makeSubscription({ id: "alex-streaming", name: "Netflix", amountCents: 1800, signedUpBy: "Alex" }),
+        makeSubscription({ id: "alex-work", name: "GitHub", amountCents: 2200, signedUpBy: " Alex " }),
+        makeSubscription({ id: "jamie", name: "Canva", amountCents: 1500, signedUpBy: "Jamie" }),
+        makeSubscription({ id: "missing-owner", name: "Cloudflare", amountCents: 1200, signedUpBy: null }),
+        makeSubscription({ id: "custom", name: "Custom Billing", billingInterval: "CUSTOM", signedUpBy: "Alex" }),
+      ],
+      now,
+    );
+
+    assert.deepEqual(
+      payload.spendBreakdown.map((group) => [
+        group.label,
+        group.subscriptionCount,
+        group.totalsByCurrency[0]?.monthlyEquivalentSpendCents,
+      ]),
+      [
+        ["Alex", 2, 4000],
+        ["Jamie", 1, 1500],
+        [DASHBOARD_UNSPECIFIED_SIGNED_UP_BY_LABEL, 1, 1200],
+      ],
+    );
   });
 
   test("uses explicit next-7 and next-30-day windows and excludes custom cadence from normalized totals", () => {

--- a/tests/dashboard/dashboard-controls.test.ts
+++ b/tests/dashboard/dashboard-controls.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
 import {
-  getDashboardCategoryColor,
+  getDashboardSpendBreakdownColor,
   mapDashboardSpendBreakdownByCurrency,
 } from "../../lib/dashboard-controls";
 import { normalizeCurrencyCode, resolvePreferredCurrency } from "../../lib/currencies";
@@ -19,7 +19,7 @@ describe("dashboard controls", () => {
     const rows = mapDashboardSpendBreakdownByCurrency(
       [
         {
-          category: "Streaming",
+          label: "Alex",
           subscriptionCount: 3,
           totalsByCurrency: [
             { currency: "USD", monthlyEquivalentSpendCents: 4500 },
@@ -27,35 +27,35 @@ describe("dashboard controls", () => {
           ],
         },
         {
-          category: "Cloud & Hosting",
+          label: "Jamie",
           subscriptionCount: 2,
           totalsByCurrency: [{ currency: "USD", monthlyEquivalentSpendCents: 9000 }],
         },
         {
-          category: "Productivity",
+          label: "Not specified",
           subscriptionCount: 1,
           totalsByCurrency: [{ currency: "AUD", monthlyEquivalentSpendCents: 2200 }],
         },
       ],
       "USD",
-      "cloud",
+      "jam",
     );
 
     assert.equal(rows.length, 1);
-    assert.equal(rows[0]?.category, "Cloud & Hosting");
+    assert.equal(rows[0]?.label, "Jamie");
     assert.equal(rows[0]?.monthlyEquivalentSpendCents, 9000);
     assert.equal(rows[0]?.subscriptionCount, 2);
   });
 
-  test("assigns deterministic category colors", () => {
-    const streamingColor = getDashboardCategoryColor("Streaming");
-    const streamingColorAgain = getDashboardCategoryColor("Streaming");
-    const trimmedCaseVariantColor = getDashboardCategoryColor(" streaming ");
-    const otherColor = getDashboardCategoryColor("Cloud & Hosting");
+  test("assigns deterministic spend breakdown colors", () => {
+    const alexColor = getDashboardSpendBreakdownColor("Alex");
+    const alexColorAgain = getDashboardSpendBreakdownColor("Alex");
+    const trimmedCaseVariantColor = getDashboardSpendBreakdownColor(" alex ");
+    const otherColor = getDashboardSpendBreakdownColor("Jamie");
 
-    assert.equal(streamingColor, streamingColorAgain);
-    assert.equal(streamingColor, trimmedCaseVariantColor);
-    assert.notEqual(streamingColor.length, 0);
+    assert.equal(alexColor, alexColorAgain);
+    assert.equal(alexColor, trimmedCaseVariantColor);
+    assert.notEqual(alexColor.length, 0);
     assert.notEqual(otherColor.length, 0);
   });
 });


### PR DESCRIPTION
## Summary
- Group dashboard spend breakdown data by each subscription's `Signed up by` value instead of inferred spending category.
- Update the spend breakdown card copy, chart labels, and legend labels to describe the owner-based breakdown.
- Cover owner grouping, fallback owner labels, and neutral spend-breakdown controls in dashboard tests.

Closes #97

## Test plan
- [x] `npm run test:dashboard`
- [x] `npx tsc --noEmit`
- [ ] `npm run typecheck` (blocked locally by Prisma generate EPERM while renaming `node_modules/.prisma/client/query_engine-windows.dll.node` on Windows)