### PR TITLE
Close subscription modal after create

### DIFF
--- a/app/subscriptions/SubscriptionsClient.tsx
+++ b/app/subscriptions/SubscriptionsClient.tsx
@@ -40,6 +40,7 @@ type SubscriptionsClientProps = {
   paymentMethodSuggestions: string[];
   signedUpBySuggestions: string[];
   resultMessage: ActionResultMessage | null;
+  createSuccessToken: string | null;
   updateSuccessToken: string | null;
   createAction: (formData: FormData) => Promise<void>;
   updateAction: (formData: FormData) => Promise<void>;
@@ -116,6 +117,7 @@ export default function SubscriptionsClient({
   paymentMethodSuggestions,
   signedUpBySuggestions,
   resultMessage,
+  createSuccessToken,
   updateSuccessToken,
   createAction,
   updateAction,
@@ -238,6 +240,14 @@ export default function SubscriptionsClient({
 
     setEditingSubscriptionId(null);
   }, [updateSuccessToken]);
+
+  useEffect(() => {
+    if (!createSuccessToken) {
+      return;
+    }
+
+    setIsAddModalOpen(false);
+  }, [createSuccessToken]);
 
   return (
     <section className="page-stack">

--- a/app/subscriptions/actions.ts
+++ b/app/subscriptions/actions.ts
@@ -222,7 +222,7 @@ export async function createSubscriptionAction(formData: FormData): Promise<void
     },
   });
 
-  redirect("/subscriptions?result=created");
+  redirect(`/subscriptions?result=created&eventId=${Date.now()}`);
 }
 
 export async function updateSubscriptionAction(formData: FormData): Promise<void> {

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -79,9 +79,19 @@ function getUpdateSuccessToken(searchParams?: SubscriptionsPageProps["searchPara
   return eventId && eventId.length > 0 ? eventId : "updated";
 }
 
+function getCreateSuccessToken(searchParams?: SubscriptionsPageProps["searchParams"]): string | null {
+  if (searchParams?.result !== "created") {
+    return null;
+  }
+
+  const eventId = searchParams.eventId?.trim();
+  return eventId && eventId.length > 0 ? eventId : "created";
+}
+
 export default async function SubscriptionsPage({ searchParams }: SubscriptionsPageProps) {
   const user = await requireAuthenticatedUser();
   const resultMessage = getResultMessage(searchParams);
+  const createSuccessToken = getCreateSuccessToken(searchParams);
   const updateSuccessToken = getUpdateSuccessToken(searchParams);
   const [subscriptions, paymentMethodSuggestions, signedUpBySuggestions] = await Promise.all([
     db.subscription.findMany({
@@ -122,6 +132,7 @@ export default async function SubscriptionsPage({ searchParams }: SubscriptionsP
 
   return (
     <SubscriptionsClient
+      createSuccessToken={createSuccessToken}
       createAction={createSubscriptionAction}
       deactivateAction={deactivateSubscriptionAction}
       resultMessage={resultMessage}


### PR DESCRIPTION
## Summary
- Close the New Subscription modal after a successful create redirect.
- Add a create success token so repeated successful creates trigger the client-side close behavior.

Closes #99

## Test plan
- [x] `npx tsc --noEmit`
- [ ] `npm run typecheck` (blocked during `prisma generate` by Windows `EPERM` rename on Prisma query engine DLL)
